### PR TITLE
pll_base fix in stm32g4.c

### DIFF
--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -83,7 +83,15 @@ DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PF0,PF1");
 static void
 enable_clock_stm32g4(void)
 {
-    uint32_t pll_base = 4000000, pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
+// klipper supports 8, 12, 16, 20, 24, and 25 MHz crystals on HSE
+#if CONFIG_CLOCK_REF_FREQ % 5000000 == 0
+    uint32_t pll_base = 5000000;
+#elif CONFIG_CLOCK_REF_FREQ % 4000000 == 0
+    uint32_t pll_base = 4000000;
+#else
+#error Unknown pll_base for CLOCK_REF_FREQ
+#endif
+    uint32_t pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
         // Configure 150Mhz PLL from external crystal (HSE)
         uint32_t div = CONFIG_CLOCK_REF_FREQ / pll_base - 1;


### PR DESCRIPTION
Quick fix to apply fix from https://github.com/KalicoCrew/kalico/pull/148 to stm32g4.c to prevent this from happening on a 25 MHz crystal

![image](https://github.com/user-attachments/assets/8ff3a776-8524-402d-aa38-4fccd4e3b3bd)

If I were smarter we would probably want to have a function that sets pll_base defined somewhere else and reference it everywhere else
## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
