### PR TITLE
Fix #511

### DIFF
--- a/docs/_kalico/mkdocs.yml
+++ b/docs/_kalico/mkdocs.yml
@@ -25,6 +25,7 @@ markdown_extensions:
   - mdx_partial_gfm
   - mdx_truly_sane_lists
   - mdx_breakless_lists
+  - admonition
 plugins:
   search:
     lang: en


### PR DESCRIPTION
This fixes #511 as it was left out by mistake.
The markdown extension for admonitions must be enabled as well.
