### PR TITLE
stm32: Add support for stm32f070x6 mcus

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -15,7 +15,7 @@ config STM32_SELECT
     select HAVE_CHIPID
     select HAVE_STEPPER_BOTH_EDGE
     select HAVE_BOOTLOADER_REQUEST
-    select HAVE_LIMITED_CODE_SIZE if MACH_STM32F031 || MACH_STM32F042
+    select HAVE_LIMITED_CODE_SIZE if FLASH_SIZE < 0x10000
 
 config BOARD_DIRECTORY
     string
@@ -120,6 +120,10 @@ config MACH_STM32F103x6
     depends on LOW_LEVEL_OPTIONS && MACH_STM32F103
     bool "Only 10KiB of RAM (for rare stm32f103x6 variant)"
 
+config MACH_STM32F070x6
+    depends on LOW_LEVEL_OPTIONS && MACH_STM32F070
+    bool "Only 6KiB of RAM (for rare stm32f070x6 variant)"
+
 config MACH_STM32F0
     bool
 config MACH_STM32F1
@@ -216,8 +220,8 @@ config CLOCK_FREQ
 
 config FLASH_SIZE
     hex
-    default 0x8000 if MACH_STM32F031 || MACH_STM32F042
-    default 0x20000 if MACH_STM32F070 || MACH_STM32F072
+    default 0x8000 if MACH_STM32F031 || MACH_STM32F042 || MACH_STM32F070x6
+    default 0x20000 if (MACH_STM32F070 || MACH_STM32F072) && !MACH_STM32F070x6
     default 0x10000 if MACH_STM32F103 || MACH_STM32L412 # Flash size of stm32f103x8 (64KiB)
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401 || MACH_STM32H723 || MACH_AT32F403
     default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
@@ -239,7 +243,8 @@ config RAM_SIZE
     hex
     default 0x1000 if MACH_STM32F031
     default 0x1800 if MACH_STM32F042
-    default 0x4000 if MACH_STM32F070 || MACH_STM32F072
+    default 0x1800 if MACH_STM32F070x6
+    default 0x4000 if (MACH_STM32F070 || MACH_STM32F072) && !MACH_STM32F070x6
     default 0x2800 if MACH_STM32F103x6
     default 0x5000 if MACH_STM32F103 && !MACH_STM32F103x6 # Ram size of stm32f103x8
     default 0x8000 if MACH_STM32G431
@@ -391,7 +396,8 @@ choice
         bool "USB (on PA11/PA12)" if HAVE_STM32_USBFS || HAVE_STM32_USBOTG
         select USBSERIAL
     config STM32_USB_PA11_PA12_REMAP
-        bool "USB (on PA9/PA10)" if LOW_LEVEL_OPTIONS && MACH_STM32F042
+        bool "USB (on PA9/PA10)"
+        depends on MACH_STM32F042 || MACH_STM32F070x6
         select USBSERIAL
     config STM32_USB_PB14_PB15
         bool "USB (on PB14/PB15)"
@@ -441,7 +447,7 @@ choice
         select CANSERIAL
     config STM32_CANBUS_PA11_PA12_REMAP
         bool "CAN bus (on PA9/PA10)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS && MACH_STM32F042
+        depends on HAVE_STM32_CANBUS && (MACH_STM32F042 || MACH_STM32F070x6)
         select CANSERIAL
     config STM32_CANBUS_PA11_PB9
         bool "CAN bus (on PA11/PB9)"

--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -186,10 +186,8 @@ armcm_main(void)
     hsi14_setup();
 
     // Support pin remapping USB/CAN pins on low pinout stm32f042
-#ifdef SYSCFG_CFGR1_PA11_PA12_RMP
     if (CONFIG_STM32_USB_PA11_PA12_REMAP || CONFIG_STM32_CANBUS_PA11_PA12_REMAP)
-        SYSCFG->CFGR1 |= SYSCFG_CFGR1_PA11_PA12_RMP;
-#endif
+        SYSCFG->CFGR1 |= 1<<4; // SYSCFG_CFGR1_PA11_PA12_RMP
 
     sched_main();
 }


### PR DESCRIPTION
This mcu has smaller memory and may require remapping of PA11/PA12.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6799