### PR TITLE
Add telemetry module

### DIFF
--- a/klippy/extras/telemetry.py
+++ b/klippy/extras/telemetry.py
@@ -1,0 +1,275 @@
+"""
+Kalico Telemetry
+
+Submit anonymized information about your printer to the Kalico project
+Configuration options
+"""
+
+import gzip
+import json
+import logging
+import pathlib
+import platform
+import sys
+import threading
+import urllib.request
+import uuid
+
+
+class KalicoTelemetryPrompt:
+    "Kalico extra prompting the user to enable or disable telemetry"
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+
+        gcode = self.printer.lookup_object("gcode")
+        gcode.register_command(
+            "ENABLE_TELEMETRY", self.cmd_ENABLE_TELEMETRY, True
+        )
+        gcode.register_command(
+            "DISABLE_TELEMETRY", self.cmd_DISABLE_TELEMETRY, True
+        )
+
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+
+    def _handle_ready(self):
+        gcode = self.printer.lookup_object("gcode")
+
+        gcode.respond_info(
+            "Welcome to Kalico\n"
+            "\n"
+            "Kalico is starting an opt-in analytics campaign, collecting anonymous data about our users\n"
+            "Submitted data will contain an anonymized copy of your current configuration, enabled"
+            " Kalico modules and plugins, and some basic information about the host machine.\n"
+            "\n"
+            "`ENABLE_TELEMETRY` will opt-in to the campaign\n"
+            "`DISABLE_TELEMETRY` will permanently opt-out\n"
+            "\n"
+            "`TELEMETRY_EXAMPLE` will save a full example of what would be"
+            " submitted as 'telemetry.json' in your configuration folder\n"
+            "\n"
+            "For more information, visit https://kalico.gg/telemetry"
+        )
+
+    def cmd_ENABLE_TELEMETRY(self, gcmd):
+        "Enable Kalico telemetry reporting"
+
+        configfile = self.printer.lookup_object("configfile")
+        configfile.set("telemetry", "enabled", True)
+
+        gcmd.respond_info(
+            "Kalico telemetry enabled\n"
+            "\n"
+            "`SAVE_CONFIG` will update your printer config\n"
+            "file with this setting and restart the printer."
+        )
+
+    def cmd_DISABLE_TELEMETRY(self, gcmd):
+        "Disable Kalico telemetry reporting"
+
+        configfile = self.printer.lookup_object("configfile")
+        configfile.set("telemetry", "enabled", False)
+
+        gcmd.respond_info(
+            "Kalico telemetry disabled\n"
+            "\n"
+            "`SAVE_CONFIG` will update your printer config\n"
+            "file with this setting and restart the printer."
+        )
+
+
+class KalicoTelementry:
+    TELEMETRY_ENDPOINT = "https://telemetry.kalico.gg/collect"
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.enabled = config.getboolean("enabled", None)
+
+        self.last_report = None
+
+        gcode = self.printer.lookup_object("gcode")
+
+        if self.enabled is not False:
+            gcode.register_command(
+                "TELEMETRY_EXAMPLE", self.cmd_TELEMETRY_EXAMPLE, True
+            )
+
+        if self.enabled is None:
+            self.telemetry_prompt = KalicoTelemetryPrompt(config)
+
+        elif self.enabled:
+            self.printer.register_event_handler(
+                "klippy:ready", self._handle_ready
+            )
+
+    def get_status(self, eventtime=None):
+        return {
+            "enabled": self.enabled,
+            "last_report": self.last_report,
+        }
+
+    def _handle_ready(self):
+        try:
+            data = self._collect_telemetry()
+            self._send(data)
+        except:
+            logging.exception("exception collecting telemetry")
+
+    def cmd_TELEMETRY_EXAMPLE(self, gcmd):
+        "Save an example of the current machine telemetry to 'telemetry.json'"
+
+        filename = (
+            pathlib.Path(self.printer.get_start_args()["config_file"]).parent
+            / "telemetry.json"
+        )
+        data = self._collect_telemetry()
+
+        with filename.open("w", encoding="utf-8") as fp:
+            json.dump(data, fp, indent=2)
+
+        gcmd.respond_info(
+            f"Example telemetry saved to {filename.relative_to(pathlib.Path.home())}"
+        )
+
+    def _get_machine_id(self):
+        """
+        Get the freedesktop machine-id if available, otherwise generate and save our own
+
+        If enabled, /etc/machine-id is automatically generated on first boot
+        If not available, a unique ID will be generated and saved to `.machine-id`
+         next to your printer.cfg
+        """
+
+        MACHINE_ID = pathlib.Path("/etc/machine-id")
+        KALICO_MACHINE_ID = (
+            pathlib.Path(self.printer.get_start_args()["config_file"]).parent
+            / ".machine-id"
+        )
+
+        if MACHINE_ID.exists():
+            return MACHINE_ID.read_text().strip()
+        elif KALICO_MACHINE_ID.exists():
+            return KALICO_MACHINE_ID.read_text().strip()
+        else:
+            generated_id = f"kalico-{uuid.uuid4()}"
+            KALICO_MACHINE_ID.write_text(generated_id)
+            return generated_id
+
+    def _collect_anonymized_config(self):
+        """
+        Generate an anonymized version of the current printer configuration.
+
+        Only section and option names are submitted
+
+        A truncated example:
+
+        {
+            "danger_options": [
+                "autosave_includes",
+                "allow_plugin_override",
+                "log_bed_mesh_at_startup"
+            ],
+            "printer": [
+                "kinematics",
+                "invert_kinematics",
+                "max_velocity",
+                "max_accel",
+                "max_z_velocity",
+                "max_z_accel",
+                "minimum_cruise_ratio",
+                "square_corner_velocity"
+            ],
+            ...
+        }
+        """
+        configfile = self.printer.lookup_object("configfile")
+        raw_config = configfile.status_raw_config
+
+        return {
+            section: [option for option in options.keys()]
+            for section, options in raw_config.items()
+        }
+
+    def _collect_platform(self):
+        """
+        Collect basic platform information
+
+        {
+            "machine": "x86_64",
+            "os_release": {
+                "NAME": "Debian GNU/Linux",
+                "ID": "debian",
+                "PRETTY_NAME": "Debian GNU/Linux trixie/sid",
+                "VERSION_CODENAME": "trixie",
+                "HOME_URL": "https://www.debian.org/",
+                "SUPPORT_URL": "https://www.debian.org/support",
+                "BUG_REPORT_URL": "https://bugs.debian.org/"
+            },
+            "version": "#1 SMP PREEMPT_DYNAMIC Debian 6.12~rc6-1~exp1 (2024-11-10)",
+            "python": "3.12.7 (main, Nov  8 2024, 17:55:36) [GCC 14.2.0]"
+        }
+        """
+        return {
+            "machine": platform.machine(),
+            "os_release": platform.freedesktop_os_release(),
+            "version": platform.version(),
+            "python": sys.version,
+        }
+
+    def _collect_printer_objects(self):
+        """
+        Collect a list of all enabled objects in the current Kalico runtime
+
+        This may include extra modules not visible in the config, every module loaded
+        may request additional modules that may not need configuration.
+        """
+
+        return list(self.printer.objects.keys())
+
+    def _collect_telemetry(self):
+        """
+        Collect the full telemetry for submission
+
+        As well as the above, the current Kalico software version
+        """
+        machine_id = self._get_machine_id()
+        start_args = self.printer.get_start_args()
+
+        return {
+            "id": machine_id,
+            # the Kalico git version e.g. "v0.12.0-527-g79013da3-dirty"
+            "version": start_args.get("software_version", "unknown"),
+            # e.g. "4 core Intel(R) N100",
+            "cpu_info": start_args.get("cpu_info", "unknown"),
+            "platform": self._collect_platform(),
+            "config": self._collect_anonymized_config(),
+            "objects": self._collect_printer_objects(),
+        }
+
+    def _send(self, collected_data: dict):
+        data = json.dumps(collected_data).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "Kalico {}".format(
+                self.printer.get_start_args().get("software_version", "")
+            ),
+        }
+
+        try:
+            data = gzip.compress(data)
+            headers["Content-Encoding"] = "gzip"
+        except:
+            pass
+
+        req = urllib.request.Request(
+            self.TELEMETRY_ENDPOINT,
+            headers=headers,
+            data=data,
+        )
+
+        thread = threading.Thread(target=urllib.request.urlopen, args=(req,))
+        thread.start()
+
+
+def load_config(config):
+    return KalicoTelementry(config)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -196,6 +196,8 @@ class GCodeDispatch:
                 del self.base_gcode_handlers[cmd]
             self._build_status_commands()
             return old_cmd
