### PR TITLE
danger_options: adds the log_pressure_advance_changes option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -140,6 +140,11 @@ A collection of Kalico-specific system options
 #log_velocity_limit_changes: True
 #   If changes to velocity limits should be logged. If False, velocity limits will only
 #   be logged at rollover. Some slicers emit very frequent SET_VELOCITY_LIMIT commands
+#   The default is True
+#log_pressure_advance_changes: True
+#   If changes to pressure advance should be logged. If false, pressure advance data
+#   will only be logged at rollover.
+#   The default is True.
 #log_shutdown_info: True
 #   If we should log detailed crash info when an exception occurs
 #   Most of it is overly-verbose and fluff and we still get a stack trace
@@ -2634,11 +2639,11 @@ for more detailed information regarding symptoms, configuration and setup.
 calibrate_start_x: 20
 #   Defines the minimum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the starting
-#   calibration position. 
+#   calibration position.
 calibrate_end_x: 200
 #   Defines the maximum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the ending
-#   calibration position. 
+#   calibration position.
 calibrate_y: 112.5
 #   Defines the Y coordinate of the calibration
 #   This should be the Y coordinate that positions the nozzle during the

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -11,6 +11,9 @@ class DangerOptions:
         self.log_velocity_limit_changes = config.getboolean(
             "log_velocity_limit_changes", True
         )
+        self.log_pressure_advance_changes = config.getboolean(
+            "log_pressure_advance_changes", True
+        )
         self.log_shutdown_info = config.getboolean("log_shutdown_info", True)
         self.log_serial_reader_warnings = config.getboolean(
             "log_serial_reader_warnings", True
@@ -62,6 +65,7 @@ class DangerOptions:
             self.log_config_file_at_startup = False
             self.log_bed_mesh_at_startup = False
             self.log_velocity_limit_changes = False
+            self.log_pressure_advance_changes = False
             self.log_shutdown_info = False
             self.log_serial_reader_warnings = False
             self.log_startup_info = False

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
 from klippy import stepper, chelper
+from ..extras.danger_options import get_danger_options
 
 
 class ExtruderStepper:
@@ -137,12 +138,16 @@ class ExtruderStepper:
             maxval=0.200,
         )
         self._set_pressure_advance(pressure_advance, smooth_time)
-        msg = "pressure_advance: %.6f\npressure_advance_smooth_time: %.6f" % (
-            pressure_advance,
-            smooth_time,
-        )
-        self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
-        gcmd.respond_info(msg, log=False)
+
+        if get_danger_options().log_pressure_advance_changes:
+            msg = (
+                "pressure_advance: %.6f" % pressure_advance,
+                "pressure_advance_smooth_time: %.6f" % smooth_time,
+            )
+            self.printer.set_rollover_info(
+                self.name, "%s: %s" % (self.name, (" ".join(msg)))
+            )
+            gcmd.respond_info("\n".join(msg), log=False)
 
     cmd_SET_E_ROTATION_DISTANCE_help = "Set extruder rotation distance"
 


### PR DESCRIPTION
Following the idea from https://github.com/KalicoCrew/kalico/pull/489 allows control of pressure_advance logging. OrcaSlicer and its adaptative pressure advance emit many pressure advance changes.

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
