### PR TITLE
Fix telemetry commands being available when they shouldnt

### DIFF
--- a/klippy/extras/telemetry.py
+++ b/klippy/extras/telemetry.py
@@ -30,12 +30,12 @@ class KalicoTelementry:
 
         if self.enabled is not True:
             gcode.register_command(
-                "ENABLE_TELEMETRY", self.cmd_ENABLE_TELEMETRY, True
+                "ENABLE_TELEMETRY", self.cmd_ENABLE_TELEMETRY
             )
 
         if self.enabled is not False:
             gcode.register_command(
-                "DISABLE_TELEMETRY", self.cmd_DISABLE_TELEMETRY, True
+                "DISABLE_TELEMETRY", self.cmd_DISABLE_TELEMETRY
             )
 
         if self.enabled is None:


### PR DESCRIPTION
Telemetry commands were available while klipper wasnt ready, which should not be since they call for SAVE_CONFIG which is not available in that state

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
