### PR TITLE
mcu: expose non critical status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -160,8 +160,8 @@ objects:
 - `power`: The fan power as a float between 0|`min_power` and 1.0|`max_power`.
 - `rpm`: The measured fan speed in rotations per minute if the fan has
   a tachometer_pin defined.
-deprecated objects (for UI compatibility only): 
-- `speed`: The fan speed as a float between 0.0 and `max_power`. 
+deprecated objects (for UI compatibility only):
+- `speed`: The fan speed as a float between 0.0 and `max_power`.
 
 ## filament_switch_sensor
 
@@ -346,6 +346,7 @@ The following information is available in
   micro-controller architectures and with each code revision.
 - `last_stats.<statistics_name>`: Statistics information on the
   micro-controller connection.
+- `non_critical_disconnected`: True/False if the mcu is disconnected.
 
 ## motion_report
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1148,9 +1148,11 @@ class MCU:
     def _mcu_identify(self):
         if self.is_non_critical and not self._check_serial_exists():
             self.non_critical_disconnected = True
+            self._get_status_info["non_critical_disconnected"] = True
             return False
         else:
             self.non_critical_disconnected = False
+            self._get_status_info["non_critical_disconnected"] = False
         if self.is_fileoutput():
             self._connect_file()
         else:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1148,11 +1148,13 @@ class MCU:
     def _mcu_identify(self):
         if self.is_non_critical and not self._check_serial_exists():
             self.non_critical_disconnected = True
-            self._get_status_info["non_critical_disconnected"] = True
+            if self.is_non_critical:
+                self._get_status_info["non_critical_disconnected"] = True
             return False
         else:
             self.non_critical_disconnected = False
-            self._get_status_info["non_critical_disconnected"] = False
+            if self.is_non_critical:
+                self._get_status_info["non_critical_disconnected"] = False
         if self.is_fileoutput():
             self._connect_file()
         else:


### PR DESCRIPTION
expose the non critical disconnection status to the get_status()

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
