### PR TITLE
stm32g4/h7 - fix pll_base when using a 25mhz crystal

### DIFF
--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -83,9 +83,16 @@ DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PF0,PF1");
 static void
 enable_clock_stm32g4(void)
 {
-    uint32_t pll_base = 4000000, pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
+    uint32_t pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
+    uint32_t pll_base;
+
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
         // Configure 150Mhz PLL from external crystal (HSE)
+#if CONFIG_CLOCK_REF_FREQ % 5000000 == 0
+        pll_base = 5000000;
+#else
+        pll_base = 4000000;
+#endif
         uint32_t div = CONFIG_CLOCK_REF_FREQ / pll_base - 1;
         RCC->CR |= RCC_CR_HSEON;
         while (!(RCC->CR & RCC_CR_HSERDY))
@@ -93,6 +100,7 @@ enable_clock_stm32g4(void)
         pllcfgr = RCC_PLLCFGR_PLLSRC_HSE | (div << RCC_PLLCFGR_PLLM_Pos);
     } else {
         // Configure 150Mhz PLL from internal 16Mhz oscillator (HSI)
+        pll_base = 4000000;
         uint32_t div = 16000000 / pll_base - 1;
         pllcfgr = RCC_PLLCFGR_PLLSRC_HSI | (div << RCC_PLLCFGR_PLLM_Pos);
         RCC->CR |= RCC_CR_HSION;

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -98,18 +98,17 @@ clock_setup(void)
     PWR->CR3 = (PWR->CR3 | PWR_CR3_LDOEN) & ~(PWR_CR3_BYPASS | PWR_CR3_SCUEN);
     while (!(PWR->CSR1 & PWR_CSR1_ACTVOSRDY))
         ;
-// klipper supports 8, 12, 16, 20, 24, and 25 MHz crystals on HSE
-#if CONFIG_CLOCK_REF_FREQ % 5000000 == 0
-    uint32_t pll_base = 5000000;
-#elif CONFIG_CLOCK_REF_FREQ % 4000000 == 0
-    uint32_t pll_base = 4000000;
-#else
-#error Unknown pll_base for CLOCK_REF_FREQ
-#endif
     // Only even dividers (DIVP1) are allowed
     uint32_t pll_freq = CONFIG_CLOCK_FREQ * 2;
+    uint32_t pll_base;
+
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
         // Configure PLL from external crystal (HSE)
+#if CONFIG_CLOCK_REF_FREQ % 5000000 == 0
+        pll_base = 5000000;
+#else
+        pll_base = 4000000;
+#endif
         RCC->CR |= RCC_CR_HSEON;
         while(!(RCC->CR & RCC_CR_HSERDY))
             ;


### PR DESCRIPTION
based on from https://github.com/KalicoCrew/kalico/pull/581

enables 25mhz crystal for stm32g4
fixes stm32h7 build when internal crystal is used