### PR TITLE
turn fan to 50% in ringing and PA test tower generators

### DIFF
--- a/klippy/extras/pa_test.py
+++ b/klippy/extras/pa_test.py
@@ -433,6 +433,7 @@ class PATest:
         yield "G90"
         for line in gen_brim():
             yield line
+        yield "M106 S127"
         for line in gen_tower():
             yield line
         if final_gcode_id is not None:

--- a/klippy/extras/ringing_test.py
+++ b/klippy/extras/ringing_test.py
@@ -512,6 +512,7 @@ class RingingTest:
         yield "M220 S100"
         for line in gen_brim():
             yield line
+        yield "M106 S127"
         for line in gen_tower():
             yield line
         if final_gcode_id is not None:


### PR DESCRIPTION
Dmitri's PA and ringing test towers don't start the fan, so the user has to manually start them once the brim is done. This is a major nuisance.

This change starts the fan at 50% once the brim is done, that should be a good starting value for most printers. (note, I have a 24v printer with a 12v fan so it won't overvolt that)

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
