### PR TITLE
skew_correction: Supports retrieving the name of the currently loaded skew correction

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -500,6 +500,12 @@ The following information is available in
 - `printer["servo <config_name>"].value`: The last setting of the PWM
   pin (a value between 0.0 and 1.0) associated with the servo.
 
+## skew_correction.py
+
+The following information is available in the `skew_correction` object (this
+object is available if any skew_correction is defined):
+- `current_profile_name`: Returns the name of the currently loaded SKEW_PROFILE.
+
 ## stepper_enable
 
 The following information is available in the `stepper_enable` object (this

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -24,6 +24,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
+        self.current_profile_name = ""
         self.toolhead = None
         self.xy_factor = 0.0
         self.xz_factor = 0.0
@@ -152,6 +153,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get("LOAD", None) is not None:
             name = gcmd.get("LOAD")
+            self.current_profile_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(
@@ -194,6 +196,9 @@ class PrinterSkew:
                 gcmd.respond_info(
                     "skew_correction: No profile named [%s] to remove" % (name)
                 )
+
+    def get_status(self, eventtime):
+        return {"current_profile_name": self.current_profile_name}
 
 
 def load_config(config):


### PR DESCRIPTION
Added a command to retrieve the name of the current tilt correction configuration.

In some cases (such as enabling filament cutter or nozzle wipe), activating tilt correction may cause the tool head to exceed its range of motion. By retrieving the current tilt correction name, it is possible to get the tilt configuration name before execution, unload tilt correction, execute the command (cut filament or wipe nozzle), and then reload tilt correction using the obtained name.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6821