### PR TITLE
Simplify kinematic set_position() and clear_homing_state() calls

### DIFF
--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -852,7 +852,7 @@ class DockableProbe:
 
         tpos = self.toolhead.get_position()
         self.toolhead.set_position(
-            [tpos[0], tpos[1], 0.0, tpos[3]], homing_axes=[2]
+            [tpos[0], tpos[1], 0.0, tpos[3]], homing_axes="z"
         )
         self.toolhead.manual_move([None, None, self.z_hop], self.lift_speed)
         kin = self.toolhead.get_kinematics()

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -856,7 +856,7 @@ class DockableProbe:
         )
         self.toolhead.manual_move([None, None, self.z_hop], self.lift_speed)
         kin = self.toolhead.get_kinematics()
-        kin.clear_homing_state([2])
+        kin.clear_homing_state("z")
         self.last_z = self.toolhead.get_position()[2]
 
     #######################################################################

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -186,7 +186,7 @@ class ForceMove:
             z,
             ",".join((axes[i] for i in clear_axes)),
         )
-        toolhead.set_position([x, y, z, curpos[3]], homing_axes=(0, 1, 2))
+        toolhead.set_position([x, y, z, curpos[3]], homing_axes="xyz")
         toolhead.get_kinematics().clear_homing_state(clear_axes)
 
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -176,15 +176,14 @@ class ForceMove:
         x = gcmd.get_float("X", curpos[0])
         y = gcmd.get_float("Y", curpos[1])
         z = gcmd.get_float("Z", curpos[2])
-        clear = gcmd.get("CLEAR", "").upper()
-        axes = ["X", "Y", "Z"]
-        clear_axes = [axes.index(a) for a in axes if a in clear]
+        clear = gcmd.get("CLEAR", "").lower()
+        clear_axes = "".join([a for a in "xyz" if a in clear])
         logging.info(
             "SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f clear=%s",
             x,
             y,
             z,
-            ",".join((axes[i] for i in clear_axes)),
+            clear_axes,
         )
         toolhead.set_position([x, y, z, curpos[3]], homing_axes="xyz")
         toolhead.get_kinematics().clear_homing_state(clear_axes)

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -280,8 +280,7 @@ class Homing:
         print_time = self.toolhead.get_last_move_time()
         affected_rails = set()
         for axis in homing_axes:
-            axis_name = "xyz"[axis]  # only works for cartesian
-            partial_rails = self.toolhead.get_active_rails_for_axis(axis_name)
+            partial_rails = self.toolhead.get_active_rails_for_axis(axis)
             affected_rails = affected_rails | set(partial_rails)
 
         dwell_time = 0.0
@@ -330,7 +329,7 @@ class Homing:
 
         needs_rehome = False
         retract_dist = hi.retract_dist
-        if hmove.moved_less_than_dist(hi.min_home_dist, homing_axes):
+        if hmove.moved_less_than_dist(hi.min_home_dist, force_axes):
             needs_rehome = True
             retract_dist = hi.min_home_dist
 

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -308,8 +308,9 @@ class Homing:
     def home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
-        # Alter kinematics class to think printer is at forcepo
-        homing_axes = [axis for axis in range(3) if forcepos[axis] is not None]
+        # Alter kinematics class to think printer is at forcepos
+        force_axes = [axis for axis in range(3) if forcepos[axis] is not None]
+        homing_axes = "".join(["xyz"[i] for i in force_axes])
         startpos = self._fill_coord(forcepos)
         homepos = self._fill_coord(movepos)
         self.toolhead.set_position(startpos, homing_axes=homing_axes)
@@ -368,7 +369,7 @@ class Homing:
                         hi.use_sensorless_homing
                         and needs_rehome
                         and hmove.moved_less_than_dist(
-                            hi.min_home_dist, homing_axes
+                            hi.min_home_dist, force_axes
                         )
                     ):
                         raise self.printer.command_error(
@@ -411,7 +412,7 @@ class Homing:
                 for s in kin.get_steppers()
             }
             newpos = kin.calc_position(kin_spos)
-            for axis in homing_axes:
+            for axis in force_axes:
                 homepos[axis] = newpos[axis]
             self.toolhead.set_position(homepos)
 

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -49,11 +49,11 @@ class HomingOverride:
         # Calculate forced position (if configured)
         toolhead = self.printer.lookup_object("toolhead")
         pos = toolhead.get_position()
