### PR TITLE
Fix compat again

### DIFF
--- a/klippy/compat.py
+++ b/klippy/compat.py
@@ -55,13 +55,11 @@ class KlippyPathFinder(importlib.machinery.PathFinder):
             parts = fullname.split(".")
             klippy_path = ROOT.joinpath(*parts)
 
-            if klippy_path.with_suffix(".py").is_file():
+            if (
+                klippy_path.with_suffix(".py").is_file()
+                or (klippy_path / "__init__.py").is_file()
+            ):
                 fullname = "klippy." + fullname
-                path = [str(klippy_path.parent)]
-
-            elif (klippy_path / "__init__.py").is_file():
-                fullname = "klippy." + fullname
-                path = [str(klippy_path)]
 
         spec = super().find_spec(fullname, path, target)
 


### PR DESCRIPTION
iamnotahippie reported breakage in HappyHare after PR #490 was merged. I did a bunch of investigation, and found that the `path` rewrite in the import aliasing was causing the imported modules to have the wrong internal package name, which caused subsequent relative imports to also look in the wrong place

This change fixes that, and with compat in place HappyHare now passes our `--import-test`

_Enter a good description of whats being changed and WHY

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
