### PR TITLE
bugfix - single_mcu_trsync_timeout defaults to 0.25

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -93,9 +93,9 @@ A collection of Kalico-specific system options
 #allow_plugin_override: False
 #   Allows modules in `plugins` to override modules of the same name in `extras`
 #   The default is False.
-#single_mcu_trsync_timeout: 0.025
+#single_mcu_trsync_timeout: 0.25
 #   The timeout (in seconds) for MCU synchronization during the homing process when
-#   a single MCUs is in use. The default is 0.025
+#   a single MCUs is in use. The default is 0.25
 #multi_mcu_trsync_timeout: 0.025
 #   The timeout (in seconds) for MCU synchronization during the homing process when
 #   multiple MCUs are in use. The default is 0.025

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -29,7 +29,7 @@ class DangerOptions:
             "allow_plugin_override", False
         )
         self.single_mcu_trsync_timeout = config.getfloat(
-            "single_mcu_trsync_timeout", 0.025, minval=0.0
+            "single_mcu_trsync_timeout", 0.25, minval=0.0
         )
         self.multi_mcu_trsync_timeout = config.getfloat(
             "multi_mcu_trsync_timeout", 0.025, minval=0.0


### PR DESCRIPTION
Fixes https://github.com/KalicoCrew/kalico/issues/625

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
