### PR TITLE
bed_mesh - new BED_MESH_CHECK gcode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [force_move: turn on by default](https://github.com/KalicoCrew/kalico/pull/135)
 
+- [bed_mesh: add BED_MESH_CHECK command for mesh validation](https://github.com/KalicoCrew/kalico/pull/XXX)
+
 - [respond: turn on by default](https://github.com/KalicoCrew/kalico/pull/296)
 
 - [exclude_object: turn on by default](https://github.com/KalicoCrew/kalico/pull/306)

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -225,6 +225,16 @@ adjustment after a tool change.  Note that a ZFADE offset does not apply
 additional z-adjustment directly, it is used to correct the `fade`
 calculation when a `gcode offset` has been applied to the Z axis.
 
+#### BED_MESH_CHECK
+`BED_MESH_CHECK [MAX_DEVIATION=<value>] [MAX_SLOPE=<value>]`: Validates the
+current bed mesh against specified criteria. If MAX_DEVIATION is specified,
+checks that the difference between the highest and lowest mesh points does not
+exceed the provided value. If MAX_SLOPE is specified, checks that the maximum
+slope between adjacent mesh points does not exceed the provided value (in mm/mm).
+The command will raise an error if any specified check fails, or display a message
+confirming the mesh is valid if all checks pass. If no parameters are specified,
+the command will list the available validation checks.
+
 ### [bed_screws]
 
 The following commands are available when the
@@ -1155,9 +1165,11 @@ Saves the currently loaded profile of the specified heater to the config under
 the given name.
 
 `PID_PROFILE REMOVE=<profile_name> HEATER=<heater_name>`:
-Removes the given profile from the profiles List for the current session and config if SAVE_CONFIG is issued afterwards.
+Removes the given profile from the profiles List for the current session and
+config if SAVE_CONFIG is issued afterwards.
 
-`PID_PROFILE SET_VALUES=<profile_name> HEATER=<heater_name> TARGET=<target_temp> TOLERANCE=<tolerance>
+`PID_PROFILE SET_VALUES=<profile_name> HEATER=<heater_name> TARGET=<target_temp>
+TOLERANCE=<tolerance>
 CONTROL=<control_type> KP=<kp> KI=<ki> KD=<kd> [RESET_TARGET=0|1] [LOAD_CLEAN=0|1]`:
 Creates a new profile with the given PID values, CONTROL must either be `pid` or
 `pid_v`, TOLERANCE and TARGET must be specified to create a valid profile,

--- a/docs/Kalico_Additions.md
+++ b/docs/Kalico_Additions.md
@@ -19,6 +19,7 @@
 ## Enhanced behavior
 
 - [`canbus_query.py`](./CANBUS.md#finding-the-canbus_uuid-for-new-micro-controllers) now responds with all Kalico devices, even after they've been assigned a node_id.
+- [`BED_MESH_CHECK`](./G-Codes.md#bed_mesh_check) validates the current bed mesh against specified criteria, allowing you to check maximum deviation and slope between adjacent points before printing.
 
 ## New Kalico Modules
 

--- a/test/klippy/bed_mesh_check.cfg
+++ b/test/klippy/bed_mesh_check.cfg
@@ -1,0 +1,76 @@
+# Test config for bltouch
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[bltouch]
+sensor_pin: PC7
+control_pin: PC5
+z_offset: 1.15
+
+[bed_mesh]
+mesh_min: 10,10
+mesh_max: 180,180
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/bed_mesh_check.test
+++ b/test/klippy/bed_mesh_check.test
@@ -1,0 +1,20 @@
+# Test case for bed_mesh_check command
+CONFIG bed_mesh_check.cfg
+DICTIONARY atmega2560.dict
+
+# Generate a mesh
+G28
+BED_MESH_CALIBRATE PROFILE=test_mesh
+
+# Test BED_MESH_CHECK with no parameters (should list available checks)
+BED_MESH_CHECK
+
+# Test MAX_DEVIATION check with passing value
+BED_MESH_CHECK MAX_DEVIATION=10.0
+
+# Test SLOPE_MAX check with passing value
+BED_MESH_CHECK SLOPE_MAX=1.0
+
+# Test both checks together with passing values
+BED_MESH_CHECK MAX_DEVIATION=10.0 SLOPE_MAX=1.0
+


### PR DESCRIPTION
This pull request introduces a new BED_MESH_CHECK command that allows users to validate their bed mesh against specific criteria. This feature helps identify potential issues with bed levelling before starting a print.

- New BED_MESH_CHECK command with two validation parameters:
  - MAX_DEVIATION: Validates that the difference between the highest and lowest mesh points doesn't exceed the specified value
  - MAX_SLOPE: Validates that the maximum slope between adjacent mesh points doesn't exceed the specified value (in mm/mm)

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
