### PR TITLE
usb_cdc: Avoid ending a transmission with a max size usb packet

### DIFF
--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -44,11 +44,13 @@ usb_bulk_in_task(void)
 {
     if (!sched_check_wake(&usb_bulk_in_wake))
         return;
-    uint_fast8_t tpos = transmit_pos;
+    uint_fast8_t tpos = transmit_pos, max_tpos = tpos;
     if (!tpos)
         return;
-    uint_fast8_t max_tpos = (tpos > USB_CDC_EP_BULK_IN_SIZE
-                             ? USB_CDC_EP_BULK_IN_SIZE : tpos);
+    if (max_tpos > USB_CDC_EP_BULK_IN_SIZE)
+        max_tpos = USB_CDC_EP_BULK_IN_SIZE;
+    else if (max_tpos == USB_CDC_EP_BULK_IN_SIZE)
+        max_tpos = USB_CDC_EP_BULK_IN_SIZE-1; // Avoid zero-length-packets
     int_fast8_t ret = usb_send_bulk_in(transmit_buf, max_tpos);
     if (ret <= 0)
         return;

--- a/src/generic/usb_cdc.h
+++ b/src/generic/usb_cdc.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h> // uint_fast8_t
 
-// endpoint sizes
-enum {
-    USB_CDC_EP0_SIZE = 16,
-    USB_CDC_EP_ACM_SIZE = 8,
-    USB_CDC_EP_BULK_OUT_SIZE = 64,
-    USB_CDC_EP_BULK_IN_SIZE = 64,
-};
-
 // callbacks provided by board specific code
 int_fast8_t usb_read_bulk_out(void *data, uint_fast8_t max_len);
 int_fast8_t usb_send_bulk_in(void *data, uint_fast8_t len);

--- a/src/generic/usb_cdc_ep.h
+++ b/src/generic/usb_cdc_ep.h
@@ -8,4 +8,12 @@ enum {
     USB_CDC_EP_ACM = 3,
 };
 
+// Default endpoint sizes
+enum {
+    USB_CDC_EP0_SIZE = 16,
+    USB_CDC_EP_ACM_SIZE = 8,
+    USB_CDC_EP_BULK_OUT_SIZE = 64,
+    USB_CDC_EP_BULK_IN_SIZE = 64,
+};
+
 #endif // usb_cdc_ep.h

--- a/src/lpc176x/usb_cdc_ep.h
+++ b/src/lpc176x/usb_cdc_ep.h
@@ -7,4 +7,11 @@ enum {
     USB_CDC_EP_BULK_IN = 5,
 };
 
+enum {
+    USB_CDC_EP0_SIZE = 16,
+    USB_CDC_EP_ACM_SIZE = 8,
+    USB_CDC_EP_BULK_OUT_SIZE = 64,
+    USB_CDC_EP_BULK_IN_SIZE = 64,
+};
+
 #endif // usb_cdc_ep.h


### PR DESCRIPTION
It seems the Linux kernel will consider a maximum size usb packet to be a transaction that will continue into the next usb packet.  It will thus hold on to the traffic from the first packet until it gets the next packet.  However, if the mcu has no further data to send after the first packet then the data could get delayed for an extended period of time.

To avoid this, check for transmissions that could end on a maximum sized packet and send that data in two packets instead.  This avoids this unusual corner case.

It's very rare for this exact sequence to occur (ending a series of messages on a 64 byte usb packet), which is why this has probably not been noticed before.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6811