### PR TITLE
tmc5160: expose driver_CS, defaults to 31

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,18 @@ All dates in this document are approximate.
 
 ## Changes
 
+
+20250203: The `driver_CS` parameter has been added to tmc5160. The
+ideal driver_cs value may be found by setting the CS value on the
+tmc5160_calculations.xlsx spreadsheet, under the chopper tab, so that
+the Rsense value in the spreadsheet matches `sense_resistor` as defined
+in printer.cfg. While it's not necessary to change the CS value, it can
+be helpful to reach adequate hystersis values on high current drivers paired
+with low current motors. The default for this value is 31, meaning only
+globalscaler will be used to scale the current during normal operation.
+Errors will be invoked if the CS value is set too low, as the target
+current will not be able to be reached.
+
 20250121: The `second_homing_speed` default value in the stepper config section
 is now set to `homing_speed` if sensorless homing is enabled.
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,7 +8,6 @@ All dates in this document are approximate.
 
 ## Changes
 
-
 20250207: The `driver_CS` parameter has been added to tmc5160. Previously the
 CS value was nearly always set to 31. Now, the default is 31, but may be changed.
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -9,16 +9,8 @@ All dates in this document are approximate.
 ## Changes
 
 
-20250203: The `driver_CS` parameter has been added to tmc5160. The
-ideal driver_cs value may be found by setting the CS value on the
-tmc5160_calculations.xlsx spreadsheet, under the chopper tab, so that
-the Rsense value in the spreadsheet matches `sense_resistor` as defined
-in printer.cfg. While it's not necessary to change the CS value, it can
-be helpful to reach adequate hystersis values on high current drivers paired
-with low current motors. The default for this value is 31, meaning only
-globalscaler will be used to scale the current during normal operation.
-Errors will be invoked if the CS value is set too low, as the target
-current will not be able to be reached.
+20250207: The `driver_CS` parameter has been added to tmc5160. Previously the
+CS value was nearly always set to 31. Now, the default is 31, but may be changed.
 
 20250121: The `second_homing_speed` default value in the stepper config section
 is now set to `homing_speed` if sensorless homing is enabled.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4694,6 +4694,16 @@ sense_resistor:
 #driver_CHM: 0
 #driver_VHIGHFS: 0
 #driver_VHIGHCHM: 0
+#driver_CS: 31
+#   The ideal driver_cs value may be found by setting the CS value on the
+#   tmc5160_calculations.xlsx spreadsheet, under the chopper tab, so that
+#   the Rsense value in the spreadsheet matches `sense_resistor` as defined
+#   in printer.cfg. While it's not necessary to change the CS value, it can
+#   be helpful to reach adequate hystersis values on high current drivers paired
+#   with low current motors. The default for this value is 31, meaning only
+#   globalscaler will be used to scale the current during normal operation.
+#   Errors will be invoked if the CS value is set too low, as the target
+#   current will not be able to be reached.
 #driver_DISS2G: 0
 #driver_DISS2VS: 0
 #driver_PWM_AUTOSCALE: True

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4695,15 +4695,15 @@ sense_resistor:
 #driver_VHIGHFS: 0
 #driver_VHIGHCHM: 0
 #driver_CS: 31
-#   The ideal driver_cs value may be found by setting the CS value on the
-#   tmc5160_calculations.xlsx spreadsheet, under the chopper tab, so that
-#   the Rsense value in the spreadsheet matches `sense_resistor` as defined
-#   in printer.cfg. While it's not necessary to change the CS value, it can
-#   be helpful to reach adequate hystersis values on high current drivers paired
-#   with low current motors. The default for this value is 31, meaning only
-#   globalscaler will be used to scale the current during normal operation.
-#   Errors will be invoked if the CS value is set too low, as the target
-#   current will not be able to be reached.
+#   The current scale value for the TMC driver. The ideal `driver_CS` value may
+#   be found by setting the `CS` value on the tmc5160_calculations.xlsx spreadsheet,
+#   under the chopper tab, so that the Rsense value in the spreadsheet matches
+#   `sense_resistor`. While it's not necessary to change
+#   the CS value, it can be helpful to reach adequate hysteresis values on high
+#   current drivers paired with low current motors. The default for this value is 31,
+#   meaning only globalscaler will be used to scale the current during normal operation.
+#   Errors will be invoked if the CS value is set too low, as the target current
+#   will not be able to be reached.
 #driver_DISS2G: 0
 #driver_DISS2VS: 0
 #driver_PWM_AUTOSCALE: True

