### PR TITLE
Fix default target temp for mpc calibrate on bed

### DIFF
--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -380,7 +380,10 @@ class MpcCalibrate:
             "AMBIENT_MEASURE_SAMPLE_TIME", 5.0, below=ambient_max_measure_time
         )
         fan_breakpoints = gcmd.get_int("FAN_BREAKPOINTS", 3, minval=2)
-        target_temp = gcmd.get_float("TARGET", 200.0, minval=90.0)
+        default_target_temp = (
+            90.0 if self.heater.get_name() == "heater_bed" else 200.0
+        )
+        target_temp = gcmd.get_float("TARGET", default_target_temp, minval=90.0)
         threshold_temp = gcmd.get_float(
             "THRESHOLD", max(50.0, min(100, target_temp - 100.0))
         )


### PR DESCRIPTION
The docs state that for heater_bed the default target when calibrating mpc is 90 but the code just always uses 200, this fixes that

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
