### PR TITLE
Add default 0.11 sense_resistor values for SKR Mini E3 V3.0 example config

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
@@ -25,6 +25,7 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 run_current: 0.580
+sense_resistor: 0.11
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -43,6 +44,7 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
 run_current: 0.580
+sense_resistor: 0.11
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -60,6 +62,7 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
 run_current: 0.580
+sense_resistor: 0.11
 stealthchop_threshold: 999999
 
 [extruder]


### PR DESCRIPTION
Related to https://github.com/KalicoCrew/kalico/issues/582.

From [the Voron bigtreetech-skr-mini-e3-v3.0.cfg file](https://github.com/VoronDesign/Voron-0/blob/a53fc87562fd630c846af38d7de850c894dc3d85/Firmware/bigtreetech-skr-mini-e3-v3.0.cfg#L65-L75):

```ini
[tmc2209 stepper_x]
uart_pin: PC11
tx_pin: PC10
uart_address: 0
interpolate: False
# run_current: 0.0            
# you need to calculate the run_current value using the equation (rated_motor_current * 0.707 = Maximum_run_current) start with a value that is about 60%-70% of your maximum value.
sense_resistor: 0.110
stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
diag_pin: ^PC0  													# YOU NEED TO JUMP THIS DIAG PIN ON YOUR BOARD FOR SENSORLESS HOMING TO WORK 
driver_SGTHRS: 255                                                  # this is set to 255 which is the MAX sensitivity for sensorless homing, you will need to tune this later
```

This PR copies the `sense_resistor: 0.11` value from the Voron repo's BIGTREETECH SKR Mini E3 V3.0 config and includes it in the example config for the same board in this repo :+1: 

The BIGTREETECH SKR Mini E3 V3.0 board uses soldered resistor values that are behind this board's heatsink.  They are not user replaceable or adjustable parts, so it should be safe to add this default value :+1: 

Here's a photo of this board:

![image](https://github.com/user-attachments/assets/5ba524c3-4539-4a0f-abc3-324fe4291016)


## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