--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -453,6 +453,8 @@ class MpcCalibrate:
                 f"  sensor_responsiveness={sensor_responsiveness:#.6g} [K/s/K]\n"
                 f"  ambient_transfer={ambient_transfer:#.6g} [W/K]\n"
                 f"  fan_ambient_transfer={fan_ambient_transfer} [W/K]\n"
+                "The SAVE_CONFIG command will update the printer config file\n"
+                "with these parameters and restart the printer."
             )
 
             configfile = self.heater.printer.lookup_object("configfile")

--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -453,8 +453,6 @@ class MpcCalibrate:
                 f"  sensor_responsiveness={sensor_responsiveness:#.6g} [K/s/K]\n"
                 f"  ambient_transfer={ambient_transfer:#.6g} [W/K]\n"
                 f"  fan_ambient_transfer={fan_ambient_transfer} [W/K]\n"
-                "The SAVE_CONFIG command will update the printer config file\n"
-                "with these parameters and restart the printer."
             )
 
             configfile = self.heater.printer.lookup_object("configfile")

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -266,6 +266,7 @@ GLOBALSCALER_ERROR = (
     "A value of %d may be a reasonable starting point.\n"
 )
 
+
 class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
         super().__init__(config, mcu_tmc, MAX_CURRENT)
@@ -280,9 +281,12 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
 
     def _calc_globalscaler(self, current):
         cs = self.cs
-        globalscaler=int(math.floor(
-            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0) ) / (
-            (cs + 1) * VREF)))
+        globalscaler = int(
+            math.floor(
+                (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0))
+                / ((cs + 1) * VREF)
+            )
+        )
         if globalscaler == 256:
             return 0
         if 1 <= globalscaler <= 31 or globalscaler > 256:

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -254,13 +254,14 @@ FieldFormatters.update(
 ######################################################################
 
 VREF = 0.325
-MAX_CURRENT = 10.000  # Maximum dependent on board, but 10 is safe sanity check
+MAX_CURRENT = 10.600  # Maximum dependent on board, but 10 is safe sanity check
 
 
 class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
         super().__init__(config, mcu_tmc, MAX_CURRENT)
 
+        self.cs = config.getint('driver_cs', 31, maxval=31, minval=0)
         gscaler, irun, ihold = self._calc_current(
             self.req_run_current, self.req_hold_current
         )
@@ -269,30 +270,19 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
         self.fields.set_field("irun", irun)
 
     def _calc_globalscaler(self, current):
-        globalscaler = int(
-            (current * 256.0 * math.sqrt(2.0) * self.sense_resistor / VREF)
-            + 0.5
-        )
+        cs = self.cs
+        globalscaler=int(
+            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0) ) / (
+            (cs + 1) * VREF))
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0
         return globalscaler
 
-    def _calc_current_bits(self, current, globalscaler):
-        if not globalscaler:
-            globalscaler = 256
-        cs = int(
-            (current * 256.0 * 32.0 * math.sqrt(2.0) * self.sense_resistor)
-            / (globalscaler * VREF)
-            - 1.0
-            + 0.5
-        )
-        return max(0, min(31, cs))
-
     def _calc_current(self, run_current, hold_current):
         gscaler = self._calc_globalscaler(run_current)
