### PR TITLE
kconfig: adds more flexibility small mcus

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -110,9 +110,13 @@ config WANT_DISPLAYS
     bool
     depends on HAVE_GPIO
     default y
-config WANT_SENSORS
+config WANT_THERMOCOUPLE
     bool
-    depends on WANT_GPIO_I2C || WANT_GPIO_SPI
+    depends on HAVE_GPIO_SPI
+    default y
+config WANT_ADXL345
+    bool
+    depends on HAVE_GPIO_SPI
     default y
 config WANT_LIS2DW
     bool
@@ -121,6 +125,14 @@ config WANT_LIS2DW
 config WANT_LDC1612
     bool
     depends on WANT_GPIO_I2C
+    default y
+config WANT_MPU9250
+    bool
+    depends on HAVE_GPIO_I2C
+    default y
+config WANT_SENSOR_ANGLE
+    bool
+    depends on HAVE_GPIO_SPI
     default y
 config WANT_HX71X
     bool
@@ -152,8 +164,9 @@ config WANT_GPIO_I2C
     default y
 config NEED_SENSOR_BULK
     bool
-    depends on WANT_SENSORS || WANT_LIS2DW || WANT_LDC1612 || WANT_HX71X \
-        || WANT_ADS1220
+    depends on WANT_ADXL345 || WANT_LIS2DW || WANT_ADXL345 \
+        || WANT_LDC1612 || WANT_HX71X || WANT_ADS1220 \
+        || WANT_SENSOR_ANGLE
     default y
 config WANT_OPTIMIZE_SIZE
     bool
@@ -175,12 +188,15 @@ config WANT_GPIO_BITBANGING
 config WANT_DISPLAYS
     bool "Support LCD devices"
     depends on HAVE_GPIO
-config WANT_SENSORS
-    bool "Support external sensor devices"
-    depends on WANT_GPIO_I2C || WANT_GPIO_SPI
+config WANT_ADXL345
+    bool "Support adxl accelerometers"
+    depends on WANT_GPIO_SPI
 config WANT_LIS2DW
     bool "Support lis2dw and lis3dh 3-axis accelerometers"
     depends on WANT_GPIO_SPI || WANT_GPIO_I2C
+config WANT_MPU9250
+    bool "Support MPU accelerometers"
+    depends on WANT_GPIO_I2C
 config WANT_LDC1612
     bool "Support ldc1612 eddy current sensor"
     depends on WANT_GPIO_I2C
@@ -190,6 +206,9 @@ config WANT_HX71X
 config WANT_ADS1220
     bool "Support ADS 1220 ADC chip"
     depends on WANT_GPIO_SPI
+config WANT_SENSOR_ANGLE
+    bool "Support angle sensors"
+    depends on HAVE_GPIO_SPI
 config WANT_SOFTWARE_I2C
     bool "Support software based I2C \"bit-banging\""
     depends on HAVE_GPIO && HAVE_GPIO_I2C

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,12 +14,12 @@ src-$(CONFIG_WANT_GPIO_BITBANGING) += buttons.c tmcuart.c neopixel.c \
 src-$(CONFIG_WANT_DISPLAYS) += lcd_st7920.c lcd_hd44780.c
 src-$(CONFIG_WANT_SOFTWARE_SPI) += spi_software.c
 src-$(CONFIG_WANT_SOFTWARE_I2C) += i2c_software.c
-sensors-src-$(CONFIG_WANT_GPIO_SPI) := thermocouple.c sensor_adxl345.c \
-    sensor_angle.c
-sensors-src-$(CONFIG_WANT_GPIO_I2C) += sensor_mpu9250.c
-src-$(CONFIG_WANT_SENSORS) += $(sensors-src-y)
+src-$(CONFIG_WANT_THERMOCOUPLE) += thermocouple.c
+src-$(CONFIG_WANT_ADXL345) += sensor_adxl345.c
 src-$(CONFIG_WANT_LIS2DW) += sensor_lis2dw.c
 src-$(CONFIG_WANT_LDC1612) += sensor_ldc1612.c
+src-$(CONFIG_WANT_MPU9250) += sensor_mpu9250.c
 src-$(CONFIG_WANT_HX71X) += sensor_hx71x.c
 src-$(CONFIG_WANT_ADS1220) += sensor_ads1220.c
+src-$(CONFIG_WANT_SENSOR_ANGLE) += sensor_angle.c
 src-$(CONFIG_NEED_SENSOR_BULK) += sensor_bulk.c


### PR DESCRIPTION
replaces WANT_SENSORS with WANT_ADXL, WANT_THERMOCOUPLE, WANT_SENSOR_ANGLE and WANT_MPU9250