### PR TITLE
Treat rapid_scan probe method as automatic

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -579,6 +579,12 @@ class ProbePointsHelper:
         # Lookup objects
         probe = self.printer.lookup_object("probe", None)
         method = gcmd.get("METHOD", "automatic").lower()
+        if method == "rapid_scan":
+            gcmd.respond_info(
+                "METHOD=rapid_scan not supported, using automatic"
+            )
+            method = "automatic"
+
         self.results = []
 
         def_move_z = self.default_horizontal_move_z


### PR DESCRIPTION
Many people coming from Klipper will have `METHOD=rapid_scan` in their start print macros for bed mesh and such. This ends up being treated as `manual` by Kalico, leading to a confusing manual Z probe during print start. This just treats `rapid_scan` as `automatic` for convenience/compatibility until rapid scan gets implemented.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
