### PR TITLE
Update Danger Features link to Kalico Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Our goal is to support features and behavior that could be "risky" if used incor
 
 If I want my printer to light itself on fire, I should be able to make my printer light itself on fire.
 
-See the [Danger Features document](https://docs.kalico.gg/Danger_Features.html) for more information on *some* of the differences from Klipper.
+See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html) for more information on *some* of the differences from Klipper.
 
 ## Features merged into the main branch:
 


### PR DESCRIPTION
Fix Danger Additions link, change to proper link. If you click on the link it redirects to the Kalico Additions link, so might as well.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
