### PR TITLE
Add options to change mode, user, and group of API server socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [core: rotate log file at every restart](https://github.com/KalicoCrew/kalico/pull/181)
 
+- [core: options for API server socket file mode, user, and group](https://github.com/KalicoCrew/kalico/pull/612)
+
 - [fan: normalising Fan PWM power](https://github.com/KalicoCrew/kalico/pull/44) ([klipper#6307](https://github.com/Klipper3d/klipper/pull/6307))
 
 - [fan: reverse FAN](https://github.com/KalicoCrew/kalico/pull/51) ([klipper#4983](https://github.com/Klipper3d/klipper/pull/4983))

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -472,8 +472,23 @@ def main():
     opts.add_option(
         "-a",
         "--api-server",
-        dest="apiserver",
+        dest="apiserver_file",
         help="api server unix domain socket filename",
+    )
+    opts.add_option(
+        "--api-server-user",
+        dest="apiserver_user",
+        help="api server unix domain socket user",
+    )
+    opts.add_option(
+        "--api-server-group",
+        dest="apiserver_group",
+        help="api server unix domain socket group",
+    )
+    opts.add_option(
+        "--api-server-file-mode",
+        dest="apiserver_file_mode",
+        help="api server unix domain socket file mode",
     )
     opts.add_option(
         "-l",
@@ -516,7 +531,10 @@ def main():
         opts.error("Incorrect number of arguments")
     start_args = {
         "config_file": args[0],
-        "apiserver": options.apiserver,
+        "apiserver_file": options.apiserver_file,
+        "apiserver_user": options.apiserver_user,
+        "apiserver_group": options.apiserver_group,
+        "apiserver_file_mode": options.apiserver_file_mode,
         "start_reason": "startup",
     }
 

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
-import logging, socket, os, sys, errno, json, collections
+import logging, socket, os, sys, errno, json, collections, pwd, grp
 from . import gcode
 from . import APP_NAME
 from .extras.danger_options import get_danger_options
@@ -125,7 +125,7 @@ class ServerSocket:
         self.sock = self.fd_handle = None
         self.clients = {}
         start_args = printer.get_start_args()
-        server_address = start_args.get("apiserver")
+        server_address = start_args.get("apiserver_file")
         is_fileinput = start_args.get("debuginput") is not None
         if not server_address or is_fileinput:
             # Do not enable server
@@ -134,6 +134,7 @@ class ServerSocket:
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.setblocking(0)
         self.sock.bind(server_address)
+        self.__apply_permission_options_to_socket(server_address, start_args)
         self.sock.listen(1)
         self.fd_handle = self.reactor.register_fd(
             self.sock.fileno(), self._handle_accept
@@ -189,6 +190,21 @@ class ServerSocket:
                     client.close()
         return False, ""
 
+    def __apply_permission_options_to_socket(self, socket_path, start_args):
+        user = start_args.get("apiserver_user")
+        group = start_args.get("apiserver_group")
+        file_mode = start_args.get("apiserver_file_mode")
+
+        if user is not None or group is not None:
+            uid = -1 if user is None else pwd.getpwnam(user).pw_uid
+            gid = -1 if group is None else grp.getgrnam(group).gr_gid
+
+            os.chown(socket_path, uid, gid)
+
+        if file_mode is not None:
+            mode_int = int(file_mode, 8)
+
+            os.chmod(socket_path, mode_int)
 
 class ClientConnection:
     def __init__(self, server, sock):

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -206,6 +206,7 @@ class ServerSocket:
 
             os.chmod(socket_path, mode_int)
 
+
 class ClientConnection:
     def __init__(self, server, sock):
         self.printer = server.printer


### PR DESCRIPTION
Closes https://github.com/KalicoCrew/kalico/issues/604!

This PR adds three new options to klippy.py, as seen from this truncated help page:

```
  --api-server-user=APISERVER_USER
                        api server unix domain socket user
  --api-server-group=APISERVER_GROUP
                        api server unix domain socket group
  --api-server-file-mode=APISERVER_FILE_MODE
                        api server unix domain socket file mode
```

These options allow user to change the user, group, and file mode of the API server socket, i.e. `/run/kalico/ud_sock`.

For example, these options...

```
/usr/bin/python /usr/lib/kalico/klippy/klippy.py \
  /etc/kalico/kalico.cfg \
  --input-tty=/run/kalico/sock \
  --api-server=/run/kalico/ud_sock \
  --api-server-group=tty \
  --api-server-file-mode=660
```

...will create `/run/kalico/ud_sock` like so:

```
srw-rw---- 1 kalico tty     0 Mar  5 21:30 ud_sock
```

From a UNIX permissions perspective, it's a good idea to have Moonraker and Kalico run as different users.  Kalico typically has access to hardware, video, network, etc., and if Moonraker runs as the same user, then Moonraker also has access to these things.  Moonraker is an API server that should only be communicating with Kalico, and should not have access to the extra privileges Kalico requires.  For example, if an RCE in Moonraker is discovered, then the attacker will have access to these elevated permissions.

With this PR, the principle of least permissions can be applied between Kalico, Moonraker, and other software.  The socket can be given 660 permissions with a special group, and as long as the Moonraker user is in this group, then it can read/write to the socket without additional permissions.

If the end user doesn't need these features, then no biggie: this PR is not a breaking change, and there will be no behavioral difference before and after this PR without these options set :+1: 

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
