### PR TITLE
Add starting pytest shims for testing klippy objects

### DIFF
--- a/test/klippy_testing/__init__.py
+++ b/test/klippy_testing/__init__.py
@@ -1,0 +1,10 @@
+from .shims import PrinterShim, Restart
+from .utils import configwrapper_to_dict
+
+
+__all__ = (
+    "ConfigRoot",
+    "configwrapper_to_dict",
+    "PrinterShim",
+    "Restart",
+)

--- a/test/klippy_testing/shims.py
+++ b/test/klippy_testing/shims.py
@@ -1,0 +1,84 @@
+import typing
+import klippy.configfile
+import klippy.gcode
+import klippy.extras.danger_options
+
+
+class Restart(Exception): ...
+
+
+class PrinterShim:
+    class GCode:
+        error = Exception
+
+        def __init__(self):
+            self.ready_gcode_handlers = {}
+
+        def register_command(self, cmd, func, *_, **__):
+            self.ready_gcode_handlers[cmd.upper()] = func
+
+        def respond_info(self, msg):
+            print("info", msg)
+
+        def respond_raw(self, msg):
+            print("raw", msg)
+
+        def request_restart(self, reason):
+            raise Restart(reason)
+
+        def call(self, cmdline):
+            command, *paramlist = cmdline.split()
+            func = self.ready_gcode_handlers[command.upper()]
+            params = dict(param.split("=", 1) for param in paramlist)
+            gcmd = klippy.gcode.GCodeCommand(
+                self, command, cmdline, params, False
+            )
+            print("Calling", func, "with", params)
+            func(gcmd)
+
+    def __init__(self, start_args):
+        self.start_args = start_args
+        self.objects = {}
+        self.add_object("gcode", self.GCode())
+        self.add_object("configfile", klippy.configfile.PrinterConfig(self))
+
+        self.call = self.lookup_object("gcode").call
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def get_start_args(self):
+        return self.start_args
+
+    def add_object(self, name, obj):
+        self.objects[name] = obj
+
+    @typing.overload
+    def lookup_object(self, name: typing.Literal["gcode"]) -> GCode: ...
+    @typing.overload
+    def lookup_object(
+        self, name: typing.Literal["configfile"]
+    ) -> klippy.configfile.PrinterConfig: ...
+
+    def lookup_object(self, name):
+        return self.objects[name]
+
+    def lookup_objects(self, pfx=""):
+        if pfx:
+            pfx = pfx + " "
+        return [(k, v) for k, v in self.objects.items() if k.startswith(pfx)]
+
+    def load_config(self):
+        config = self.lookup_object("configfile").read_main_config()
+        self.add_object(
+            "danger_options",
+            klippy.extras.danger_options.load_config(
+                config.getsection("danger_options")
+            ),
+        )
+        return config
+
+    def set_rollover_info(self, *_): ...

--- a/test/klippy_testing/utils.py
+++ b/test/klippy_testing/utils.py
@@ -1,0 +1,10 @@
+import klippy.configfile
+
+
+def configwrapper_to_dict(
+    wrapper: klippy.configfile.ConfigWrapper,
+) -> dict[str, dict[str, str]]:
+    return {
+        section: wrapper.fileconfig.items(section)
+        for section in wrapper.fileconfig.sections()
+    }

--- a/test/test_autosave.py
+++ b/test/test_autosave.py
@@ -1,0 +1,43 @@
+import typing, pathlib
+import pytest
+from klippy_testing import PrinterShim, Restart
+
+
+def test_autosave_includes(
+    config_root: typing.Annotated[pathlib.Path, "test_configs/autosave"],
+):
+    start_args = {"config_file": str(config_root / "printer.cfg")}
+    with PrinterShim(start_args) as printer:
+        pconfig = printer.lookup_object("configfile")
+        config = printer.load_config()
+        assert (
+            config.getsection("danger_options").getboolean("temp_ignore_limits")
+            is True
+        )
+
+        pconfig.set("danger_options", "temp_ignore_limits", "False")
+        assert pconfig.status_save_pending == {
+            "danger_options": {"temp_ignore_limits": "False"}
+        }
+        with pytest.raises(Restart):
+            printer.call("SAVE_CONFIG")
+
+    with PrinterShim(start_args) as printer:
+        config = printer.load_config()
+
+        # Test that the changed config value is properly saved
+        assert (
+            config.getsection("danger_options").getboolean("temp_ignore_limits")
+            is False
+        )
+
+        # Test that the autosave line is now in printer.cfg
+        assert (
+            "#*# temp_ignore_limits = False"
+            in (config_root / "printer.cfg").read_text()
+        )
+        # Test that the source line in danger_options.cfg is commented out
+        assert (
+            "#temp_ignore_limits: True"
+            in (config_root / "danger_options.cfg").read_text()
+        )

--- a/test/test_configs/autosave/danger_options.cfg
+++ b/test/test_configs/autosave/danger_options.cfg
@@ -1,0 +1,11 @@
+[danger_options]
+log_statistics: False
+log_config_file_at_startup: False
+error_on_unused_config_options: ${constants.false}
+log_bed_mesh_at_startup: False
+log_shutdown_info: False
+allow_plugin_override: True
+multi_mcu_trsync_timeout: 0.05
+temp_ignore_limits: True
+autosave_includes: True
+bgflush_extra_time: 0.250

--- a/test/test_configs/autosave/printer.cfg
+++ b/test/test_configs/autosave/printer.cfg
@@ -1,0 +1,76 @@
+[constants]
+false: False
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[probe]
+pin: PH6
+z_offset: 1.15
+drop_first_result: true
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[include danger_options.cfg]


### PR DESCRIPTION
Also, add a test fixture to create a cloned directory for a config root. This is used in test_autosave to create a clone of a printer config
 so the autosave testing doesn't change the source path

@jwueller, this should work for your branch too. In fact, if you rebase over this you'll actually have to fix the newly broken test 😁 

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
