### PR TITLE
Improved canbus diagnostics (#6784)

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -39,6 +39,15 @@ the following strings: "adjust", "fine".
 - `current_screw`: The index for the current screw being adjusted.
 - `accepted_screws`: The number of accepted screws.
 
+## belay
+
+The following information is available in
+[belay some_name](Config_Reference.md#belay) objects:
+- `printer["belay <config_name>"].last_state`: Returns True if the belay's
+  sensor is in a triggered state (indicating its slider is compressed).
+- `printer["belay <config_name>"].enabled`: Returns True if the belay is
+  currently enabled.
+
 ## canbus_stats
 
 The following information is available in the `canbus_stats

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -39,14 +39,26 @@ the following strings: "adjust", "fine".
 - `current_screw`: The index for the current screw being adjusted.
 - `accepted_screws`: The number of accepted screws.
 
-## belay
+## canbus_stats
 
-The following information is available in
-[belay some_name](Config_Reference.md#belay) objects:
-- `printer["belay <config_name>"].last_state`: Returns True if the belay's
-  sensor is in a triggered state (indicating its slider is compressed).
-- `printer["belay <config_name>"].enabled`: Returns True if the belay is
-  currently enabled.
+The following information is available in the `canbus_stats
+some_mcu_name` object (this object is automatically available if an
+mcu is configured to use canbus):
+- `rx_error`: The number of receive errors detected by the
+  micro-controller canbus hardware.
+- `tx_error`: The number of transmit errors detected by the
+  micro-controller canbus hardware.
+- `tx_retries`: The number of transmit attempts that were retried due
+  to bus contention or errors.
+- `bus_state`: The status of the interface (typically "active" for a
+  bus in normal operation, "warn" for a bus with recent errors,
+  "passive" for a bus that will no longer transmit canbus error
+  frames, or "off" for a bus that will no longer transmit or receive
+  messages).
+
+Note that only the rp2XXX micro-controllers report a non-zero
+`tx_retries` field and the rp2XXX micro-controllers always report
+`tx_error` as zero and `bus_state` as "active".
 
 ## configfile
 

--- a/klippy/extras/canbus_stats.py
+++ b/klippy/extras/canbus_stats.py
@@ -1,0 +1,95 @@
+# Report canbus connection status
+#
+# Copyright (C) 2025  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+
+class PrinterCANBusStats:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.name = config.get_name().split()[-1]
+        self.mcu = None
+        self.get_canbus_status_cmd = None
+        self.status = {
+            "rx_error": None,
+            "tx_error": None,
+            "tx_retries": None,
+            "bus_state": None,
+        }
+        self.printer.register_event_handler(
+            "klippy:connect", self.handle_connect
+        )
+        self.printer.register_event_handler(
+            "klippy:shutdown", self.handle_shutdown
+        )
+
+    def handle_shutdown(self):
+        status = self.status.copy()
+        if status["bus_state"] is not None:
+            # Clear bus_state on shutdown to note that the values may be stale
+            status["bus_state"] = "unknown"
+            self.status = status
+
+    def handle_connect(self):
+        # Lookup mcu
+        mcu_name = self.name
+        if mcu_name != "mcu":
+            mcu_name = "mcu " + mcu_name
+        self.mcu = self.printer.lookup_object(mcu_name)
+        # Lookup status query command
+        if self.mcu.try_lookup_command("get_canbus_status") is None:
+            return
+        self.get_canbus_status_cmd = self.mcu.lookup_query_command(
+            "get_canbus_status",
+            "canbus_status rx_error=%u tx_error=%u tx_retries=%u"
+            " canbus_bus_state=%u",
+        )
+        # Register periodic query timer
+        self.reactor.register_timer(self.query_event, self.reactor.NOW)
+
+    def query_event(self, eventtime):
+        prev_rx = self.status["rx_error"]
+        prev_tx = self.status["tx_error"]
+        prev_retries = self.status["tx_retries"]
+        if prev_rx is None:
+            prev_rx = prev_tx = prev_retries = 0
+        params = self.get_canbus_status_cmd.send()
+        rx = prev_rx + ((params["rx_error"] - prev_rx) & 0xFFFFFFFF)
+        tx = prev_tx + ((params["tx_error"] - prev_tx) & 0xFFFFFFFF)
+        retries = prev_retries + (
+            (params["tx_retries"] - prev_retries) & 0xFFFFFFFF
+        )
+        state = params["canbus_bus_state"]
+        self.status = {
+            "rx_error": rx,
+            "tx_error": tx,
+            "tx_retries": retries,
+            "bus_state": state,
+        }
+        return self.reactor.monotonic() + 1.0
+
+    def stats(self, eventtime):
+        status = self.status
+        if status["rx_error"] is None:
+            return (False, "")
+        return (
+            False,
+            "canstat_%s: bus_state=%s rx_error=%d"
+            " tx_error=%d tx_retries=%d"
+            % (
+                self.name,
+                status["bus_state"],
+                status["rx_error"],
+                status["tx_error"],
+                status["tx_retries"],
+            ),
+        )
+
+    def get_status(self, eventtime):
+        return self.status
+
+
+def load_config_prefix(config):
+    return PrinterCANBusStats(config)

--- a/klippy/extras/canbus_stats.py
+++ b/klippy/extras/canbus_stats.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 
 
 class PrinterCANBusStats:
@@ -46,8 +47,23 @@ class PrinterCANBusStats:
             "canbus_status rx_error=%u tx_error=%u tx_retries=%u"
             " canbus_bus_state=%u",
         )
+        # Register usb_canbus_state message handling (for usb to canbus bridge)
+        self.mcu.register_response(
+            self.handle_usb_canbus_state, "usb_canbus_state"
+        )
         # Register periodic query timer
         self.reactor.register_timer(self.query_event, self.reactor.NOW)
+
+    def handle_usb_canbus_state(self, params):
+        discard = params["discard"]
+        if discard:
+            logging.warning(
+                "USB CANBUS bridge '%s' is discarding!" % (self.name,)
+            )
+        else:
+            logging.warning(
+                "USB CANBUS bridge '%s' is no longer discarding." % (self.name,)
+            )
 
     def query_event(self, eventtime):
         prev_rx = self.status["rx_error"]

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -757,6 +757,7 @@ class MCU:
             self._canbus_iface = config.get("canbus_interface", "can0")
             cbid = self._printer.load_object(config, "canbus_ids")
             cbid.add_uuid(config, canbus_uuid, self._canbus_iface)
+            self._printer.load_object(config, "canbus_stats %s" % (self._name,))
         else:
             self._serialport = config.get("serial")
             if not (

--- a/src/atsam/fdcan.c
+++ b/src/atsam/fdcan.c
@@ -1,11 +1,12 @@
 // CANbus support on atsame70 chips
 //
-// Copyright (C) 2021-2022  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2021-2025  Kevin O'Connor <kevin@koconnor.net>
 // Copyright (C) 2019 Eug Krashtan <eug.krashtan@gmail.com>
 // Copyright (C) 2020 Pontus Borg <glpontus@gmail.com>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "board/irq.h" // irq_save
 #include "command.h" // DECL_CONSTANT_STR
 #include "generic/armcm_boot.h" // armcm_enable_irq
 #include "generic/canbus.h" // canbus_notify_tx
@@ -147,6 +148,38 @@ canhw_set_filter(uint32_t id)
     CANx->MCAN_CCCR &= ~MCAN_CCCR_INIT;
 }
 
+static struct {
+    uint32_t rx_error, tx_error;
+} CAN_Errors;
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    irqstatus_t flag = irq_save();
+    uint32_t psr = CANx->MCAN_PSR, lec = psr & MCAN_PSR_LEC_Msk;
+    if (lec && lec != 7) {
+        // Reading PSR clears it - so update state here
+        if (lec >= 3 && lec <= 5)
+            CAN_Errors.tx_error += 1;
+        else
+            CAN_Errors.rx_error += 1;
+    }
+    uint32_t rx_error = CAN_Errors.rx_error, tx_error = CAN_Errors.tx_error;
+    irq_restore(flag);
+
+    status->rx_error = rx_error;
+    status->tx_error = tx_error;
+    if (psr & MCAN_PSR_BO)
+        status->bus_state = CANBUS_STATE_OFF;
+    else if (psr & MCAN_PSR_EP)
+        status->bus_state = CANBUS_STATE_PASSIVE;
+    else if (psr & MCAN_PSR_EW)
+        status->bus_state = CANBUS_STATE_WARN;
+    else
+        status->bus_state = 0;
+}
+
 // This function handles CAN global interrupts
 void
 CAN_IRQHandler(void)
@@ -182,6 +215,18 @@ CAN_IRQHandler(void)
         // Tx
         CANx->MCAN_IR = FDCAN_IE_TC;
         canbus_notify_tx();
+    }
+    if (ir & (MCAN_IR_PED | MCAN_IR_PEA)) {
+        // Bus error
+        uint32_t psr = CANx->MCAN_PSR;
+        CANx->MCAN_IR = MCAN_IR_PED | MCAN_IR_PEA;
+        uint32_t lec = psr & MCAN_PSR_LEC_Msk;
+        if (lec && lec != 7) {
+            if (lec >= 3 && lec <= 5)
+                CAN_Errors.tx_error += 1;
+            else
+                CAN_Errors.rx_error += 1;
+        }
     }
 }
 
@@ -302,6 +347,6 @@ can_init(void)
     /*##-3- Configure Interrupts #################################*/
     armcm_enable_irq(CAN_IRQHandler, CANx_IRQn, 1);
     CANx->MCAN_ILE = MCAN_ILE_EINT0;
-    CANx->MCAN_IE = MCAN_IE_RF0NE | FDCAN_IE_TC;
+    CANx->MCAN_IE = MCAN_IE_RF0NE | FDCAN_IE_TC | MCAN_IE_PEDE | MCAN_IE_PEAE;
 }
 DECL_INIT(can_init);

--- a/src/atsamd/fdcan.c
+++ b/src/atsamd/fdcan.c
@@ -1,11 +1,12 @@
 // CANbus support on atsame51 chips
 //
-// Copyright (C) 2021-2022  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2021-2025  Kevin O'Connor <kevin@koconnor.net>
 // Copyright (C) 2019 Eug Krashtan <eug.krashtan@gmail.com>
 // Copyright (C) 2020 Pontus Borg <glpontus@gmail.com>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "board/irq.h" // irq_save
 #include "command.h" // DECL_CONSTANT_STR
 #include "generic/armcm_boot.h" // armcm_enable_irq
 #include "generic/canbus.h" // canbus_notify_tx
@@ -163,6 +164,38 @@ canhw_set_filter(uint32_t id)
     CANx->CCCR.reg &= ~CAN_CCCR_INIT;
 }
 
+static struct {
+    uint32_t rx_error, tx_error;
+} CAN_Errors;
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    irqstatus_t flag = irq_save();
+    uint32_t psr = CANx->PSR.reg, lec = psr & CAN_PSR_LEC_Msk;
+    if (lec && lec != 7) {
+        // Reading PSR clears it - so update state here
+        if (lec >= 3 && lec <= 5)
+            CAN_Errors.tx_error += 1;
+        else
+            CAN_Errors.rx_error += 1;
+    }
+    uint32_t rx_error = CAN_Errors.rx_error, tx_error = CAN_Errors.tx_error;
+    irq_restore(flag);
+
+    status->rx_error = rx_error;
+    status->tx_error = tx_error;
+    if (psr & CAN_PSR_BO)
+        status->bus_state = CANBUS_STATE_OFF;
+    else if (psr & CAN_PSR_EP)
+        status->bus_state = CANBUS_STATE_PASSIVE;
+    else if (psr & CAN_PSR_EW)
+        status->bus_state = CANBUS_STATE_WARN;
+    else
+        status->bus_state = 0;
+}
+
 // This function handles CAN global interrupts
 void
 CAN_IRQHandler(void)
@@ -198,6 +231,18 @@ CAN_IRQHandler(void)
         // Tx
         CANx->IR.reg = FDCAN_IE_TC;
         canbus_notify_tx();
+    }
+    if (ir & (CAN_IR_PED | CAN_IR_PEA)) {
+        // Bus error
+        uint32_t psr = CANx->PSR.reg;
+        CANx->IR.reg = CAN_IR_PED | CAN_IR_PEA;
+        uint32_t lec = psr & CAN_PSR_LEC_Msk;
+        if (lec && lec != 7) {
+            if (lec >= 3 && lec <= 5)
+                CAN_Errors.tx_error += 1;
+            else
+                CAN_Errors.rx_error += 1;
+        }
     }
 }
 
@@ -309,6 +354,6 @@ can_init(void)
     /*##-3- Configure Interrupts #################################*/
     armcm_enable_irq(CAN_IRQHandler, CANx_IRQn, 1);
     CANx->ILE.reg = CAN_ILE_EINT0;
-    CANx->IE.reg = CAN_IE_RF0NE | FDCAN_IE_TC;
+    CANx->IE.reg = CAN_IE_RF0NE | FDCAN_IE_TC | CAN_IE_PEDE | CAN_IE_PEAE;
 }
 DECL_INIT(can_init);

--- a/src/generic/canbus.h
+++ b/src/generic/canbus.h
@@ -17,9 +17,20 @@ struct canbus_msg {
 
 #define CANMSG_DATA_LEN(msg) ((msg)->dlc > 8 ? 8 : (msg)->dlc)
 
+struct canbus_status {
+    uint32_t rx_error, tx_error, tx_retries;
+    uint32_t bus_state;
+};
+
+enum {
+    CANBUS_STATE_ACTIVE, CANBUS_STATE_WARN, CANBUS_STATE_PASSIVE,
+    CANBUS_STATE_OFF,
+};
+
 // callbacks provided by board specific code
 int canhw_send(struct canbus_msg *msg);
 void canhw_set_filter(uint32_t id);
+void canhw_get_status(struct canbus_status *status);
 
 // canbus.c
 int canbus_send(struct canbus_msg *msg);

--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2019 Eug Krashtan <eug.krashtan@gmail.com>
 // Copyright (C) 2020 Pontus Borg <glpontus@gmail.com>
-// Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2021-2025  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -335,6 +335,25 @@ DECL_TASK(canserial_rx_task);
 /****************************************************************
  * Setup and shutdown
  ****************************************************************/
+
+DECL_ENUMERATION("canbus_bus_state", "active", CANBUS_STATE_ACTIVE);
+DECL_ENUMERATION("canbus_bus_state", "warn", CANBUS_STATE_WARN);
+DECL_ENUMERATION("canbus_bus_state", "passive", CANBUS_STATE_PASSIVE);
+DECL_ENUMERATION("canbus_bus_state", "off", CANBUS_STATE_OFF);
+
+void
+command_get_canbus_status(uint32_t *args)
+{
+    struct canbus_status status;
+    memset(&status, 0, sizeof(status));
+    canhw_get_status(&status);
+    sendf("canbus_status rx_error=%u tx_error=%u tx_retries=%u"
+          " canbus_bus_state=%u"
+          , status.rx_error, status.tx_error, status.tx_retries
+          , status.bus_state);
+}
+DECL_COMMAND_FLAGS(command_get_canbus_status, HF_IN_SHUTDOWN
+                   , "get_canbus_status");
 
 void
 command_get_canbus_id(uint32_t *args)

--- a/src/rp2040/can.c
+++ b/src/rp2040/can.c
@@ -1,6 +1,6 @@
 // Serial over CAN emulation for rp2040 using can2040 software canbus
 //
-// Copyright (C) 2022  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2022-2025  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -39,6 +39,23 @@ void
 canhw_set_filter(uint32_t id)
 {
     // Filter not implemented (and not necessary)
+}
+
+static uint32_t last_tx_retries;
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    struct can2040_stats stats;
+    can2040_get_statistics(&cbus, &stats);
+    uint32_t tx_extra = stats.tx_attempt - stats.tx_total;
+    if (last_tx_retries != tx_extra)
+        last_tx_retries = tx_extra - 1;
+
+    status->rx_error = stats.parse_error;
+    status->tx_retries = last_tx_retries;
+    status->bus_state = CANBUS_STATE_ACTIVE;
 }
 
 // can2040 callback function - handle rx and tx notifications

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2019 Eug Krashtan <eug.krashtan@gmail.com>
 // Copyright (C) 2020 Pontus Borg <glpontus@gmail.com>
-// Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2021-2025  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -168,6 +168,31 @@ canhw_set_filter(uint32_t id)
     fcan->FMR = fmr & ~CAN_FMR_FINIT;
 }
 
+static struct {
+    uint32_t rx_error, tx_error;
+} CAN_Errors;
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    irqstatus_t flag = irq_save();
+    uint32_t esr = SOC_CAN->ESR;
+    uint32_t rx_error = CAN_Errors.rx_error, tx_error = CAN_Errors.tx_error;
+    irq_restore(flag);
+
+    status->rx_error = rx_error;
+    status->tx_error = tx_error;
+    if (esr & CAN_ESR_BOFF)
+        status->bus_state = CANBUS_STATE_OFF;
+    else if (esr & CAN_ESR_EPVF)
+        status->bus_state = CANBUS_STATE_PASSIVE;
+    else if (esr & CAN_ESR_EWGF)
+        status->bus_state = CANBUS_STATE_WARN;
+    else
+        status->bus_state = 0;
+}
+
 // This function handles CAN global interrupts
 void
 CAN_IRQHandler(void)
@@ -190,12 +215,29 @@ CAN_IRQHandler(void)
         // Process packet
         canbus_process_data(&msg);
     }
+
+    // Check for transmit ready
     uint32_t ier = SOC_CAN->IER;
     if (ier & CAN_IER_TMEIE
         && SOC_CAN->TSR & (CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2)) {
         // Tx
         SOC_CAN->IER = ier & ~CAN_IER_TMEIE;
         canbus_notify_tx();
+    }
+
+    // Check for error irq
+    uint32_t msr = SOC_CAN->MSR;
+    if (msr & CAN_MSR_ERRI) {
+        uint32_t esr = SOC_CAN->ESR;
+        uint32_t lec = (esr & CAN_ESR_LEC_Msk) >> CAN_ESR_LEC_Pos;
+        if (lec && lec != 7) {
+            SOC_CAN->ESR = 7 << CAN_ESR_LEC_Pos;
+            if (lec >= 3 && lec <= 5)
+                CAN_Errors.tx_error += 1;
+            else
+                CAN_Errors.rx_error += 1;
+        }
+        SOC_CAN->MSR = CAN_MSR_ERRI;
     }
 }
 
@@ -289,6 +331,8 @@ can_init(void)
         armcm_enable_irq(CAN_IRQHandler, CAN_RX1_IRQn, 0);
     if (CAN_RX0_IRQn != CAN_TX_IRQn)
         armcm_enable_irq(CAN_IRQHandler, CAN_TX_IRQn, 0);
-    SOC_CAN->IER = CAN_IER_FMPIE0;
+    if (CAN_RX0_IRQn != CAN_SCE_IRQn)
+        armcm_enable_irq(CAN_IRQHandler, CAN_SCE_IRQn, 0);
+    SOC_CAN->IER = CAN_IER_FMPIE0 | CAN_IER_ERRIE;
 }
 DECL_INIT(can_init);

--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -1,11 +1,12 @@
 // FDCAN support on stm32 chips
 //
-// Copyright (C) 2021-2022  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2021-2025  Kevin O'Connor <kevin@koconnor.net>
 // Copyright (C) 2019 Eug Krashtan <eug.krashtan@gmail.com>
 // Copyright (C) 2020 Pontus Borg <glpontus@gmail.com>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "board/irq.h" // irq_save
 #include "command.h" // DECL_CONSTANT_STR
 #include "generic/armcm_boot.h" // armcm_enable_irq
 #include "generic/canbus.h" // canbus_notify_tx
@@ -184,6 +185,38 @@ canhw_set_filter(uint32_t id)
     SOC_CAN->CCCR &= ~FDCAN_CCCR_INIT;
 }
 
+static struct {
+    uint32_t rx_error, tx_error;
+} CAN_Errors;
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    irqstatus_t flag = irq_save();
+    uint32_t psr = SOC_CAN->PSR, lec = psr & FDCAN_PSR_LEC_Msk;
+    if (lec && lec != 7) {
+        // Reading PSR clears it - so update state here
+        if (lec >= 3 && lec <= 5)
+            CAN_Errors.tx_error += 1;
+        else
+            CAN_Errors.rx_error += 1;
+    }
+    uint32_t rx_error = CAN_Errors.rx_error, tx_error = CAN_Errors.tx_error;
+    irq_restore(flag);
+
+    status->rx_error = rx_error;
+    status->tx_error = tx_error;
+    if (psr & FDCAN_PSR_BO)
+        status->bus_state = CANBUS_STATE_OFF;
+    else if (psr & FDCAN_PSR_EP)
+        status->bus_state = CANBUS_STATE_PASSIVE;
+    else if (psr & FDCAN_PSR_EW)
+        status->bus_state = CANBUS_STATE_WARN;
+    else
+        status->bus_state = 0;
+}
+
 // This function handles CAN global interrupts
 void
 CAN_IRQHandler(void)
@@ -219,6 +252,18 @@ CAN_IRQHandler(void)
         // Tx
         SOC_CAN->IR = FDCAN_IE_TC;
         canbus_notify_tx();
+    }
+    if (ir & (FDCAN_IR_PED | FDCAN_IR_PEA)) {
+        // Bus error
+        uint32_t psr = SOC_CAN->PSR;
+        SOC_CAN->IR = FDCAN_IR_PED | FDCAN_IR_PEA;
+        uint32_t lec = psr & FDCAN_PSR_LEC_Msk;
+        if (lec && lec != 7) {
+            if (lec >= 3 && lec <= 5)
+                CAN_Errors.tx_error += 1;
+            else
+                CAN_Errors.rx_error += 1;
+        }
     }
 }
 
@@ -320,6 +365,6 @@ can_init(void)
     /*##-3- Configure Interrupts #################################*/
     armcm_enable_irq(CAN_IRQHandler, CAN_IT0_IRQn, 1);
     SOC_CAN->ILE = FDCAN_ILE_EINT0;
-    SOC_CAN->IE = FDCAN_IE_RF0NE | FDCAN_IE_TC;
+    SOC_CAN->IE = FDCAN_IE_RF0NE | FDCAN_IE_TC | FDCAN_IE_PEDE | FDCAN_IE_PEAE;
 }
 DECL_INIT(can_init);


### PR DESCRIPTION
This PR adds support for reporting the micro-controller canbus receive and transmit error status.

The low-level canbus hardware will generally automatically retransmit messages that don't transmit correctly (eg, due to line noise). Unfortunately, this system may hide wiring problems - wiring problems that could cause hard to debug failures in the middle of a print.

The new code here will report the low-level interface statistics in the log statistics messages. For example, one might see messages like: Stats 815.9: ... canstat_mcu: rx_error=0 tx_error=0 bus_state=active ... canstat_corexy_rear_left: rx_error=0 tx_error=0 bus_state=active

In addition to the additional logging, the "usb to canbus bridge mode" has also been extended to detect canbus stalls. Previously, if the canbus were to stall, it would likely become impossible to communicate with the canbus bridge node itself. That complicates debugging (as it is not obvious if the failure is due to something occurring on the bridge node or the canbus). The new code here changes the "usb to canbus bridge" code to detect canbus stalls (no ability to transmit for 50+ms). When a stall is detected canbus transmit messages are discarded, but at least messages to and from the bridge node can continue.

Unfortunately, I don't have a good way to test this code. It runs fine on my local canbus wired printer, but I'm not getting any interface errors. Testing results from others would be appreciated.

-Kevin

Klipper PR: https://github.com/Klipper3d/klipper/pull/6784