+        if desc is None and func.__doc__:
+            desc = func.__doc__
         if cmd in self.ready_gcode_handlers:
             raise self.printer.config_error(
                 "gcode command %s already registered" % (cmd,)

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -551,6 +551,7 @@ def main():
     extra_git_desc += "\nRemote: %s" % (git_info["remote"])
     extra_git_desc += "\nTracked URL: %s" % (git_info["url"])
     start_args["software_version"] = git_vers
+    start_args["git_branch"] = git_info["branch"]
     start_args["cpu_info"] = util.get_cpu_info()
     if bglogger is not None:
         versions = "\n".join(

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -213,7 +213,12 @@ class Printer:
         for section_config in config.get_prefix_sections(""):
             self.load_object(config, section_config.get_name(), None)
         # dangerklipper on-by-default extras
-        for section_config in ["force_move", "respond", "exclude_object"]:
+        for section_config in [
+            "force_move",
+            "respond",
+            "exclude_object",
+            "telemetry",
+        ]:
             self.load_object(config, section_config, None)
         for m in [toolhead]:
             m.add_printer_objects(config)


### PR DESCRIPTION
Telemetry is explicitly OPT-IN for privacy concerns

Configuration is semi-anonymized (option values are removed), and no
 identifying information besides a machine-unique ID are sent

On startup after updating, a message is sent to the printer console

```
// Welcome to Kalico
// 
// Kalico is starting an opt-in analytics campaign, collecting anonymous data about our users
// Submitted data will contain an anonymized copy of your current configuration, enabled Kalico modules and plugins, and some basic information about the host machine.
// 
// `ENABLE_TELEMETRY` will opt-in to the campaign
// `DISABLE_TELEMETRY` will permanently opt-out
// 
// `TELEMETRY_EXAMPLE` will save a full copy of what would be submitted as 'telemetry.json' in your configuration folder
// 
// For more information, visit https://kalico.gg/telemetry
```

The `ENABLE_TELEMETRY` and `DISABLE_TELEMETRY` commands are available while telemetry is not configured. `TELEMETRY_EXAMPLE` is available unless telemetry is explicitly disabled

Here is a complete copy of a telemetry submission from my development printer: 
[telemetry.json](https://github.com/user-attachments/files/18015549/telemetry.json)

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
