### PR TITLE
Remove "squashed to 1 commit" PR template checklist item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@ _Enter a good description of whats being changed and WHY
 ## Checklist
 
 - [ ] pr title makes sense
-- [ ] squashed to 1 commit
 - [ ] added a test case if possible
 - [ ] if new feature, added to the readme
 - [ ] ci is happy and green


### PR DESCRIPTION
Fixes https://github.com/KalicoCrew/kalico/issues/584!

This PR removes the "squashed to 1 commit" PR template checklist item.  The squash merge strategy is configured for this repository, so this checklist item is obsolete :+1: 

From https://github.com/KalicoCrew/kalico/issues/584:

> This is in the PR template:
> 
> https://github.com/KalicoCrew/kalico/blob/aa4cc80507a985b33de8b037cb8e400e7e168201/.github/pull_request_template.md?plain=1#L3-L9
> 
> I was curious about the `- [ ] squashed to 1 commit` checklist item, and asked about this in the Kalico Discord server.  This is what was said:
> 
> > It is just a suggestion, and from a time where squash commits weren’t enabled
> > but mostly because I like the commit history looking nice and clean without 10x ‘fix fix fix’ 
> 
> This checklist item isn't useful anymore since the squash merge strategy is enabled on this repo, so we can remove this checklist item 👍 

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
