### PR TITLE
console - encode the message before sending it

### DIFF
--- a/scripts/console.py
+++ b/scripts/console.py
@@ -286,7 +286,7 @@ class KeyboardReader:
             if msg is None:
                 continue
             try:
-                self.ser.send(msg)
+                self.ser.send(msg.encode("utf-8"))
             except msgproto.error as e:
                 self.output("Error: %s" % (str(e),))
         self.data = kbdlines[-1]


### PR DESCRIPTION
Fixes `TypeError: initializer for ctype 'uint8_t *' must be a bytes or list or tuple, not str`