### PR TITLE
fix sense_resistor description

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4034,7 +4034,7 @@ run_current:
 #   The amount of time (in seconds) to wait after changing homing current.
 #   The default is 0.5 seconds.
 sense_resistor:
-#   The resistance (in ohms) of the motor sense resistor. This
+#   The resistance (in ohms) of the driver sense resistor. This
 #   parameter must be provided.
 #stealthchop_threshold: 0
 #   The velocity (in mm/s) to set the "stealthChop" threshold to. When
@@ -4145,7 +4145,7 @@ run_current:
 #   The amount of time (in seconds) to wait after changing homing current.
 #   The default is 0.5 seconds.
 sense_resistor:
-#   The resistance (in ohms) of the motor sense resistor. This
+#   The resistance (in ohms) of the driver sense resistor. This
 #   parameter must be provided.
 #stealthchop_threshold: 0
 #   The velocity (in mm/s) to set the "stealthChop" threshold to. When
@@ -4271,7 +4271,7 @@ run_current:
 #   The amount of time (in seconds) to wait after changing homing current.
 #   The default is 0.5 seconds.
 sense_resistor:
-#   The resistance (in ohms) of the motor sense resistor. This
+#   The resistance (in ohms) of the driver sense resistor. This
 #   parameter must be provided.
 #idle_current_percent: 100
 #   The percentage of the run_current the stepper driver will be
@@ -4496,7 +4496,7 @@ run_current:
 #   The amount of time (in seconds) to wait after changing homing current.
 #   The default is 0.5 seconds.
 sense_resistor:
-#   The resistance (in ohms) of the motor sense resistor. This
+#   The resistance (in ohms) of the driver sense resistor. This
 #   parameter must be provided.
 #stealthchop_threshold: 0
 #   The velocity (in mm/s) to set the "stealthChop" threshold to. When


### PR DESCRIPTION
Specifying the sense resistor as "motor" dependant confuses people as it is a driver spec, not a motor spec.

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
