### PR TITLE
Make firmware_extras work with GNU find, not Darwin find

### DIFF
--- a/scripts/find-firmware-extras.sh
+++ b/scripts/find-firmware-extras.sh
@@ -5,14 +5,18 @@ if [ ! -d src/extras ] ; then
     exit 1
 fi
 
-find src/extras -name Kconfig -depth 2 | sed 's,\(.*\),source "\1",' > src/extras/Kconfig.tmp
+find_extras() {
+    find -L src/extras -mindepth 2 -maxdepth 2 -name $1
+}
+
+find_extras Kconfig | sed 's,\(.*\),source "\1",' > src/extras/Kconfig.tmp
 
 if [ -s src/extras/Kconfig.tmp ] ; then
     echo 'menu "Firmware Extras"' > src/extras/Kconfig
     cat src/extras/Kconfig.tmp >> src/extras/Kconfig
     echo 'endmenu' >> src/extras/Kconfig
 
-    find src/extras -name Makefile -depth 2 | sed 's,\(.*\),include \1,' > src/extras/Makefile
+    find_extras Makefile | sed 's,\(.*\),include \1,' > src/extras/Makefile
 else
     echo -n '' > src/extras/Kconfig
     echo -n '' > src/extras/Makefile


### PR DESCRIPTION
So turns out I developed and tested this on macOS, and forgot that the `find` there is wildly different than GNU. This makes it work with GNU find on Linux; I'll fix macOS separately when I'm back at my mac.