### PR TITLE
Fixing admonitions blocks on docs

### DIFF
--- a/docs/_kalico/mkdocs-requirements.txt
+++ b/docs/_kalico/mkdocs-requirements.txt
@@ -8,3 +8,4 @@ mdx-truly-sane-lists==1.3
 mdx-breakless-lists==1.0.1
 py-gfm==2.0.0
 markdown==3.6
+mkdocs-github-admonitions-plugin==0.0.3

--- a/docs/_kalico/mkdocs.yml
+++ b/docs/_kalico/mkdocs.yml
@@ -31,6 +31,7 @@ plugins:
   mkdocs-simple-hooks:
     hooks:
       on_page_markdown: "docs._kalico.mkdocs_hooks:transform"
+  gh-admonitions:
 
 # Website layout configuration (using mkdocs-material theme)
 theme:


### PR DESCRIPTION
At the moment admonition blocks in the docs are rendered like 
![image](https://github.com/user-attachments/assets/9033f633-4395-4bbf-b74d-e36abe18058f)

This PR should fix them using a plugin, and rendering them mostly as they are on github.
