### PR TITLE
Support dynamic power for PTC heaters in MPC

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -350,6 +350,19 @@ class Heater:
                 temp_profile["heater_power"] = config_section.getfloat(
                     "heater_power", above=0.0
                 )
+                temp_profile["heater_voltage"] = config_section.getfloat(
+                    "heater_voltage", above=0.0, default=None
+                )
+                temp_profile["heater_temp_coefficient"] = (
+                    config_section.getfloat(
+                        "heater_temp_coefficient", above=0.0, default=None
+                    )
+                )
+                temp_profile["heater_wattage_ambient"] = (
+                    config_section.getfloat(
+                        "heater_wattage_ambient", above=0.0, default=None
+                    )
+                )
                 temp_profile["sensor_responsiveness"] = config_section.getfloat(
                     "sensor_responsiveness", above=0.0, default=None
                 )


### PR DESCRIPTION
This change adds basic support to MPC for heaters whose max power changes
as the temperature changes.
We require the voltage, temperature coefficient, and ambient temp at which
max wattage is spec'd (usually 23C).
With that, we compute the available power as the temperature changes,
instead of treating it as a constant.

The temperature coefficient is usually spec'd by the manufacturer,
but can also be calculated if you have two wattage@temp points.

R@t1 = Voltage^2 / wattage@t1
R@t2 = Voltage^2 / wattage@t2

R@t2 = R@t1 * (1 + temp_coefficient * (t2 - t1))
Solve for temp_coefficient

I have some experimental code as a followup that tries to calculate the temp coefficient
by seeing how actual heating changes when constant power is applied.
It works okay, as most of these heaters are fairly linear.


