### PR TITLE
Add missing git fetch to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Can switch back to mainline klipper at any time via a `git checkout upstream_mai
 ```bash
 cd ~/klipper
 git remote add kalico https://github.com/KalicoCrew/kalico.git
+git fetch kalico
 git checkout -b upstream-main origin/master
 git branch -D master
 git checkout -b main kalico/main


### PR DESCRIPTION
Existing instructions don't actually work. Fetch is required.
