### PR TITLE
implement rehome_z for z_tilt/qgl

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ See the [Danger Features document](https://docs.kalico.gg/Danger_Features.html) 
 
 - [danger_options: configurable homing constants](https://github.com/KalicoCrew/kalico/pull/378)
 
+- [z_tilt, qgl: rehome_z](https://github.com/KalicoCrew/kalico/pull/494)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1448,8 +1448,7 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #   Sets the threshold that probe points can increase before z_tilt aborts.
 #   To disable the validation, set this parameter to a high value.
 #rehome_z: False
-#   If set to true, a G28 Z  will  automatically be called after z_tilt has
-#   finished to rehome Z.
+#   If set to True, execute G28 Z after z_tilt is applied. Defaults to False.
 
 ```
 
@@ -1582,8 +1581,7 @@ Where x is the 0, 0 point on the bed
 #   Sets the threshold that probe points can increase before qgl aborts.
 #   To disable the validation, set this parameter to a high value.
 #rehome_z: False
-#   If set to true, a G28 Z  will  automatically be called after z_tilt has
-#   finished to rehome Z.
+#   If set to True, execute G28 Z after qgl is applied. Defaults to False.
 ```
 
 ### [skew_correction]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1447,6 +1447,9 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #increasing_threshold: 0.0000001
 #   Sets the threshold that probe points can increase before z_tilt aborts.
 #   To disable the validation, set this parameter to a high value.
+#rehome_z: False
+#   If set to true, a G28 Z  will  automatically be called after z_tilt has
+#   finished to rehome Z.
 
 ```
 
@@ -1486,6 +1489,8 @@ commands become available, enhancing bed leveling accuracy and calibration effic
 #retry_tolerance: 0
 # See [z_tilt]
 #increasing_threshold: 0.0000001
+# See [z_tilt]
+#rehome_z: False
 # See [z_tilt]
 #extra_points:
 #   A list in the same format as "points" above. This list contains
@@ -1576,6 +1581,9 @@ Where x is the 0, 0 point on the bed
 #increasing_threshold: 0.0000001
 #   Sets the threshold that probe points can increase before qgl aborts.
 #   To disable the validation, set this parameter to a high value.
+#rehome_z: False
+#   If set to true, a G28 Z  will  automatically be called after z_tilt has
+#   finished to rehome Z.
 ```
 
 ### [skew_correction]

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -36,7 +36,7 @@ class QuadGantryLevel:
             raise config.error(
                 "Need exactly 4 probe points for quad_gantry_level"
             )
-        self.z_status = z_tilt.ZAdjustStatus(self.printer)
+        self.z_status = z_tilt.ZAdjustStatus(self.printer, config)
         self.z_helper = z_tilt.ZAdjustHelper(config, 4)
         self.gantry_corners = config.getlists(
             "gantry_corners", parser=float, seps=(",", "\n"), count=2

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -174,7 +174,6 @@ class ZTilt:
         self.z_positions = config.getlists(
             "z_positions", seps=(",", "\n"), parser=float, count=2
         )
-        self.default_rehome_z = config.getboolean("rehome_z", False)
         self.retry_helper = RetryHelper(config)
         self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
         self.probe_helper.minimum_points(2)

--- a/klippy/extras/z_tilt_ng.py
+++ b/klippy/extras/z_tilt_ng.py
@@ -210,7 +210,7 @@ class ZTilt:
             "z_offsets", parser=float, count=z_count, default=None
         )
 
-        self.z_status = ZAdjustStatus(self.printer)
+        self.z_status = ZAdjustStatus(self.printer, config)
         self.z_helper = ZAdjustHelper(config, z_count)
         # probe points for calibrate/autodetect
         cal_probe_points = list(self.probe_helper.get_probe_points())

--- a/klippy/extras/z_tilt_ng.py
+++ b/klippy/extras/z_tilt_ng.py
@@ -100,7 +100,9 @@ class ZAdjustHelper:
 
 
 class ZAdjustStatus:
-    def __init__(self, printer):
+    def __init__(self, printer, config):
+        self.gcode = printer.lookup_object("gcode")
+        self.default_rehome_z = config.getboolean("rehome_z", False)
         self.applied = False
         printer.register_event_handler(
             "stepper_enable:motor_off", self._motor_off
@@ -111,6 +113,8 @@ class ZAdjustStatus:
             isinstance(retry_result, float) and retry_result == 0.0
         ):
             self.applied = True
+            if self.default_rehome_z:
+                self.gcode.run_script_from_command("G28 Z")
         return retry_result
 
     def reset(self):

--- a/test/klippy/z_tilt.cfg
+++ b/test/klippy/z_tilt.cfg
@@ -74,6 +74,7 @@ points:
     195,195
     195,50
 increasing_threshold: 0.001
+rehome_z: True
 
 [bed_tilt]
 points:

--- a/test/klippy/z_tilt_ng.cfg
+++ b/test/klippy/z_tilt_ng.cfg
@@ -60,6 +60,7 @@ extra_points:
     50,195
     195,195
 increasing_threshold: 0.001
+rehome_z: True
 
 [extruder]
 step_pin: PA4


### PR DESCRIPTION
Added `rehome_z` parameter to z_tilt, z_tilt_ng and qgl to automatically rehome z after leveling the bed/gantry
Also removed boilerplate code as ZAdjustStatus in z_tilt and z_tilt_ng was the same in both

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
