### PR TITLE
Allow overriding USB_MANUFACTURER from Kconfig

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -76,6 +76,8 @@ config USB_SERIAL_NUMBER_CHIPID
     default y
 config USB_SERIAL_NUMBER
     default "12345"
+config USB_MANUFACTURER
+    default "Klipper"
 
 menu "USB ids"
     depends on USB && LOW_LEVEL_OPTIONS
@@ -87,6 +89,8 @@ config USB_SERIAL_NUMBER_CHIPID
     bool "USB serial number from CHIPID" if HAVE_CHIPID
 config USB_SERIAL_NUMBER
     string "USB serial number" if !USB_SERIAL_NUMBER_CHIPID
+config USB_MANUFACTURER
+    string "USB manufacturer"
 endmenu
 
 menu "CAN bus UUID"

--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -369,7 +369,11 @@ usb_notify_bulk_in(void)
 
 #define CONCAT1(a, b) a ## b
 #define CONCAT(a, b) CONCAT1(a, b)
+#if defined(CONFIG_USB_MANUFACTURER)
+#define USB_STR_MANUFACTURER u""CONFIG_USB_MANUFACTURER
+#else
 #define USB_STR_MANUFACTURER u"Klipper"
+#endif
 #define USB_STR_PRODUCT CONCAT(u,CONFIG_MCU)
 #define USB_STR_SERIAL CONCAT(u,CONFIG_USB_SERIAL_NUMBER)
 

--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -133,7 +133,11 @@ DECL_TASK(usb_bulk_out_task);
 
 #define CONCAT1(a, b) a ## b
 #define CONCAT(a, b) CONCAT1(a, b)
+#if defined(CONFIG_USB_MANUFACTURER)
+#define USB_STR_MANUFACTURER u""CONFIG_USB_MANUFACTURER
+#else
 #define USB_STR_MANUFACTURER u"Klipper"
+#endif
 #define USB_STR_PRODUCT CONCAT(u,CONFIG_MCU)
 #define USB_STR_SERIAL CONCAT(u,CONFIG_USB_SERIAL_NUMBER)
 


### PR DESCRIPTION
This is a small quality of life thing -- I got annoyed at having 3+ different serial (or canbus) devices all named "Klipper". This lets you override the manufacturer via menuconfig so you can get `/dev/serial/by-ud/usb-Eddy_rp2040_...` and similar.

(also the `u""CONFIG_USB..` is intentional; only way to get a utf16 string from a string literal #define!)

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
