### PR TITLE
Minor amend to documentation on constants

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -155,7 +155,8 @@ A collection of Kalico-specific system options
 In your configuration, you can reference other values to share
 configuration between multiple sections. References take the form of
 `${option}` to copy a value in the current section, or
-`${section.option}` to look up a value elsewhere in your configuration.
+`${section.option}` to look up a value elsewhere in your configuration. Note,
+that constants must always be lower case.
 
 Optionally, a `[constants]` section may be used specifically to store
 these values. Unlike the rest of your configuration, unused constants


### PR DESCRIPTION
Just added a note in the constants section of the documents to advise people they must always be lower case.

It caught me out, so I thought it might be worth adding it to the docs to save others.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [N/A] added a test case if possible
- [N/A] if new feature, added to the readme
- [ ] ci is happy and green
