### PR TITLE
force_move: Implement CLEAR for SET_KINEMATIC_POSITION

### DIFF
--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -359,10 +359,10 @@ Useful steps:
    be efficient as it is typically only called during homing and
    probing operations.
 5. Other methods. Implement the `check_move()`, `get_status()`,
-   `get_steppers()`, `home()`, and `set_position()` methods. These
-   functions are typically used to provide kinematic specific checks.
-   However, at the start of development one can use boiler-plate code
-   here.
+   `get_steppers()`, `home()`, `clear_homing_state()`, and `set_position()`
+   methods. These functions are typically used to provide kinematic
+   specific checks. However, at the start of development one can use
+   boiler-plate code here.
 6. Implement test cases. Create a g-code file with a series of moves
    that can test important cases for the given kinematics. Follow the
    [debugging documentation](Debugging.md) to convert this g-code file

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -738,15 +738,18 @@ state; issue a G28 afterwards to reset the kinematics. This command is
 intended for low-level diagnostics and debugging.
 
 #### SET_KINEMATIC_POSITION
-`SET_KINEMATIC_POSITION [X=<value>] [Y=<value>] [Z=<value>]`: Force
-the low-level kinematic code to believe the toolhead is at the given
-cartesian position. This is a diagnostic and debugging command; use
-SET_GCODE_OFFSET and/or G92 for regular axis transformations. If an
-axis is not specified then it will default to the position that the
-head was last commanded to. Setting an incorrect or invalid position
-may lead to internal software errors. This command may invalidate
-future boundary checks; issue a G28 afterwards to reset the
-kinematics.
+`SET_KINEMATIC_POSITION [X=<value>] [Y=<value>] [Z=<value>]
+[CLEAR=<[X][Y][Z]>]`: Force the low-level kinematic code to believe the
+toolhead is at the given cartesian position. This is a diagnostic and
+debugging command; use SET_GCODE_OFFSET and/or G92 for regular axis
+transformations. If an axis is not specified then it will default to the
+position that the head was last commanded to. Setting an incorrect or
+invalid position may lead to internal software errors. Use the CLEAR
+parameter to forget the homing state for the given axes. Note that CLEAR
+will not override the previous functionality; if an axis is not specified
+to CLEAR it will have its kinematic position set as per above. This
+command may invalidate future boundary checks; issue a G28 afterwards to
+reset the kinematics.
 
 ### [gcode]
 

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -854,7 +854,7 @@ class DockableProbe:
         )
         self.toolhead.manual_move([None, None, self.z_hop], self.lift_speed)
         kin = self.toolhead.get_kinematics()
-        kin.note_z_not_homed()
+        kin.clear_homing_state([2])
         self.last_z = self.toolhead.get_position()[2]
 
     #######################################################################

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -174,8 +174,18 @@ class ForceMove:
         x = gcmd.get_float("X", curpos[0])
         y = gcmd.get_float("Y", curpos[1])
         z = gcmd.get_float("Z", curpos[2])
-        logging.info("SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f", x, y, z)
+        clear = gcmd.get("CLEAR", "").upper()
+        axes = ["X", "Y", "Z"]
+        clear_axes = [axes.index(a) for a in axes if a in clear]
+        logging.info(
+            "SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f clear=%s",
+            x,
+            y,
+            z,
+            ",".join((axes[i] for i in clear_axes)),
+        )
         toolhead.set_position([x, y, z, curpos[3]], homing_axes=(0, 1, 2))
+        toolhead.get_kinematics().clear_homing_state(clear_axes)
 
 
 def load_config(config):

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -47,8 +47,7 @@ class SafeZHoming:
                 pos[2] = 0
                 toolhead.set_position(pos, homing_axes=[2])
                 toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)
-                if hasattr(toolhead.get_kinematics(), "note_z_not_homed"):
-                    toolhead.get_kinematics().note_z_not_homed()
+                toolhead.get_kinematics().clear_homing_state((2,))
             elif pos[2] < self.z_hop:
                 # If the Z axis is homed, and below z_hop, lift it to z_hop
                 toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -92,8 +92,12 @@ class CartKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limits[2] = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.limits[i] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         # Determine movement
@@ -118,7 +122,7 @@ class CartKinematics:
                 self.home_axis(homing_state, axis, self.rails[axis])
 
     def _motor_off(self, print_time):
-        self.limits = [(1.0, -1.0)] * 3
+        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -54,8 +54,12 @@ class CoreXYKinematics:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limits[2] = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.limits[i] = (1.0, -1.0)
 
     def home(self, homing_state):
         # Each axis is homed independently and in order
@@ -75,7 +79,7 @@ class CoreXYKinematics:
             homing_state.home_rails([rail], forcepos, homepos)
 
     def _motor_off(self, print_time):
-        self.limits = [(1.0, -1.0)] * 3
+        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -54,8 +54,12 @@ class CoreXZKinematics:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limits[2] = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.limits[i] = (1.0, -1.0)
 
     def home(self, homing_state):
         # Each axis is homed independently and in order
@@ -75,7 +79,7 @@ class CoreXZKinematics:
             homing_state.home_rails([rail], forcepos, homepos)
 
     def _motor_off(self, print_time):
-        self.limits = [(1.0, -1.0)] * 3
+        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -144,6 +144,12 @@ class DeltaKinematics:
         if tuple(homing_axes) == (0, 1, 2):
             self.need_home = False
 