-        homing_axes = []
+        homing_axes = ""
         for axis, loc in enumerate(self.start_pos):
             if loc is not None:
                 pos[axis] = loc
-                homing_axes.append(axis)
+                homing_axes += "xyz"[axis]
         toolhead.set_position(pos, homing_axes=homing_axes)
         # Perform homing
         context = self.template.create_template_context()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -147,7 +147,7 @@ class ManualStepper:
     def get_position(self):
         return [self.rail.get_commanded_position(), 0.0, 0.0, 0.0]
 
-    def set_position(self, newpos, homing_axes=()):
+    def set_position(self, newpos, homing_axes=""):
         self.do_set_position(newpos[0])
 
     def get_last_move_time(self):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -603,7 +603,7 @@ class PrinterProbe:
             toolhead.get_last_move_time()
             toolhead_pos = toolhead.get_position()
             toolhead_pos[2] = toolhead_pos[2] - self.last_z_result
-            toolhead.set_position(toolhead_pos, homing_axes=[2])
+            toolhead.set_position(toolhead_pos, homing_axes="z")
 
     cmd_QUERY_PROBE_help = "Return the status of the z-probe"
 

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -45,7 +45,7 @@ class SafeZHoming:
             if "z" not in kin_status["homed_axes"]:
                 # Always perform the z_hop if the Z axis is not homed
                 pos[2] = 0
-                toolhead.set_position(pos, homing_axes=[2])
+                toolhead.set_position(pos, homing_axes="z")
                 toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)
                 toolhead.get_kinematics().clear_homing_state((2,))
             elif pos[2] < self.z_hop:

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -47,7 +47,7 @@ class SafeZHoming:
                 pos[2] = 0
                 toolhead.set_position(pos, homing_axes="z")
                 toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)
-                toolhead.get_kinematics().clear_homing_state((2,))
+                toolhead.get_kinematics().clear_homing_state("z")
             elif pos[2] < self.z_hop:
                 # If the Z axis is homed, and below z_hop, lift it to z_hop
                 toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -111,6 +111,7 @@ class PrinterStepperEnable:
         print_time = toolhead.get_last_move_time()
         for el in self.enable_lines.values():
             el.motor_disable(print_time)
+        toolhead.get_kinematics().clear_homing_state((0, 1, 2))
         self.printer.send_event("stepper_enable:motor_off", print_time)
         toolhead.dwell(DISABLE_STALL_TIME)
 

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -111,7 +111,7 @@ class PrinterStepperEnable:
         print_time = toolhead.get_last_move_time()
         for el in self.enable_lines.values():
             el.motor_disable(print_time)
-        toolhead.get_kinematics().clear_homing_state((0, 1, 2))
+        toolhead.get_kinematics().clear_homing_state("xyz")
         self.printer.send_event("stepper_enable:motor_off", print_time)
         toolhead.dwell(DISABLE_STALL_TIME)
 

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -91,12 +91,12 @@ class CartKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        self.clear_homing_state([2])
+        self.clear_homing_state("z")
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         # Determine movement

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -48,9 +48,6 @@ class CartKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -121,9 +118,6 @@ class CartKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -82,7 +82,8 @@ class CartKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -23,9 +23,6 @@ class CoreXYKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -77,9 +74,6 @@ class CoreXYKinematics:
                 forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -47,7 +47,7 @@ class CoreXYKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
+            if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -51,12 +51,12 @@ class CoreXYKinematics:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):
-        self.clear_homing_state([2])
+        self.clear_homing_state("z")
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
 
     def home(self, homing_state):
         # Each axis is homed independently and in order

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -23,9 +23,6 @@ class CoreXZKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -77,9 +74,6 @@ class CoreXZKinematics:
                 forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -51,12 +51,12 @@ class CoreXZKinematics:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):
-        self.clear_homing_state([2])
+        self.clear_homing_state("z")
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
 
     def home(self, homing_state):
         # Each axis is homed independently and in order

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -47,7 +47,7 @@ class CoreXZKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
+            if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
 
     def note_z_not_homed(self):

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -142,9 +142,12 @@ class DeltaKinematics:
         if homing_axes == "xyz":
             self.need_home = False
 
-    def clear_homing_state(self, axes):
+    def note_z_not_homed(self):
+        self.clear_homing_state("z")
+
+    def clear_homing_state(self, clear_axes):
         # Clearing homing state for each axis individually is not implemented
