### PR TITLE
adds danger_options.single_mcu_trsync_timeout

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -91,6 +91,9 @@ A collection of DangerKlipper-specific system options
 #allow_plugin_override: False
 #   Allows modules in `plugins` to override modules of the same name in `extras`
 #   The default is False.
+#single_mcu_trsync_timeout: 0.025
+#   The timeout (in seconds) for MCU synchronization during the homing process when
+#   a single MCUs is in use. The default is 0.025
 #multi_mcu_trsync_timeout: 0.025
 #   The timeout (in seconds) for MCU synchronization during the homing process when
 #   multiple MCUs are in use. The default is 0.025

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -22,6 +22,9 @@ class DangerOptions:
         self.allow_plugin_override = config.getboolean(
             "allow_plugin_override", False
         )
+        self.single_mcu_trsync_timeout = config.getfloat(
+            "single_mcu_trsync_timeout", 0.025, minval=0.0
+        )
         self.multi_mcu_trsync_timeout = config.getfloat(
             "multi_mcu_trsync_timeout", 0.025, minval=0.0
         )

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -294,9 +294,6 @@ class MCU_trsync:
         return params["trigger_reason"]
 
 
-TRSYNC_SINGLE_MCU_TIMEOUT = 0.250
-
-
 class TriggerDispatch:
     def __init__(self, mcu):
         self._mcu = mcu
@@ -338,7 +335,7 @@ class TriggerDispatch:
         self._trigger_completion = reactor.completion()
         expire_timeout = get_danger_options().multi_mcu_trsync_timeout
         if len(self._trsyncs) == 1:
-            expire_timeout = TRSYNC_SINGLE_MCU_TIMEOUT
+            expire_timeout = get_danger_options().single_mcu_trsync_timeout
         for i, trsync in enumerate(self._trsyncs):
             report_offset = float(i) / len(self._trsyncs)
             trsync.start(


### PR DESCRIPTION
adds danger_options.single_mcu_trsync_timeout

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
