### PR TITLE
Support building and running on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ CFLAGS := -iquote $(OUT) -iquote src -iquote $(OUT)board-generic/ \
 		-Wold-style-definition $(call cc-option,$(CC),-Wtype-limits,) \
     -ffunction-sections -fdata-sections -fno-delete-null-pointer-checks
 CFLAGS += -flto=auto -fwhole-program -fno-use-linker-plugin -ggdb3
+CFLAGS += $(EXTRA_CFLAGS)
 
 ifeq ($(CONFIG_WANT_OPTIMIZE_SIZE), y)
 CFLAGS += -Os

--- a/klippy/chelper/compiler.h
+++ b/klippy/chelper/compiler.h
@@ -11,7 +11,11 @@
 #ifndef __always_inline
 #define __always_inline inline __attribute__((always_inline))
 #endif
+#if !defined(clang)
 #define __visible __attribute__((externally_visible))
+#else
+#define __visible __attribute__((visibility("default")))
+#endif
 #define __noreturn __attribute__((noreturn))
 
 #define PACKED __attribute__((packed))

--- a/scripts/check-gcc.sh
+++ b/scripts/check-gcc.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # This script checks for a broken Ubuntu 18.04 arm-none-eabi-gcc compile
 
+if [ ! -f /etc/issue ] ; then
+    # doesn't exist on mac
+    exit 0
+fi
+
 f1="$1"
 f2="$2"
 


### PR DESCRIPTION
This makes a few tweaks to allow chelper to compile on macOS and klippy to run. Things work fine on macOS, except for CAN. I didn't update the flashing scripts here because my implementation is super hacky, but this at least will let somone run `uv run python klippy.py ....`. I also have some docker compose files that allow running moonraker/mainsail/fluidd in containers, though with using `socat` to communicate between klippy and moonraker (because macos docker can't share pipes from the host OS). 


## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