+    def clear_homing_state(self, axes):
+        # Clearing homing state for each axis individually is not implemented
+        if 0 in axes or 1 in axes or 2 in axes:
+            self.limit_xy2 = -1
+            self.need_home = True
+
     def home(self, homing_state):
         # All axes are homed simultaneously
         homing_state.set_axes([0, 1, 2])
@@ -152,8 +158,7 @@ class DeltaKinematics:
         homing_state.home_rails(self.rails, forcepos, self.home_position)
 
     def _motor_off(self, print_time):
-        self.limit_xy2 = -1.0
-        self.need_home = True
+        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -156,6 +156,11 @@ class DeltesianKinematics:
         for n in homing_axes:
             self.homed_axis[n] = True
 
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.homed_axis[i] = False
+
     def home(self, homing_state):
         homing_axes = homing_state.get_axes()
         home_xz = 0 in homing_axes or 2 in homing_axes

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -111,8 +111,12 @@ class HybridCoreXYKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limits[2] = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.limits[i] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()
@@ -135,7 +139,7 @@ class HybridCoreXYKinematics:
                 self.home_axis(homing_state, axis, self.rails[axis])
 
     def _motor_off(self, print_time):
-        self.limits = [(1.0, -1.0)] * 3
+        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -110,8 +110,12 @@ class HybridCoreXZKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limits[2] = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        for i, _ in enumerate(self.limits):
+            if i in axes:
+                self.limits[i] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()
@@ -134,7 +138,7 @@ class HybridCoreXZKinematics:
                 self.home_axis(homing_state, axis, self.rails[axis])
 
     def _motor_off(self, print_time):
-        self.limits = [(1.0, -1.0)] * 3
+        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -19,6 +19,9 @@ class NoneKinematics:
     def set_position(self, newpos, homing_axes):
         pass
 
+    def clear_homing_state(self, axes):
+        pass
+
     def home(self, homing_state):
         pass
 

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -66,8 +66,14 @@ class PolarKinematics:
             self.limit_xy2 = self.rails[0].get_range()[1] ** 2
 
     def note_z_not_homed(self):
-        # Helper for Safe Z Home
-        self.limit_z = (1.0, -1.0)
+        self.clear_homing_state([2])
+
+    def clear_homing_state(self, axes):
+        if 0 in axes or 1 in axes:
+            # X and Y cannot be cleared separately
+            self.limit_xy2 = -1.0
+        if 2 in axes:
+            self.limit_z = (1.0, -1.0)
 
     def _home_axis(self, homing_state, axis, rail):
         # Determine movement
@@ -103,8 +109,7 @@ class PolarKinematics:
             self._home_axis(homing_state, 2, self.rails[1])
 
     def _motor_off(self, print_time):
-        self.limit_z = (1.0, -1.0)
-        self.limit_xy2 = -1.0
+        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -127,6 +127,12 @@ class RotaryDeltaKinematics:
         if tuple(homing_axes) == (0, 1, 2):
             self.need_home = False
 
+    def clear_homing_state(self, axes):
+        # Clearing homing state for each axis individually is not implemented
+        if 0 in axes or 1 in axes or 2 in axes:
+            self.limit_xy2 = -1
+            self.need_home = True
+
     def home(self, homing_state):
         # All axes are homed simultaneously
         homing_state.set_axes([0, 1, 2])
@@ -137,8 +143,7 @@ class RotaryDeltaKinematics:
         homing_state.home_rails(self.rails, forcepos, self.home_position)
 
     def _motor_off(self, print_time):
-        self.limit_xy2 = -1.0
-        self.need_home = True
+        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -42,6 +42,10 @@ class WinchKinematics:
         for s in self.steppers:
             s.set_position(newpos)
 
+    def clear_homing_state(self, axes):
+        # XXX - homing not implemented
+        pass
+
     def home(self, homing_state):
         # XXX - homing not implemented
         homing_state.set_axes([0, 1, 2])

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -570,7 +570,7 @@ class PrinterRail:
             changed_pullup = pin_params["pullup"] != endstop["pullup"]
             if changed_invert or changed_pullup:
                 raise error(
-                    "Pinter rail %s shared endstop pin %s "
+                    "Printer rail %s shared endstop pin %s "
                     "must specify the same pullup/invert settings"
                     % (self.get_name(), pin_name)
                 )


### PR DESCRIPTION
This is the same as the Klipper PR below, but I kept `note_z_not_homed()`
everywhere it existed currently. (I did change the one remaining usage of
`note_z_not_homed` in the tree into a `clear_homing_state`.) I didn't
touch `TradRackKinematics` though; that should probably go upstream or
else it risks being blown away?

It would be nice if there was a `@deprecated` decorator (though maybe not named
that, since one named that is coming post python 3.13), even if it didn't
do anything right now. 

Klipper PR: https://github.com/klipper3d/klipper/pull/6262

force_move: Implement CLEAR for SET_KINEMATIC_POSITION  (#6262)

`CLEAR` clears the homing status (resets the axis limits) without turning off
the motors. This is particularly useful when implementing safe Z homing in
`[homing_override]` on printers with multiple independent Z steppers (where
`FORCE_MOVE` can't be used).

Signed-off-by: Dennis Marttinen <twelho@welho.tech>