### PR TITLE
docs - update resonances docs to include matplotlib

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -207,12 +207,12 @@ software dependencies not installed by default. First, run on your Raspberry Pi
 the following commands:
 ```
 sudo apt update
-sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-dev
+sudo apt install libatlas-base-dev libopenblas-dev
 ```
 
 Next, in order to install NumPy in the Kalico environment, run the command:
 ```
-~/klippy-env/bin/pip install -v numpy
+~/klippy-env/bin/pip install -v numpy matplotlib
 ```
 Note that, depending on the performance of the CPU, it may take *a lot*
 of time, up to 10-20 minutes. Be patient and wait for the completion of


### PR DESCRIPTION
In https://github.com/KalicoCrew/kalico/pull/536 we updated the commands to use the klippy venv, but we forgot to update the commands to install the required modules