-        if 0 in axes or 1 in axes or 2 in axes:
+        if clear_axes:
             self.limit_xy2 = -1
             self.need_home = True
 

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -31,9 +31,6 @@ class DeltaKinematics:
             default_position_endstop=a_endstop,
         )
         self.rails = [rail_a, rail_b, rail_c]
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup max velocity
         self.max_velocity, self.max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -158,9 +155,6 @@ class DeltaKinematics:
         forcepos = list(self.home_position)
         forcepos[2] = -1.5 * math.sqrt(max(self.arm2) - self.max_xy2)
         homing_state.home_rails(self.rails, forcepos, self.home_position)
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -122,8 +122,7 @@ class DeltaKinematics:
         )
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.0)
-        self.set_position([0.0, 0.0, 0.0], ())
-        self.supports_dual_carriage = False
+        self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
@@ -140,7 +139,7 @@ class DeltaKinematics:
         for rail in self.rails:
             rail.set_position(newpos)
         self.limit_xy2 = -1.0
-        if tuple(homing_axes) == (0, 1, 2):
+        if homing_axes == "xyz":
             self.need_home = False
 
     def clear_homing_state(self, axes):

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -118,8 +118,7 @@ class DeltesianKinematics:
         self.axes_min = toolhead.Coord(*[l[0] for l in self.limits], e=0.0)
         self.axes_max = toolhead.Coord(*[l[1] for l in self.limits], e=0.0)
         self.homed_axis = [False] * 3
-        self.set_position([0.0, 0.0, 0.0], ())
-        self.supports_dual_carriage = False
+        self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
@@ -152,8 +151,9 @@ class DeltesianKinematics:
     def set_position(self, newpos, homing_axes):
         for rail in self.rails:
             rail.set_position(newpos)
-        for n in homing_axes:
-            self.homed_axis[n] = True
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
+            self.homed_axis[axis] = True
 
     def clear_homing_state(self, axes):
         for i, _ in enumerate(self.limits):

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -52,9 +52,6 @@ class DeltesianKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         self.limits = [(1.0, -1.0)] * 3
         # X axis limits
         min_angle = config.getfloat(
@@ -195,9 +192,6 @@ class DeltesianKinematics:
             else:
                 forcepos[1] += 1.5 * (position_max - hi.position_endstop)
             homing_state.home_rails([self.rails[2]], forcepos, homepos)
-
-    def _motor_off(self, print_time):
-        self.homed_axis = [False] * 3
 
     def check_move(self, move):
         limits = list(map(list, self.limits))

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -155,10 +155,13 @@ class DeltesianKinematics:
             axis = "xyz".index(axis_name)
             self.homed_axis[axis] = True
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.homed_axis[i] = False
+    def note_z_not_homed(self):
+        self.clear_homing_state("z")
+
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.homed_axis[axis] = False
 
     def home(self, homing_state):
         homing_axes = homing_state.get_axes()

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -99,7 +99,8 @@ class HybridCoreXYKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -108,12 +108,12 @@ class HybridCoreXYKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        self.clear_homing_state([2])
+        self.clear_homing_state("z")
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -60,9 +60,6 @@ class HybridCoreXYKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -136,9 +133,6 @@ class HybridCoreXYKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -107,12 +107,12 @@ class HybridCoreXZKinematics:
             self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
-        self.clear_homing_state([2])
+        self.clear_homing_state("z")
 
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
 
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -98,7 +98,8 @@ class HybridCoreXZKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -59,9 +59,6 @@ class HybridCoreXZKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -135,9 +132,6 @@ class HybridCoreXZKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def _check_endstops(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -19,7 +19,7 @@ class NoneKinematics:
     def set_position(self, newpos, homing_axes):
         pass
 
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         pass
 
     def home(self, homing_state):

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -58,13 +58,10 @@ class PolarKinematics:
     def set_position(self, newpos, homing_axes):
         for s in self.steppers:
             s.set_position(newpos)
-        if 2 in homing_axes:
+        if "z" in homing_axes:
             self.limit_z = self.rails[1].get_range()
-        if 0 in homing_axes and 1 in homing_axes:
+        if "x" in homing_axes and "y" in homing_axes:
             self.limit_xy2 = self.rails[0].get_range()[1] ** 2
-
-    def note_z_not_homed(self):
-        self.clear_homing_state([2])
 
     def clear_homing_state(self, axes):
         if 0 in axes or 1 in axes:

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -63,11 +63,14 @@ class PolarKinematics:
         if "x" in homing_axes and "y" in homing_axes:
             self.limit_xy2 = self.rails[0].get_range()[1] ** 2
 
-    def clear_homing_state(self, axes):
-        if 0 in axes or 1 in axes:
+    def note_z_not_homed(self):
+        self.clear_homing_state("z")
+
+    def clear_homing_state(self, clear_axes):
+        if "x" in clear_axes or "y" in clear_axes:
             # X and Y cannot be cleared separately
             self.limit_xy2 = -1.0
-        if 2 in axes:
+        if "z" in clear_axes:
             self.limit_z = (1.0, -1.0)
 
     def _home_axis(self, homing_state, axis, rail):

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -26,9 +26,6 @@ class PolarKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -108,9 +105,6 @@ class PolarKinematics:
             self._home_axis(homing_state, 0, self.rails[0])
         if home_z:
             self._home_axis(homing_state, 2, self.rails[1])
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -109,8 +109,7 @@ class RotaryDeltaKinematics:
         max_xy = math.sqrt(self.max_xy2)
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.0)
-        self.set_position([0.0, 0.0, 0.0], ())
-        self.supports_dual_carriage = False
+        self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
@@ -123,7 +122,7 @@ class RotaryDeltaKinematics:
         for rail in self.rails:
             rail.set_position(newpos)
         self.limit_xy2 = -1.0
-        if tuple(homing_axes) == (0, 1, 2):
+        if homing_axes == "xyz":
             self.need_home = False
 
     def clear_homing_state(self, axes):

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -109,6 +109,7 @@ class RotaryDeltaKinematics:
         max_xy = math.sqrt(self.max_xy2)
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.0)
+        self.supports_dual_carriage = False
         self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
