### PR TITLE
Allow negative "switch_offset" for the auto Z offset

### DIFF
--- a/klippy/extras/z_calibration.py
+++ b/klippy/extras/z_calibration.py
@@ -17,7 +17,7 @@ class ZCalibrationHelper:
         self.position_z_endstop = None
         self.config = config
         self.printer = config.get_printer()
-        self.switch_offset = config.getfloat("switch_offset", 0.0, above=0.0)
+        self.switch_offset = config.getfloat("switch_offset", 0.0)
         # max_deviation is deprecated
         self.max_deviation = config.getfloat("max_deviation", None, above=0.0)
         config.deprecate("max_deviation")


### PR DESCRIPTION
Don't ask me why, but I need a negative switch offset, and there is a issue on the original plugin for the same reason: https://github.com/protoloft/klipper_z_calibration/issues/152

Anyway it is aligned with "Our goal is to support features and behavior that could be "risky" if used incorrectly." :)

p.s.: Tested and running on my printer. 

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
