### PR TITLE
Rewrite `compat` patching to fix module double-execution

### DIFF
--- a/klippy/compat.py
+++ b/klippy/compat.py
@@ -1,20 +1,75 @@
+"""
+Kalico compatibility for legacy Klipper extras and plugins
+
+This hook provides two features:
+
+1. Rewrite non-package imports, e.g. `import mcu` effectively becomes `import klippy.mcu as mcu`
+2. Provide aliases in sys.modules to prevent double-execution of modules.
+
+The second is especially important as `is` and `isinstance` checks will fail between two seperately
+imported copies of the same module.
+"""
+
+import functools
+import importlib.machinery
+import pathlib
 import sys
 
+ROOT = pathlib.Path(__file__).parent
 
-def hotpatch_modules():
-    """
-    This is a compatibility shim for legacy external modules
-     to fix
-    Redirect legacy `import x` to `import klippy.x`
 
-    """
+class KlippyPathFinder(importlib.machinery.PathFinder):
+    @classmethod
+    def install_hook(cls):
+        # Place the KlippyMetaPathFinder *before* `PathFinder`
+        sys.meta_path.insert(-1, KlippyPathFinder())
 
-    for module_name, module in list(sys.modules.items()):
-        if not module_name.startswith("klippy."):
-            continue
+        # Setup aliases for already loaded modules
+        for name in list(sys.modules.keys()):
+            if name.startswith("klippy."):
+                sys.modules.setdefault(
+                    name.removeprefix("klippy."),
+                    sys.modules[name],
+                )
 
-        hotpatched_name = module_name.removeprefix("klippy.")
-        if hotpatched_name in sys.modules:
-            continue
+    @classmethod
+    def patch_loader(cls, spec, *names):
+        "Patch a spec loader to add aliases for a module after import"
 
-        sys.modules[hotpatched_name] = module
+        orig_exec_module = spec.loader.exec_module
+
+        @functools.wraps(orig_exec_module)
+        def aliased(module):
+            try:
+                return orig_exec_module(module)
+            finally:
+                for name in names:
+                    if name not in sys.modules:
+                        sys.modules[name] = module
+
+        spec.loader.exec_module = aliased
+
+    @classmethod
+    def find_spec(cls, fullname, path=None, target=None):
+        if not fullname.startswith("klippy."):
+            parts = fullname.split(".")
+            klippy_path = ROOT.joinpath(*parts)
+
+            if klippy_path.with_suffix(".py").is_file():
+                fullname = "klippy." + fullname
+                path = [str(klippy_path.parent)]
+
+            elif (klippy_path / "__init__.py").is_file():
+                fullname = "klippy." + fullname
+                path = [str(klippy_path)]
+
+        spec = super().find_spec(fullname, path, target)
+
+        if spec and spec.name.startswith("klippy."):
+            cls.patch_loader(spec, spec.name.removeprefix("klippy."))
+
+        return spec
+
+
+def install():
+    KlippyPathFinder.install_hook()

--- a/klippy/extras/telemetry.py
+++ b/klippy/extras/telemetry.py
@@ -49,6 +49,9 @@ class KalicoTelementry:
             )
 
     def _telemetry_prompt(self):
+        if self.printer.get_start_args().get("debuginput"):
+            return
+
         gcode = self.printer.lookup_object("gcode")
 
         gcode.respond_info(

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -63,8 +63,8 @@ class Printer:
     command_error = gcode.CommandError
 
     def __init__(self, main_reactor, bglogger, start_args):
-        if sys.version_info < (3, 9):
-            logging.error("Kalico requires Python 3.9+")
+        if sys.version_info[0] < 3:
+            logging.error("Kalico requires Python 3")
             sys.exit(1)
 
         self.bglogger = bglogger

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -63,8 +63,8 @@ class Printer:
     command_error = gcode.CommandError
 
     def __init__(self, main_reactor, bglogger, start_args):
-        if sys.version_info[0] < 3:
-            logging.error("Kalico requires Python 3")
+        if sys.version_info < (3, 9):
+            logging.error("Kalico requires Python 3.9+")
             sys.exit(1)
 
         self.bglogger = bglogger
@@ -571,7 +571,7 @@ def main():
             "No log file specified!" " Severe timing issues may result!"
         )
 
-    compat.hotpatch_modules()
+    compat.install()
 
     gc.disable()
 


### PR DESCRIPTION
I previously was simply generating aliases for any currently imported klippy modules. While this somewhat worked, it did not handle cases where a module was not imported until after patching completed.

This new hooking method provides two features:

1. Rewrite non-package imports, e.g. `import mcu` effectively becomes `import klippy.mcu as mcu`
2. Provide aliases in sys.modules to prevent double-execution of modules.

The second is especially important as `is` and `isinstance` checks will fail between two seperately imported copies of the same module.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
