### PR TITLE
Fix incorrect unicode in docs

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1857,7 +1857,7 @@ file for a Marlin compatible M808 G-Code macro.
 [sdcard_loop]
 ```
 
-### ⚠ [force_move]
+### ⚠️ [force_move]
 
 This module is enabled by default in Kalico!
 


### PR DESCRIPTION
The force_move docs are using the incorrect unicode for the "warning sign", making it show differently from the rest of the entries.

![image](https://github.com/user-attachments/assets/037277d4-ba34-4a47-9132-5cccf2c8adb7)

Here's the browser debug showing the problem:

![image](https://github.com/user-attachments/assets/e8e08a76-473a-4d3f-8312-54daf0f6364f)

## Checklist

- [X] pr title makes sense
- [X] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [X] ci is happy and green
