### PR TITLE
Update temperature_mcu.py to support gd32e230x MCUs

### DIFF
--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -104,6 +104,9 @@ class PrinterTemperatureMCU:
             ("stm32l4", self.config_stm32g0),
             ("stm32h723", self.config_stm32h723),
             ("stm32h7", self.config_stm32h7),
+            ('gd32e230x8', self.config_gd32e230x8),
+            ('gd32f303xe', self.config_gd32f303xe),
+            ('gd32f303xb', self.config_gd32f303xb),
             ("", self.config_unknown),
         ]
         for name, func in cfg_funcs:
@@ -136,7 +139,19 @@ class PrinterTemperatureMCU:
         raise self.printer.config_error(
             "MCU temperature not supported on %s" % (self.mcu_type,)
         )
-
+    
+    def config_gd32e230x8(self):
+        self.slope = 3.3 / -.004300
+        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
+        
+    def config_gd32f303xe(self):
+        self.slope = 3.3 / -.004100
+        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
+        
+    def config_gd32f303xb(self):
+        self.slope = 3.3 / -.004100
+        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
+        
     def config_rp2040(self):
         self.slope = self.reference_voltage / -0.001721
         self.base_temperature = self.calc_base(

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -139,6 +139,7 @@ class PrinterTemperatureMCU:
         raise self.printer.config_error(
             "MCU temperature not supported on %s" % (self.mcu_type,)
         )
+        
     
     def config_gd32e230x8(self):
         self.slope = 3.3 / -.004300

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -104,9 +104,9 @@ class PrinterTemperatureMCU:
             ("stm32l4", self.config_stm32g0),
             ("stm32h723", self.config_stm32h723),
             ("stm32h7", self.config_stm32h7),
-            ('gd32e230x8', self.config_gd32e230x8),
-            ('gd32f303xe', self.config_gd32f303xe),
-            ('gd32f303xb', self.config_gd32f303xb),
+            ("gd32e230x8", self.config_gd32e230x8),
+            ("gd32f303xe", self.config_gd32f303xe),
+            ("gd32f303xb", self.config_gd32f303xb),
             ("", self.config_unknown),
         ]
         for name, func in cfg_funcs:
@@ -139,20 +139,19 @@ class PrinterTemperatureMCU:
         raise self.printer.config_error(
             "MCU temperature not supported on %s" % (self.mcu_type,)
         )
-        
-    
+
     def config_gd32e230x8(self):
-        self.slope = 3.3 / -.004300
-        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
-        
+        self.slope = 3.3 / -0.004300
+        self.base_temperature = self.calc_base(25.0, 1.45 / 3.3)
+
     def config_gd32f303xe(self):
-        self.slope = 3.3 / -.004100
-        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
-        
+        self.slope = 3.3 / -0.004100
+        self.base_temperature = self.calc_base(25.0, 1.45 / 3.3)
+
     def config_gd32f303xb(self):
-        self.slope = 3.3 / -.004100
-        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
-        
+        self.slope = 3.3 / -0.004100
+        self.base_temperature = self.calc_base(25.0, 1.45 / 3.3)
+
     def config_rp2040(self):
         self.slope = self.reference_voltage / -0.001721
         self.base_temperature = self.calc_base(


### PR DESCRIPTION
Pull request for this issue https://github.com/KalicoCrew/kalico/issues/610

Add support for gd32e230x MCU used in Creality and Sovol printers. Have been using it for a month without any issues.

Don't know why, but Ruff check keep failing for no reason.

## Checklist

- [v] pr title makes sense
- [ ] added a test case if possible
- [v] if new feature, added to the readme
- [v] ci is happy and green
