### PR TITLE
RFC RP2040: set clock to 200Mhz

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -408,14 +408,14 @@ config_stepper oid=2 step_pin=gpio27 dir_pin=gpio5 invert_step=-1 step_pulse_tic
 finalize_config crc=0
 ```
 
-The test was last run on commit `f6718291` with gcc version
+The test was last run on commit `14c105b8` with gcc version
 `arm-none-eabi-gcc (Fedora 14.1.0-1.fc40) 14.1.0` on Raspberry Pi
 Pico and Pico 2 boards.
 
 | rp2040 (*)           | ticks |
 | -------------------- | ----- |
-| 1 stepper            | 5     |
-| 3 stepper            | 22    |
+| 1 stepper            | 3     |
+| 3 stepper            | 14    |
 
 | rp2350               | ticks |
 | -------------------- | ----- |
@@ -423,9 +423,9 @@ Pico and Pico 2 boards.
 | 3 stepper            | 169   |
 
 (*) Note that the reported rp2040 ticks are relative to a 12Mhz
-scheduling timer and do not correspond to its 125Mhz internal ARM
+scheduling timer and do not correspond to its 200Mhz internal ARM
 processing rate. It is expected that 5 scheduling ticks corresponds to
-~47 ARM core cycles and 22 scheduling ticks corresponds to ~224 ARM
+~42 ARM core cycles and 14 scheduling ticks corresponds to ~225 ARM
 core cycles.
 
 ### Linux MCU step rate benchmark

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -184,12 +184,12 @@ represent total number of steps per second on the micro-controller.
 | SAM4S8C                         | 1690K             | 1385K             |
 | LPC1768                         | 1923K             | 1351K             |
 | LPC1769                         | 2353K             | 1622K             |
-| RP2040                          | 2400K             | 1636K             |
 | SAM4E8E                         | 2500K             | 1674K             |
 | SAMD51                          | 3077K             | 1885K             |
 | AR100                           | 3529K             | 2507K             |
 | STM32F407                       | 3652K             | 2459K             |
 | STM32F446                       | 3913K             | 2634K             |
+| RP2040                          | 4000K             | 2571K             |
 | RP2350                          | 4167K             | 2663K             |
 | SAME70                          | 6667K             | 4737K             |
 | STM32H743                       | 9091K             | 6061K             |

--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -12,11 +12,12 @@
 #include "hardware/structs/resets.h" // sio_hw
 #include "hardware/structs/watchdog.h" // watchdog_hw
 #include "hardware/structs/xosc.h" // xosc_hw
-#include "hardware/structs/vreg_and_chip_reset.h" // vreg_and_chip_reset_hw
 #include "internal.h" // enable_pclock
 #include "sched.h" // sched_main
 
-#if !CONFIG_MACH_RP2040
+#if CONFIG_MACH_RP2040
+#include "hardware/structs/vreg_and_chip_reset.h" // vreg_and_chip_reset_hw
+#else
 #include "hardware/structs/ticks.h" // ticks_hw
 #endif
 
@@ -63,18 +64,17 @@ bootloader_request(void)
 #define FBDIV (FREQ_SYS == 200000000 ? 100 : 125)
 #define FREQ_USB 48000000
 
-#if CONFIG_MACH_RP2040
 void set_vsel(void)
 {
+    // Set internal voltage regulator output to 1.15V on rp2040
+#if CONFIG_MACH_RP2040
     uint32_t cval = vreg_and_chip_reset_hw->vreg;
     uint32_t vref = VREG_AND_CHIP_RESET_VREG_VSEL_RESET + 1;
     cval &= ~VREG_AND_CHIP_RESET_VREG_VSEL_BITS;
     cval |= vref << VREG_AND_CHIP_RESET_VREG_VSEL_LSB;
     vreg_and_chip_reset_hw->vreg = cval;
-}
-#else
-void set_vsel(void) {}
 #endif
+}
 
 void
 enable_pclock(uint32_t reset_bit)

--- a/test/configs/rp2040.config
+++ b/test/configs/rp2040.config
@@ -1,2 +1,3 @@
 # Base config file for rp2040 boards
 CONFIG_MACH_RPXXXX=y
+CONFIG_MACH_RP2040=y

--- a/test/configs/rp2350.config
+++ b/test/configs/rp2350.config
@@ -1,0 +1,3 @@
+# Base config file for rp2350 boards
+CONFIG_MACH_RPXXXX=y
+CONFIG_MACH_RP2350=y


### PR DESCRIPTION
RP2040 is now certified to run at 200Mhz clock instead of 133Mhz (125Mhz from SDK was used).
https://github.com/raspberrypi/pico-sdk/releases/tag/2.1.1

So, if no one minds, this is an overclock to the new allowed ones.

New perf values:
`arm-none-eabi-gcc (Arch Repository) 14.2.0`
```
rp2040	  ticks
1 stepper 3  ~ 4000K
3 stepper 14 ~ 2571K
```
Which allows us to place it aside with STM32F446 on the benchmark page.

This patch has been only tested on the development board.


Klipper PR: https://github.com/Klipper3d/klipper/pull/6829
