### PR TITLE
stepper: default second_homing_speed to homing_speed for sensorless

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,9 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250121: The `second_homing_speed` default value in the stepper config section
+is now set to `homing_speed` if sensorless homing is enabled.
+
 20250107: The `rref` parameter for tmc2240 is now mandatory with no default value.
 
 20241202: The `sense_resistor` parameter is now mandatory with no default value.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -314,7 +314,8 @@ position_max:
 #   The default is equal to `homing_retract_dist`.
 #second_homing_speed:
 #   Velocity (in mm/s) of the stepper when performing the second home.
-#   The default is homing_speed/2.
+#   The default is homing_speed/2. If `use_sensorless_homing` is
+#   true, the default is homing_speed.
 #homing_positive_dir:
 #   If true, homing will cause the stepper to move in a positive
 #   direction (away from zero); if false, home towards zero. It is
@@ -2634,11 +2635,11 @@ for more detailed information regarding symptoms, configuration and setup.
 calibrate_start_x: 20
 #   Defines the minimum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the starting
-#   calibration position. 
+#   calibration position.
 calibrate_end_x: 200
 #   Defines the maximum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the ending
-#   calibration position. 
+#   calibration position.
 calibrate_y: 112.5
 #   Defines the Y coordinate of the calibration
 #   This should be the Y coordinate that positions the nozzle during the

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -441,9 +441,18 @@ class PrinterRail:
                 " position_min and position_max" % config.get_name()
             )
         # Homing mechanics
+        self.use_sensorless_homing = config.getboolean(
+            "use_sensorless_homing", endstop_is_virtual
+        )
+
         self.homing_speed = config.getfloat("homing_speed", 5.0, above=0.0)
+
+        default_second_homing_speed = self.homing_speed / 2.0
+        if self.use_sensorless_homing:
+            default_second_homing_speed = self.homing_speed
+
         self.second_homing_speed = config.getfloat(
-            "second_homing_speed", self.homing_speed / 2.0, above=0.0
+            "second_homing_speed", default_second_homing_speed, above=0.0
         )
         self.homing_retract_speed = config.getfloat(
             "homing_retract_speed", self.homing_speed, above=0.0
@@ -454,9 +463,7 @@ class PrinterRail:
         self.homing_positive_dir = config.getboolean(
             "homing_positive_dir", None
         )
-        self.use_sensorless_homing = config.getboolean(
-            "use_sensorless_homing", endstop_is_virtual
-        )
+
         self.min_home_dist = config.getfloat(
             "min_home_dist", self.homing_retract_dist, minval=0.0
         )


### PR DESCRIPTION
As suggested in https://github.com/KalicoCrew/kalico/issues/542 and per experience, matching homing_speed and second_homing_speed when homing using sensorless makes sense. Our own FAC (frequently asked configs) already recommends that.
