### PR TITLE
Add support for multiple accelerometer chips in resonance_tester config

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2257,21 +2257,26 @@ section of the measuring resonances guide for more information on
 #   resonances at. At least one point is required. Make sure that all
 #   points with some safety margin in XY plane (~a few centimeters)
 #   are reachable by the toolhead.
+#accel_chips:
+#   A comma-separated list of accelerometer chips to use for measurements.
+#   For example, "accel_chips: adxl345 head, adxl345 bed" would use two
+#   separate accelerometer chips. This parameter has priority over the
+#   other accelerometer parameters if specified.
 #accel_chip:
 #   A name of the accelerometer chip to use for measurements. If
 #   adxl345 chip was defined without an explicit name, this parameter
 #   can simply reference it as "accel_chip: adxl345", otherwise an
 #   explicit name must be supplied as well, e.g. "accel_chip: adxl345
-#   my_chip_name". Either this, or the next two parameters must be
-#   set.
+#   my_chip_name". Either this, 'accel_chips', or the next two parameters
+#   must be set.
 #accel_chip_x:
 #accel_chip_y:
 #   Names of the accelerometer chips to use for measurements for each
 #   of the axis. Can be useful, for instance, on bed slinger printer,
 #   if two separate accelerometers are mounted on the bed (for Y axis)
 #   and on the toolhead (for X axis). These parameters have the same
-#   format as 'accel_chip' parameter. Only 'accel_chip' or these two
-#   parameters must be provided.
+#   format as 'accel_chip' parameter. Only one of 'accel_chips', 'accel_chip',
+#   or these two parameters must be provided.
 #max_smoothing:
 #   Maximum input shaper smoothing to allow for each axis during shaper
 #   auto-calibration (with 'SHAPER_CALIBRATE' command). By default no

--- a/docs/Kalico_Additions.md
+++ b/docs/Kalico_Additions.md
@@ -21,6 +21,7 @@
 - [`canbus_query.py`](./CANBUS.md#finding-the-canbus_uuid-for-new-micro-controllers) now responds with all Kalico devices, even after they've been assigned a node_id.
 - Input shaper calibration now warns about active fans that may affect measurement accuracy.
 - [`BED_MESH_CHECK`](./G-Codes.md#bed_mesh_check) validates the current bed mesh against specified criteria, allowing you to check maximum deviation and slope between adjacent points before printing.
+- [`[resonance_tester]`](./Config_Reference.md#resonance_tester) now supports multiple accelerometer chips via the new `accel_chips` parameter, allowing data from multiple accelerometers to be combined for more accurate input shaper calibration.
 
 ## New Kalico Modules
 

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -294,15 +294,31 @@ class ResonanceTester:
         self.move_speed = config.getfloat("move_speed", 50.0, above=0.0)
         self.generator = SweepingVibrationsTestGenerator(config)
         self.executor = ResonanceTestExecutor(config)
-        if not config.get("accel_chip_x", None):
-            self.accel_chip_names = [("xy", config.get("accel_chip").strip())]
-        else:
+
+        accel_chips = config.get("accel_chips", None)
+        accel_chip = config.get("accel_chip", None)
+        accel_chip_x = config.get("accel_chip_x", None)
+        accel_chip_y = config.get("accel_chip_y", None)
+
+        # priority: accel_chips > accel_chip_x/y > accel_chip
+        if accel_chips is not None:
+            # Parse comma-separated list of chips
+            chip_names = [chip.strip() for chip in accel_chips.split(",")]
+            self.accel_chip_names = [("xy", chip) for chip in chip_names]
+        elif accel_chip_x is not None:
             self.accel_chip_names = [
-                ("x", config.get("accel_chip_x").strip()),
-                ("y", config.get("accel_chip_y").strip()),
+                ("x", accel_chip_x.strip()),
+                ("y", accel_chip_y.strip()),
             ]
             if self.accel_chip_names[0][1] == self.accel_chip_names[1][1]:
                 self.accel_chip_names = [("xy", self.accel_chip_names[0][1])]
+        elif accel_chip is not None:
+            self.accel_chip_names = [("xy", accel_chip.strip())]
+        else:
+            raise config.error(
+                "No accelerometer chips configured. At least one of accel_chips, accel_chip, or accel_chip_x/accel_chip_y must be specified."
+            )
+
         self.max_smoothing = config.getfloat("max_smoothing", None, minval=0.05)
         self.probe_points = config.getlists(
             "probe_points", seps=(",", "\n"), parser=float, count=3
@@ -327,10 +343,18 @@ class ResonanceTester:
         self.printer.register_event_handler("klippy:connect", self.connect)
 
     def connect(self):
-        self.accel_chips = [
-            (chip_axis, self.printer.lookup_object(chip_name))
-            for chip_axis, chip_name in self.accel_chip_names
-        ]
+        self.accel_chips = []
+        for chip_axis, chip_name in self.accel_chip_names:
+            try:
+                chip = self.printer.lookup_object(chip_name)
+                self.accel_chips.append((chip_axis, chip))
+            except self.printer.config_error as e:
+                logging.exception(
+                    "Error looking up accelerometer chip '%s': %s",
+                    chip_name,
+                    str(e),
+                )
+                raise
 
     def _run_test(
         self,
@@ -392,7 +416,7 @@ class ResonanceTester:
                             raw_name_suffix,
                             axis,
                             point if len(test_points) > 1 else None,
-                            chip_name if accel_chips is not None else None,
+                            chip_name,
                         )
                         aclient.write_to_file(raw_name)
                         gcmd.respond_info(
@@ -414,12 +438,17 @@ class ResonanceTester:
         return calibration_data
 
     def _parse_chips(self, accel_chips):
+        if not accel_chips:
+            return None
         parsed_chips = []
         for chip_name in accel_chips.split(","):
+            chip_name = chip_name.strip()
+            if not chip_name:
+                continue
             if "adxl345" in chip_name:
-                chip_lookup_name = chip_name.strip()
+                chip_lookup_name = chip_name
             else:
-                chip_lookup_name = "adxl345 " + chip_name.strip()
+                chip_lookup_name = "adxl345 " + chip_name
             chip = self.printer.lookup_object(chip_lookup_name)
             parsed_chips.append(chip)
         return parsed_chips

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -316,7 +316,8 @@ class ResonanceTester:
             self.accel_chip_names = [("xy", accel_chip.strip())]
         else:
             raise config.error(
-                "No accelerometer chips configured. At least one of accel_chips, accel_chip, or accel_chip_x/accel_chip_y must be specified."
+                "No accelerometer chips configured. At least one of accel_chips,"
+                " accel_chip, or accel_chip_x/accel_chip_y must be specified."
             )
 
         self.max_smoothing = config.getfloat("max_smoothing", None, minval=0.05)


### PR DESCRIPTION
This PR enhances the `resonance_tester` module to support multiple accelerometer chips in the configuration section while maintaining backward compatibility. It adds a new `accel_chips` parameter that accepts a comma-separated list of accelerometer chips.

The implementation maintains the existing behavior of combining data from all chips for resonance analysis and input shaper calibration, while ensuring that raw data files are properly labeled with chip names.