### PR TITLE
Remove mutable parameter defaults

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -19,8 +19,16 @@ def ffs(mask):
 
 class FieldHelper:
     def __init__(
-        self, all_fields, signed_fields=[], field_formatters={}, registers=None
+        self,
+        all_fields,
+        signed_fields=None,
+        field_formatters=None,
+        registers=None,
     ):
+        if field_formatters is None:
+            field_formatters = {}
+        if signed_fields is None:
+            signed_fields = []
         self.all_fields = all_fields
         self.signed_fields = {sf: 1 for sf in signed_fields}
         self.field_formatters = field_formatters

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1512,7 +1512,9 @@ or in response to an internal error in the host software.""",
 }
 
 
-def error_help(msg, append_msgs=[]):
+def error_help(msg, append_msgs=None):
+    if append_msgs is None:
+        append_msgs = []
     for prefixes, help_msg in Common_MCU_errors.items():
         for prefix in prefixes:
             if msg.startswith(prefix):

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -158,7 +158,9 @@ MessageTypes = {
 
 
 # Lookup the message types for a format string
-def lookup_params(msgformat, enumerations={}):
+def lookup_params(msgformat, enumerations=None):
+    if enumerations is None:
+        enumerations = {}
     out = []
     argparts = [arg.split("=") for arg in msgformat.split()[1:]]
     for name, fmt in argparts:
@@ -199,7 +201,9 @@ def convert_msg_format(msgformat):
 
 
 class MessageFormat:
-    def __init__(self, msgid_bytes, msgformat, enumerations={}):
+    def __init__(self, msgid_bytes, msgformat, enumerations=None):
+        if enumerations is None:
+            enumerations = {}
         self.msgid_bytes = msgid_bytes
         self.msgformat = msgformat
         self.debugformat = convert_msg_format(msgformat)
@@ -438,7 +442,11 @@ class MessageParser:
                 for i in range(count):
                     enums[enum_root + str(start_enum + i)] = start_value + i
 
-    def _init_messages(self, messages, command_ids=[], output_ids=[]):
+    def _init_messages(self, messages, command_ids=None, output_ids=None):
+        if output_ids is None:
+            output_ids = []
+        if command_ids is None:
+            command_ids = []
         for msgformat, msgid in messages.items():
             msgtype = "response"
             if msgid in command_ids:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ indent-width = 4
 exclude = [".github", ".history", "config", "docs", "lib", "src"]
 
 [tool.ruff.lint]
+extend-select = ["B006"]
 ignore = [
   "E401", # Multiple imports on one line
   "C901", # Function is too complex

--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -127,7 +127,9 @@ def flash_canboot(options, binfile):
 
 
 # Flash via a call to bossac
-def flash_bossac(device, binfile, extra_flags=[]):
+def flash_bossac(device, binfile, extra_flags=None):
+    if extra_flags is None:
+        extra_flags = []
     ttyname, pathname = translate_serial_to_tty(device)
     enter_bootloader(pathname)
     pathname = wait_path(pathname, ttyname)
@@ -160,7 +162,9 @@ def call_dfuutil(flags, binfile, sudo):
 
 
 # Flash via a call to dfu-util
-def flash_dfuutil(device, binfile, extra_flags=[], sudo=True):
+def flash_dfuutil(device, binfile, extra_flags=None, sudo=True):
+    if extra_flags is None:
+        extra_flags = []
     hexfmt_r = re.compile(r"^[a-fA-F0-9]{4}:[a-fA-F0-9]{4}$")
     if hexfmt_r.match(device.strip()):
         call_dfuutil(["-d", "," + device.strip()] + extra_flags, binfile, sudo)


### PR DESCRIPTION
This can be a particularly painful source of bugs.[^1]  The objects are constructed and retain their state between calls.  It's best to avoid this pattern altogether.

_Enter a good description of whats being changed and WHY

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] ~added a test case if possible~
- [ ] ~if new feature, added to the readme~
- [x] ci is happy and green

[^1]: https://docs.astral.sh/ruff/rules/mutable-argument-default/