### PR TITLE
Enable non-critical MCU support for CAN devices

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -63,7 +63,7 @@ serial:
 #is_non_critical: False
 #   Setting this to True will allow the mcu to be disconnected and
 #   reconnected at will without errors. Helpful for USB-accelerometer boards
-#   and USB-probes
+#   and USB/CAN-probes
 ```
 
 ### [mcu my_extra_mcu]

--- a/klippy/extras/canbus_stats.py
+++ b/klippy/extras/canbus_stats.py
@@ -69,6 +69,20 @@ class PrinterCANBusStats:
         prev_rx = self.status["rx_error"]
         prev_tx = self.status["tx_error"]
         prev_retries = self.status["tx_retries"]
+
+        # skip querying disconnected MCU and maintain previous status
+        if (
+            self.mcu.non_critical_disconnected
+            or self.get_canbus_status_cmd is None
+        ):
+            self.status = {
+                "rx_error": prev_rx,
+                "tx_error": prev_tx,
+                "tx_retries": prev_retries,
+                "bus_state": "disconnected",
+            }
+            return self.reactor.monotonic() + 1.0
+
         if prev_rx is None:
             prev_rx = prev_tx = prev_retries = 0
         params = self.get_canbus_status_cmd.send()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -813,8 +813,6 @@ class MCU:
             self.non_critical_recon_timer = self._reactor.register_timer(
                 self.non_critical_recon_event
             )
-            if canbus_uuid:
-                raise error("CAN MCUs can't be non-critical yet!")
         self.non_critical_disconnected = False
         self._non_critical_reconnect_event_name = (
             f"danger:non_critical_mcu_{self.get_name()}:reconnected"
@@ -1143,16 +1141,15 @@ class MCU:
         self._printer.set_rollover_info(self._name, log_info, log=False)
 
     def _check_serial_exists(self):
-        # if self._canbus_iface is not None:
-        #     cbid = self._printer.lookup_object("canbus_ids")
-        #     nodeid = cbid.get_nodeid(self._serialport)
-        #     # self._serial.check_canbus_connect is not functional yet
-        #     return self._serial.check_canbus_connect(
-        #         self._serialport, nodeid, self._canbus_iface
-        #     )
-        # else:
-        rts = self._restart_method != "cheetah"
-        return self._serial.check_connect(self._serialport, self._baud, rts)
+        if self._canbus_iface is not None:
+            cbid = self._printer.lookup_object("canbus_ids")
+            nodeid = cbid.get_nodeid(self._serialport)
+            return self._serial.check_canbus_connect(
+                self._serialport, nodeid, self._canbus_iface
+            )
+        else:
+            rts = self._restart_method != "cheetah"
+            return self._serial.check_connect(self._serialport, self._baud, rts)
 
     def _mcu_identify(self):
         if self.is_non_critical and not self._check_serial_exists():


### PR DESCRIPTION
This PR enables non-critical MCU support for CAN bus devices, allowing them to be disconnected and reconnected without causing errors or requiring a Klipper restart. Previously, this functionality was limited to USB devices, but with the changes from #391 that allowed querying of already-assigned devices, we can now extend this feature to CAN bus devices as well.

I tested:
- Boot with the device already connected
- Disconnecting and reconnecting devices during operation
- MCU temperature sensors
- ADXL queries before disconnection, while disconnected, and after reconnection

I did not test:
- Multiple devices on the same bus