### PR TITLE
homing: allow homing_accel to be configurable

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -297,6 +297,9 @@ position_max:
 #homing_speed: 5.0
 #   Maximum velocity (in mm/s) of the stepper when homing. The default
 #   is 5mm/s.
+#homing_accel:
+#   Maximum accel (in mm/s) of the stepper when homing. The default
+#   is to use the max accel configured in the [printer]'s object.
 #homing_retract_dist: 5.0
 #   Distance to backoff (in mm) before homing a second time during
 #   homing. If `use_sensorless_homing` is false, this setting can be set

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -270,7 +270,15 @@ class Homing:
     def set_homed_position(self, pos):
         self.toolhead.set_position(self._fill_coord(pos))
 
-    def _set_current_homing(self, homing_axes, pre_homing):
+    def _set_homing_accel(self, accel, pre_homing):
+        if accel is None:
+            return
+        if pre_homing:
+            self.toolhead.set_accel(accel)
+        else:
+            self.toolhead.reset_accel()
+
+    def _set_homing_current(self, homing_axes, pre_homing):
         print_time = self.toolhead.get_last_move_time()
         affected_rails = set()
         for axis in homing_axes:
@@ -312,10 +320,13 @@ class Homing:
         hi = rails[0].get_homing_info()
         hmove = HomingMove(self.printer, endstops)
 
-        self._set_current_homing(homing_axes, pre_homing=True)
-        self._reset_endstop_states(endstops)
-
-        hmove.homing_move(homepos, hi.speed)
+        try:
+            self._set_homing_accel(hi.accel, pre_homing=True)
+            self._set_homing_current(homing_axes, pre_homing=True)
+            self._reset_endstop_states(endstops)
+            hmove.homing_move(homepos, hi.speed)
+        finally:
+            self._set_homing_accel(hi.accel, pre_homing=False)
 
         needs_rehome = False
         retract_dist = hi.retract_dist
@@ -337,15 +348,18 @@ class Homing:
             ]
             self.toolhead.move(retractpos, hi.retract_speed)
             if not hi.use_sensorless_homing or needs_rehome:
-                # Home again
-                startpos = [
-                    rp - ad * retract_r for rp, ad in zip(retractpos, axes_d)
-                ]
-                self.toolhead.set_position(startpos)
-                self._reset_endstop_states(endstops)
-                hmove = HomingMove(self.printer, endstops)
-                hmove.homing_move(homepos, hi.second_homing_speed)
                 try:
+                    # Home again
+                    startpos = [
+                        rp - ad * retract_r
+                        for rp, ad in zip(retractpos, axes_d)
+                    ]
+                    self.toolhead.set_position(startpos)
+                    self._reset_endstop_states(endstops)
+
+                    hmove = HomingMove(self.printer, endstops)
+                    hmove.homing_move(homepos, hi.second_homing_speed)
+
                     if hmove.check_no_movement() is not None:
                         raise self.printer.command_error(
                             "Endstop %s still triggered after retract"
@@ -362,7 +376,9 @@ class Homing:
                             "Early homing trigger on second home!"
                         )
                 finally:
-                    self._set_current_homing(homing_axes, pre_homing=False)
+                    self._set_homing_accel(hi.accel, pre_homing=False)
+                    self._set_homing_current(homing_axes, pre_homing=False)
+
                 if hi.retract_dist:
                     # Retract (again)
                     startpos = self._fill_coord(forcepos)
@@ -375,7 +391,8 @@ class Homing:
                     ]
                     self.toolhead.move(retractpos, hi.retract_speed)
 
-        self._set_current_homing(homing_axes, pre_homing=False)
+        self._set_homing_accel(hi.accel, pre_homing=False)
+        self._set_homing_current(homing_axes, pre_homing=False)
         # Signal home operation complete
         self.toolhead.flush_step_generation()
         self.trigger_mcu_pos = {

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -461,9 +461,7 @@ class PrinterRail:
             "min_home_dist", self.homing_retract_dist, minval=0.0
         )
 
-        self.homing_accel = config.get("homing_accel", None)
-        if self.homing_accel is not None:
-            self.homing_accel = config.getfloat("homing_accel", minval=0.0)
+        self.homing_accel = config.getfloat("homing_accel", None, above=0.0)
 
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -461,6 +461,10 @@ class PrinterRail:
             "min_home_dist", self.homing_retract_dist, minval=0.0
         )
 
+        self.homing_accel = config.get("homing_accel", None)
+        if self.homing_accel is not None:
+            self.homing_accel = config.getfloat("homing_accel", minval=0.0)
+
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min
             if self.position_endstop <= self.position_min + axis_len / 4.0:
@@ -507,6 +511,7 @@ class PrinterRail:
                 "second_homing_speed",
                 "use_sensorless_homing",
                 "min_home_dist",
+                "accel",
             ],
         )(
             self.homing_speed,
@@ -517,6 +522,7 @@ class PrinterRail:
             self.second_homing_speed,
             self.use_sensorless_homing,
             self.min_home_dist,
+            self.homing_accel,
         )
         return homing_info
 

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -864,6 +864,14 @@ class ToolHead:
         self.max_accel = accel
         self._calc_junction_deviation()
 
+    def set_accel(self, accel):
+        self.max_accel = accel
+        self._calc_junction_deviation()
+
+    def reset_accel(self):
+        self.max_accel = self.orig_cfg["max_accel"]
+        self._calc_junction_deviation()
+
 
 def add_printer_objects(config):
     config.get_printer().add_object("toolhead", ToolHead(config))

--- a/test/klippy/tmc.cfg
+++ b/test/klippy/tmc.cfg
@@ -38,6 +38,9 @@ endstop_pin: tmc5160_stepper_y:virtual_endstop
 position_endstop: 0
 position_max: 210
 use_sensorless_homing: true
+homing_speed: 100
+homing_accel: 1000
+
 
 [tmc5160 stepper_y]
 cs_pin: PG2


### PR DESCRIPTION
As suggested in https://github.com/KalicoCrew/kalico/issues/395, untested yet

I also took the opportunity to rename `_set_current_homing` to `_set_homing_current` to match the new method added and make it more readable. 