### PR TITLE
Expose slope_control field on TMC2240.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4451,6 +4451,11 @@ run_current:
 #driver_PWM_OFS: 29
 #driver_PWM_REG: 4
 #driver_PWM_LIM: 12
+#driver_SLOPE_CONTROL: 0
+#   The chip has a default value of 0, corresponding to 100V/µs.
+#   Setting this value to 2, corresponding to 400V/µs, approximately
+#   matches the TMC2209. This lowers the power dissipation at a 50kHz
+#   chopper frequency by around 1W.
 #driver_SGT: 0
 #driver_SEMIN: 0
 #driver_SEUP: 0

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -438,6 +438,8 @@ class TMC2240:
         set_config_field(config, "tpowerdown", 10)
         #   SG4_THRS
         set_config_field(config, "sg4_angle_offset", 1)
+        #   DRV_CONF
+        set_config_field(config, "slope_control", 0)
 
 
 def load_config_prefix(config):


### PR DESCRIPTION
The chip has a default value of 0, corresponding to 100V/µs. The default is overridden with 2 here, corresponding to 400V/µs to approximately match the TMC2209. This should also solve some overheating issues as it lowers the power dissipation at a 50kHz chopper frequency by around 1W.

This is currently untested.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] ~~added a test case if possible~~
- [ ] ~~if new feature, added to the readme~~ (Pending identical PR to Klipper)
- [x] ci is happy and green
