### PR TITLE
removed tmc2240 default value

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,8 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250107: The `rref` parameter for tmc2240 is now mandatory with no default value.
+
 20241202: The `sense_resistor` parameter is now mandatory with no default value.
 
 20241201: In some cases Klipper may have ignored leading characters or

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4356,9 +4356,9 @@ run_current:
 #current_change_dwell_time:
 #   The amount of time (in seconds) to wait after changing homing current.
 #   The default is 0.5 seconds.
-#rref: 12000
-#   The resistance (in ohms) of the resistor between IREF and GND. The
-#   default is 12000.
+#rref:
+#   The resistance (in ohms) of the resistor between IREF and GND. This
+#   parameter must be provided.
 #stealthchop_threshold: 0
 #   The velocity (in mm/s) to set the "stealthChop" threshold to. When
 #   set, "stealthChop" mode will be enabled if the stepper motor

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -270,9 +270,7 @@ class TMC2240CurrentHelper(tmc.BaseTMCCurrentHelper):
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        self.Rref = config.getfloat(
-            "rref", minval=12000.0, maxval=60000.0
-        )
+        self.Rref = config.getfloat("rref", minval=12000.0, maxval=60000.0)
         self.max_current = self._get_ifs_rms(3)
         self.config_run_current = config.getfloat(
             "run_current", above=0.0, maxval=self.max_current

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -271,7 +271,7 @@ class TMC2240CurrentHelper(tmc.BaseTMCCurrentHelper):
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
         self.Rref = config.getfloat(
-            "rref", 12000.0, minval=12000.0, maxval=60000.0
+            "rref", minval=12000.0, maxval=60000.0
         )
         self.max_current = self._get_ifs_rms(3)
         self.config_run_current = config.getfloat(

--- a/test/klippy/tmc.cfg
+++ b/test/klippy/tmc.cfg
@@ -97,6 +97,7 @@ rotation_distance: 8
 [tmc2240 stepper_z2]
 cs_pin: PK3
 run_current: .5
+rref: 12000
 
 [mcu]
 serial: /dev/ttyACM0


### PR DESCRIPTION
tmc2240 still had a default value for rref which should be removed since we removed sense_resistor default as well. Adjusted code and updated docs and tests accordingly

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [x] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
