### PR TITLE
spi_flash: Update board_defs.py - BTT Octopus Max EZ (#6817)

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -98,6 +98,22 @@ BOARD_DEFS = {
         "cs_pin": "PC11",
         "skip_verify": True,
     },
+    "monster8": {"mcu": "stm32f407xx", "spi_bus": "spi3a", "cs_pin": "PC9"},
+    "fly-gemini-v2": {"mcu": "stm32f405xx", "spi_bus": "spi1", "cs_pin": "PA4"},
+    "fysetc-cheetah": {
+        "mcu": "stm32f401xc",
+        "spi_bus": "spi1",
+        "cs_pin": "PA4",
+        "current_firmware_path": "OLD.BIN",
+    },
+    "btt-octopus-max-ez": {
+        "mcu": "stm32h723xx",
+        "spi_bus": "swspi",
+        "spi_pins": "PE13,PE14,PE12",
+        "cs_pin": "PB12",
+        "skip_verify": True,
+    },
+    "btt-skrat": {"mcu": "stm32g0b1xx", "spi_bus": "spi1", "cs_pin": "PB8"},
     "chitu-v6": {
         "mcu": "stm32f103xe",
         "spi_bus": "swspi",
@@ -108,15 +124,6 @@ BOARD_DEFS = {
         "firmware_path": "update.cbd",
         "skip_verify": True,
     },
-    "monster8": {"mcu": "stm32f407xx", "spi_bus": "spi3a", "cs_pin": "PC9"},
-    "fly-gemini-v2": {"mcu": "stm32f405xx", "spi_bus": "spi1", "cs_pin": "PA4"},
-    "fysetc-cheetah": {
-        "mcu": "stm32f401xc",
-        "spi_bus": "spi1",
-        "cs_pin": "PA4",
-        "current_firmware_path": "OLD.BIN",
-    },
-    "btt-skrat": {"mcu": "stm32g0b1xx", "spi_bus": "spi1", "cs_pin": "PB8"},
 }
 
 ###########################################################


### PR DESCRIPTION
Addition to the board_defs file for the BTT Octopus Max EZ, written and confirmed by discord user Nikki @winningfaith81

Klipper PR: https://github.com/Klipper3d/klipper/pull/6817