@@ -125,9 +126,12 @@ class RotaryDeltaKinematics:
         if homing_axes == "xyz":
             self.need_home = False
 
-    def clear_homing_state(self, axes):
+    def note_z_not_homed(self):
+        self.clear_homing_state("z")
+
+    def clear_homing_state(self, clear_axes):
         # Clearing homing state for each axis individually is not implemented
-        if 0 in axes or 1 in axes or 2 in axes:
+        if clear_axes:
             self.limit_xy2 = -1
             self.need_home = True
 

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -32,9 +32,6 @@ class RotaryDeltaKinematics:
             units_in_radians=True,
         )
         self.rails = [rail_a, rail_b, rail_c]
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off
-        )
         # Read config
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -143,9 +140,6 @@ class RotaryDeltaKinematics:
         # forcepos[2] = self.calibration.actuator_to_cartesian(min_angles)[2]
         forcepos[2] = -1.0
         homing_state.home_rails(self.rails, forcepos, self.home_position)
-
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
 
     def check_move(self, move):
         end_pos = move.end_pos

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -27,6 +27,7 @@ class WinchKinematics:
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.0)
         self.axes_max = toolhead.Coord(*[max(a) for a in acoords], e=0.0)
+        self.supports_dual_carriage = False
         self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
@@ -41,7 +42,7 @@ class WinchKinematics:
         for s in self.steppers:
             s.set_position(newpos)
 
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         # XXX - homing not implemented
         pass
 

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -27,8 +27,7 @@ class WinchKinematics:
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.0)
         self.axes_max = toolhead.Coord(*[max(a) for a in acoords], e=0.0)
-        self.set_position([0.0, 0.0, 0.0], ())
-        self.supports_dual_carriage = False
+        self.set_position([0.0, 0.0, 0.0], "")
 
     def get_steppers(self):
         return list(self.steppers)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -597,7 +597,7 @@ class ToolHead:
     def get_position(self):
         return list(self.commanded_pos)
 
-    def set_position(self, newpos, homing_axes=()):
+    def set_position(self, newpos, homing_axes=""):
         self.flush_step_generation()
         ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.trapq_set_position(


### PR DESCRIPTION
Now that clear_homing_state() has been implemented, there is no longer a need for each kinematic class to manually register for the "motor_off" event, as the stepper_enable class can directly call clear_homing_state().

Also this changes the homing_axes and clear_axes parameters of the set_position() and clear_homing_state() to pass strings (eg, "xyz") instead of a list of numbers.

fyi @vvuk 

Klipper PR: https://github.com/Klipper3d/klipper/pull/6782