### PR TITLE
feat: allow multiple instances of duplicate_pin_override

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2279,6 +2279,8 @@ times in a config file without normal error checking. This is intended
 for diagnostic and debugging purposes. This section is not needed
 where Kalico supports using the same pin multiple times, and using
 this override may cause confusing and unexpected results.
+One may specify an explicit name (eg, [duplicate_pin_override my_name])
+to define multiple instances of it.
 
 ```
 [duplicate_pin_override]
@@ -2634,11 +2636,11 @@ for more detailed information regarding symptoms, configuration and setup.
 calibrate_start_x: 20
 #   Defines the minimum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the starting
-#   calibration position. 
+#   calibration position.
 calibrate_end_x: 200
 #   Defines the maximum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the ending
-#   calibration position. 
+#   calibration position.
 calibrate_y: 112.5
 #   Defines the Y coordinate of the calibration
 #   This should be the Y coordinate that positions the nozzle during the

--- a/klippy/extras/duplicate_pin_override.py
+++ b/klippy/extras/duplicate_pin_override.py
@@ -15,3 +15,7 @@ class PrinterDupPinOverride:
 
 def load_config(config):
     return PrinterDupPinOverride(config)
+
+
+def load_config_prefix(config):
+    return PrinterDupPinOverride(config)

--- a/test/klippy/duplicate_pin_override.cfg
+++ b/test/klippy/duplicate_pin_override.cfg
@@ -1,0 +1,77 @@
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[probe]
+pin: PH6
+z_offset: 1.15
+drop_first_result: true
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[duplicate_pin_override]
+pins: PA4
+
+[duplicate_pin_override xxx]
+pins: PA6

--- a/test/klippy/duplicate_pin_override.test
+++ b/test/klippy/duplicate_pin_override.test
@@ -1,0 +1,12 @@
+CONFIG duplicate_pin_override.cfg
+DICTIONARY atmega2560.dict
+
+# Start by homing the printer.
+G28
+
+G1 F6000
+
+# Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1


### PR DESCRIPTION
As suggested via Discord ([here](https://discord.com/channels/1297243471442214913/1325807514222067774)), a quick feature to allow multiple instances of `duplicate_pin_override`

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
