### PR TITLE
qgl/ztilt - bugfix lift_speed and adds enforce_lift_speed

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1439,14 +1439,16 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
 #min_horizontal_move_z: 1.0
-#   minimum value for horizontal move z
-#   (only used when adaptive_horizontal_move_z is True)
+#   The minimum value for horizontal move z to be used when
+#   adaptive_horizontal_move_z is enabled.
+#   The default is 1mm
 #adaptive_horizontal_move_z: False
-#   if we should adjust horizontal move z after the first adjustment round,
-#   based on error.
-#   when set to True, initial horizontal_move_z is the config value,
-#   subsequent iterations will set horizontal_move_z to
+#   Set it to True to automatically adjust horizontal move z after the first
+#   adjustment round, based on error.
+#   When enabled, the initial horizontal_move_z is the config value,
+#   and subsequent iterations will set horizontal_move_z to
 #   the ceil of error, or min_horizontal_move_z - whichever is greater.
+#   The default is False.
 #retries: 0
 #   Number of times to retry if the probed points aren't within
 #   tolerance.
@@ -1463,6 +1465,10 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #use_probe_xy_offsets: False
 #   If True, apply the `[probe]` XY offsets to the probed positions. The
 #   default is False.
+#enforce_lift_speed: False
+#   By default, the first Z movement to reach `horizontal_move_z` uses `speed`.
+#   Set `enforce_lift_speed` to True to enforce the `lift_speed`.
+#   The default is False.
 ```
 
 #### [z_tilt_ng]
@@ -1503,6 +1509,8 @@ commands become available, enhancing bed leveling accuracy and calibration effic
 #increasing_threshold: 0.0000001
 # See [z_tilt]
 #use_probe_xy_offsets: False
+# See [z_tilt]
+#enforce_lift_speed: False
 # See [z_tilt]
 #extra_points:
 #   A list in the same format as "points" above. This list contains
@@ -1573,14 +1581,16 @@ Where x is the 0, 0 point on the bed
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
 #min_horizontal_move_z: 1.0
-#   minimum value for horizontal move z
-#   (only used when adaptive_horizontal_move_z is True)
+#   The minimum value for horizontal move z to be used when
+#   adaptive_horizontal_move_z is enabled.
+#   The default is 1mm
 #adaptive_horizontal_move_z: False
-#   if we should adjust horizontal move z after the first adjustment round,
-#   based on error.
-#   when set to True, initial horizontal_move_z is the config value,
-#   subsequent iterations will set horizontal_move_z to
+#   Set it to True to automatically adjust horizontal move z after the first
+#   adjustment round, based on error.
+#   When enabled, the initial horizontal_move_z is the config value,
+#   and subsequent iterations will set horizontal_move_z to
 #   the ceil of error, or min_horizontal_move_z - whichever is greater.
+#   The default is False.
 #max_adjust: 4
 #   Safety limit if an adjustment greater than this value is requested
 #   quad_gantry_level will abort.
@@ -1596,6 +1606,10 @@ Where x is the 0, 0 point on the bed
 #use_probe_xy_offsets: False
 #   If True, apply the `[probe]` XY offsets to the probed positions. The
 #   default is False.
+#enforce_lift_speed: False
+#   By default, the first Z movement to reach `horizontal_move_z` uses `speed`.
+#   Set `enforce_lift_speed` to True to enforce the `lift_speed`.
+#   The default is False.
 ```
 
 ### [skew_correction]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -155,7 +155,7 @@ The following commands are available when the
 section](Config_Reference.md#axis_twist_compensation) is enabled.
 
 #### AXIS_TWIST_COMPENSATION_CALIBRATE
-`AXIS_TWIST_COMPENSATION_CALIBRATE [AXIS=<X|Y>] 
+`AXIS_TWIST_COMPENSATION_CALIBRATE [AXIS=<X|Y>]
 [SAMPLE_COUNT=<value>] [<probe_parameter>=<value>]`:
 
 Calibrates axis twist compensation by specifying the target axis or
@@ -711,7 +711,7 @@ SET_RETRACTION commands are reset to config values.
 
 NOTE: It is recommended to add `RESET_RETRACTION` to your start and end gcode
 (with a possible override in your filament start gcode to set filament-specific
-overrides of firmware retraction defaults via `SET_RETRACTION`). 
+overrides of firmware retraction defaults via `SET_RETRACTION`).
 
 ### [force_move]
 
@@ -1285,6 +1285,21 @@ using the CYCLE_TIME parameter (specified in seconds). Note that the
 CYCLE_TIME parameter is not stored between SET_PIN commands (any
 SET_PIN command without an explicit CYCLE_TIME parameter will use the
 `cycle_time` specified in the pwm_cycle_time config section).
+
+### [quad_gantry_level]
+
+The following commands are available when the
+[quad_gantry_level config section](Config_Reference.md#quad_gantry_level)
+is enabled.
+
+#### QUAD_GANTRY_LEVEL
+`QUAD_GANTRY_LEVEL [RETRIES=<value>] [RETRY_TOLERANCE=<value>]
+[HORIZONTAL_MOVE_Z=<value>] [<probe_parameter>=<value>]`: This command
+will probe the points specified in the config and then make
+independent adjustments to each Z stepper to compensate for tilt. See
+the PROBE command for details on the optional probe parameters. The
+optional `RETRIES`, `RETRY_TOLERANCE`, `HORIZONTAL_MOVE_Z` and
+`ENFORCE_LIFT_SPEED` values override those options specified in the config file.
 
 ### [query_adc]
 
@@ -1937,11 +1952,12 @@ The following commands are available when the
 [z_tilt config section](Config_Reference.md#z_tilt) is enabled.
 
 #### Z_TILT_ADJUST
-`Z_TILT_ADJUST [HORIZONTAL_MOVE_Z=<value>] [<probe_parameter>=<value>]`: This
-command will probe the points specified in the config and then make independent
-adjustments to each Z stepper to compensate for tilt. See the PROBE command for
-details on the optional probe parameters. The optional `HORIZONTAL_MOVE_Z`
-value overrides the `horizontal_move_z` option specified in the config file.
+`Z_TILT_ADJUST [HORIZONTAL_MOVE_Z=<value>] [ENFORCE_LIFT_SPEED=0|1]
+[<probe_parameter>=<value>]`: This command will probe the points specified in the
+config and then make independent adjustments to each Z stepper to compensate for tilt.
+See the PROBE command for details on the optional probe parameters. The optional
+`HORIZONTAL_MOVE_Z` and `ENFORCE_LIFT_SPEED` values override those options specified in
+the config file
 
 ### [z_tilt_ng]
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -543,7 +543,8 @@ class ProbePointsHelper:
         toolhead = self.printer.lookup_object("toolhead")
         # Check if done probing
         done = False
-        if len(self.results) >= len(self.probe_points):
+        finalize = len(self.results) >= len(self.probe_points)
+        if finalize:
             toolhead.get_last_move_time()
             res = self.finalize_callback(self.probe_offsets, self.results)
             if isinstance(res, (int, float)):
@@ -558,8 +559,9 @@ class ProbePointsHelper:
                     )
             elif res != "retry":
                 done = True
-            self.results = []
         self._lift_toolhead()
+        if finalize:
+            self.results = []
         if done:
             return True
         # Move to next XY probe point

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -506,6 +506,8 @@ class ProbePointsHelper:
             "use_probe_xy_offsets", use_offsets
         )
 
+        self.enforce_lift_speed = config.getboolean("enforce_lift_speed", False)
+
         # Internal probing state
         self.lift_speed = self.speed
         self.probe_offsets = (0.0, 0.0, 0.0)
@@ -534,7 +536,7 @@ class ProbePointsHelper:
         toolhead = self.printer.lookup_object("toolhead")
         # Lift toolhead
         speed = self.lift_speed
-        if not self.results:
+        if not self.results and not self.enforce_lift_speed:
             # Use full speed to first probe position
             speed = self.speed
         toolhead.manual_move([None, None, self.horizontal_move_z], speed)
@@ -581,6 +583,12 @@ class ProbePointsHelper:
 
         def_move_z = self.default_horizontal_move_z
         self.horizontal_move_z = gcmd.get_float("HORIZONTAL_MOVE_Z", def_move_z)
+
+        enforce_lift_speed = gcmd.get_int(
+            "ENFORCE_LIFT_SPEED", None, minval=0, maxval=1
+        )
+        if enforce_lift_speed is not None:
+            self.enforce_lift_speed = enforce_lift_speed
 
         if probe is None or method != "automatic":
             # Manual probe


### PR DESCRIPTION
- bugfix for the last z lift movement after probing points. It should use `lift_speed`, and it was using `speed.`
- introduce a new parameter, `enforce_lift_speed`, to allow the user to decide whether to use the lift_speed or speed for the first movement to reach `horizontal_move_z.`