-        irun = self._calc_current_bits(run_current, gscaler)
-        ihold = self._calc_current_bits(min(hold_current, run_current), gscaler)
+        irun = self.cs
+        ihold = int(min((hold_current / run_current) * irun, irun))
         return gscaler, irun, ihold
 
     def _calc_current_from_field(self, field_name):

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -256,6 +256,15 @@ FieldFormatters.update(
 VREF = 0.325
 MAX_CURRENT = 10.600  # Maximum dependent on board, but 10 is safe sanity check
 
+GLOBALSCALER_ERROR = (
+    "[tmc5160 %s]\n"
+    "GLOBALSCALER(%d) calculation out of bounds.\n"
+    "The target current can't be achieved with the given "
+    "CS(%d) value. Please adjust your configuration.\n"
+    "You most likely need to increase your driver_cs value in this case.\n"
+    "Please refer to the tmc5160.xlxs chopper tuning spreadsheet.\n"
+    "A value of %d may be a reasonable starting point.\n"
+)
 
 class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
@@ -271,19 +280,30 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
 
     def _calc_globalscaler(self, current):
         cs = self.cs
-        globalscaler = int(
-            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0))
-            / ((cs + 1) * VREF)
-        )
-        globalscaler = max(32, globalscaler)
-        if globalscaler >= 256:
-            globalscaler = 0
+        globalscaler=int(math.floor(
+            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0) ) / (
+            (cs + 1) * VREF)))
+        if globalscaler == 256:
+            return 0
+        if 1 <= globalscaler <= 31 or globalscaler > 256:
+            Ipeak = current * math.sqrt(2)
+            Rsens = self.sense_resistor
+            cs_calculated = int(math.floor(Rsens * 32 * Ipeak / 0.32) - 1)
+            self.printer.invoke_shutdown(
+                GLOBALSCALER_ERROR
+                % (
+                    self.name,
+                    globalscaler,
+                    self.cs,
+                    cs_calculated,
+                )
+            )
         return globalscaler
 
     def _calc_current(self, run_current, hold_current):
         gscaler = self._calc_globalscaler(run_current)
         irun = self.cs
-        ihold = int(min((hold_current / run_current) * irun, irun))
+        ihold = int(math.floor(min((hold_current / run_current) * irun, irun)))
         return gscaler, irun, ihold
 
     def _calc_current_from_field(self, field_name):

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -261,7 +261,7 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
         super().__init__(config, mcu_tmc, MAX_CURRENT)
 
-        self.cs = config.getint('driver_cs', 31, maxval=31, minval=0)
+        self.cs = config.getint("driver_cs", 31, maxval=31, minval=0)
         gscaler, irun, ihold = self._calc_current(
             self.req_run_current, self.req_hold_current
         )
@@ -271,9 +271,10 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
 
     def _calc_globalscaler(self, current):
         cs = self.cs
-        globalscaler=int(
-            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0) ) / (
-            (cs + 1) * VREF))
+        globalscaler = int(
+            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0))
+            / ((cs + 1) * VREF)
+        )
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -281,9 +281,9 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def _calc_globalscaler(self, current):
         cs = self.cs
         globalscaler = math.floor(
-                (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0))
-                / ((cs + 1) * VREF)
-            )
+            (current * 32 * 256 * self.sense_resistor * math.sqrt(2.0))
+            / ((cs + 1) * VREF)
+        )
         if globalscaler == 256:
             return 0
         if 1 <= globalscaler <= 31 or globalscaler > 256:

--- a/test/klippy/tmc.cfg
+++ b/test/klippy/tmc.cfg
@@ -49,6 +49,7 @@ home_current: .5
 current_change_dwell_time: 1
 sense_resistor: 0.220
 diag1_pin: !PK7
+driver_CS: 29
 
 [stepper_y1]
 step_pin: PA4


### PR DESCRIPTION
The `driver_CS` parameter has been added to tmc5160. The ideal driver_cs value may be found by setting the CS value on the tmc5160_calculations.xlsx spreadsheet, under the chopper tab, so that the Rsense value in the spreadsheet matches `sense_resistor` as defined in printer.cfg. While it's not necessary to change the CS value, it can be helpful to reach adequate hystersis values on high current drivers paired with low current motors. The default for this value is 31, meaning only globalscaler will be used to scale the current during normal operation. Errors will be invoked if the CS value is set too low, as the target current will not be able to be reached.

Update tmc5160.py

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
