### PR TITLE
docs: fixes tmc2240 current_range documentation

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4481,7 +4481,7 @@ run_current:
 #   the "CoolStep" feature at high speeds. The default is to not set a
 #   TMC "high velocity" threshold.
 #current_range:
-#   The current_range bit value for the driver. Valid values are 0 and 32-255.
+#   The current_range bit value for the driver. Valid values are 0-3.
 #   The defaul is to auto-calculate to match the requested run_current.
 #   For further information consult the tmc2240 datasheet and tuning table.
 #driver_CS: 31


### PR DESCRIPTION
The tmc2240 current_range is a 2 bit field, so valid values are 0, 1, 2 and 3, not 0 and 32-255

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
