### PR TITLE
Add danger_option log_velocity_limit_changes

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -137,6 +137,9 @@ A collection of Kalico-specific system options
 #   If the bed mesh should be logged at startup
 #   (helpful for keeping the log clean during development)
 #   The default is True.
+#log_velocity_limit_changes: True
+#   If changes to velocity limits should be logged. If False, velocity limits will only
+#   be logged at rollover. Some slicers emit very frequent SET_VELOCITY_LIMIT commands
 #log_shutdown_info: True
 #   If we should log detailed crash info when an exception occurs
 #   Most of it is overly-verbose and fluff and we still get a stack trace

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -8,6 +8,9 @@ class DangerOptions:
         self.log_bed_mesh_at_startup = config.getboolean(
             "log_bed_mesh_at_startup", True
         )
+        self.log_velocity_limit_changes = config.getboolean(
+            "log_velocity_limit_changes", True
+        )
         self.log_shutdown_info = config.getboolean("log_shutdown_info", True)
         self.log_serial_reader_warnings = config.getboolean(
             "log_serial_reader_warnings", True
@@ -58,6 +61,7 @@ class DangerOptions:
             self.log_statistics = False
             self.log_config_file_at_startup = False
             self.log_bed_mesh_at_startup = False
+            self.log_velocity_limit_changes = False
             self.log_shutdown_info = False
             self.log_serial_reader_warnings = False
             self.log_startup_info = False

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -804,25 +804,23 @@ class ToolHead:
             self.min_cruise_ratio = min_cruise_ratio
         self._calc_junction_deviation()
         msg = (
-            "max_velocity: %.6f\n"
-            "max_accel: %.6f\n"
-            "minimum_cruise_ratio: %.6f\n"
-            "square_corner_velocity: %.6f"
-            % (
-                self.max_velocity,
-                self.max_accel,
-                self.min_cruise_ratio,
-                self.square_corner_velocity,
-            )
+            "max_velocity: %.6f" % self.max_velocity,
+            "max_accel: %.6f" % self.max_accel,
+            "minimum_cruise_ratio: %.6f" % self.min_cruise_ratio,
+            "square_corner_velocity: %.6f" % self.square_corner_velocity,
         )
-        self.printer.set_rollover_info("toolhead", "toolhead: %s" % (msg,))
+        self.printer.set_rollover_info(
+            "toolhead",
+            "toolhead: %s" % (" ".join(msg),),
+            log=get_danger_options().log_velocity_limit_changes,
+        )
         if (
             max_velocity is None
             and max_accel is None
             and square_corner_velocity is None
             and min_cruise_ratio is None
         ):
-            gcmd.respond_info(msg, log=False)
+            gcmd.respond_info("\n".join(msg), log=False)
 
     def cmd_M204(self, gcmd):
         # Use S for accel


### PR DESCRIPTION
When false, this prevents `toolhead` from logging every change to
 velocity limits to klippy.log

Some slicers emit a ton of `SET_VELOCITY_LIMIT`s

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
