### PR TITLE
trad_rack and extruder: add support for using additional extruder steppers with trad rack

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -86,7 +86,10 @@ class ExtruderStepper:
             self.extruder = None
             return
         extruder = self.printer.lookup_object(extruder_name, None)
-        if extruder is None or not isinstance(extruder, PrinterExtruder):
+        if extruder is None or not (
+            hasattr(extruder, "link_extruder_stepper")
+            and hasattr(extruder, "unlink_extruder_stepper")
+        ):
             raise self.printer.command_error(
                 "'%s' is not a valid extruder." % (extruder_name,)
             )


### PR DESCRIPTION
This is meant to address #394 by allowing the use of a third extruder between a trad rack and the printer's main extruder (to ensure a filament segment can be retracted after a runout even if there is a large amount of filament movement between when the runout is detected and when the print is paused for the filament change).

This change is currently untested and will also need documentation changes. Also I am not sure if it should be split into multiple smaller pull requests or not? Please let me know.

This change includes:
- extruder.py was modified to allow syncing an `ExtruderStepper` to other extruder objects besides a `PrinterExtruder`:
  - I transferred some of the changes from a893f98a708ef38498df19171c498d2bd8df30c0 by dmbutyugin that move part of the `sync_to_extruder()` function into separate `link_extruder_stepper()` and `unlink_extruder_stepper()` functions so that other classes besides `PrinterExtruder` can have their own implementations of these functions so they can have extruders synced to them. Since a893f98a708ef38498df19171c498d2bd8df30c0  is already in `bleeding-edge-v2`, I think this should make it easy to make this change compatible with that branch as well.
  - Instead of checking whether the extruder object to sync to is an instance of `PrinterExtruder`, it now checks whether that object has the attributes "link_extruder_stepper" and "unlink_extruder_stepper" so that other types that have those functions can have extruders synced to them as well.
- trad_rack.py was modified to allow `ExtruderStepper` objects to be synced to its filament driver axis:
  - Added `link_extruder_stepper()` and `unlink_extruder_stepper()` functions
  - The code will take care of transferring any extruder steppers synced to trad rack to be synced to the printer's main extruder during printing. If any additional extruder steppers are used, trad rack's main filament driver motor will not be synced to the main extruder during printing (at least for now; I assumed having 3 extruders synced was unnecessary and would just degrade the filament more, but this would be easy to undo if there is a use case).

For now, this is how to modify an existing trad rack setup to test this:
- The third extruder should be placed somewhere along the filament path between trad rack and the printer's main extruder. In the Kalico config, the third extruder should be configured as an [extruder_stepper] with the `extruder` config option set to `trad_rack`.
- If a belay is used, it should be placed between the third extruder and the printer's main extruder. In the Kalico config, it should be configured the same way as if you were using trad rack's filament driver motor as the secondary extruder (with the `extruder_type` config option set to `trad_rack`).

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
