### PR TITLE
garbage_collection: freeze objects on klippy ready (#6794)

### DIFF
--- a/klippy/extras/garbage_collection.py
+++ b/klippy/extras/garbage_collection.py
@@ -1,0 +1,35 @@
+# Garbage collection optimizations
+#
+# Copyright (C) 2025  Branden Cash <ammmze@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import gc
+import logging
+
+
+class GarbageCollection:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        # feature check ... freeze/unfreeze is only available in python 3.7+
+        can_freeze = hasattr(gc, "freeze") and hasattr(gc, "unfreeze")
+        if can_freeze:
+            self.printer.register_event_handler(
+                "klippy:ready", self._handle_ready
+            )
+            self.printer.register_event_handler(
+                "klippy:disconnect", self._handle_disconnect
+            )
+
+    def _handle_ready(self):
+        logging.debug("Running full garbage collection and freezing")
+        for n in range(3):
+            gc.collect(n)
+        gc.freeze()
+
+    def _handle_disconnect(self):
+        logging.debug("Unfreezing garbage collection")
+        gc.unfreeze()
+
+
+def load_config(config):
+    return GarbageCollection(config)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -381,6 +381,7 @@ class ToolHead:
             "statistics",
             "manual_probe",
             "tuning_tower",
+            "garbage_collection",
         ]
         for module_name in modules:
             self.printer.load_object(config, module_name)


### PR DESCRIPTION
This significantly reduces the amount of data in the generation 2 garbage collection bucket from the initial startup of klipper.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6794