### PR TITLE
Avoid run-time division in stm32 hard_pwm code

### DIFF
--- a/src/stm32/gpio.h
+++ b/src/stm32/gpio.h
@@ -24,7 +24,7 @@ uint8_t gpio_in_read(struct gpio_in g);
 struct gpio_pwm {
   void *reg;
 };
-struct gpio_pwm gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val);
+struct gpio_pwm gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint32_t val);
 void gpio_pwm_write(struct gpio_pwm g, uint32_t val);
 
 struct gpio_adc {

--- a/src/stm32/hard_pwm.c
+++ b/src/stm32/hard_pwm.c
@@ -11,7 +11,7 @@
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
 
-#define MAX_PWM 255
+#define MAX_PWM (256 + 1)
 DECL_CONSTANT("PWM_MAX", MAX_PWM);
 
 struct gpio_pwm_info {
@@ -275,7 +275,8 @@ static const struct gpio_pwm_info pwm_regs[] = {
 };
 
 struct gpio_pwm
-gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val){
+gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint32_t val)
+{
     // Find pin in pwm_regs table
     const struct gpio_pwm_info* p = pwm_regs;
     for (;; p++) {

--- a/src/stm32/hard_pwm.c
+++ b/src/stm32/hard_pwm.c
@@ -291,10 +291,10 @@ gpio_pwm_setup(uint8_t pin, uint32_t cycle_time, uint8_t val){
     if (pclock_div > 1)
         pclock_div /= 2; // Timers run at twice the normal pclock frequency
     uint32_t prescaler = cycle_time / (pclock_div * (MAX_PWM - 1));
-    if (prescaler > 0) {
-        prescaler -= 1;
-    } else if (prescaler > UINT16_MAX) {
+    if (prescaler > UINT16_MAX) {
         prescaler = UINT16_MAX;
+    } else if (prescaler > 0) {
+        prescaler -= 1;
     }
 
     gpio_peripheral(p->pin, p->function, 0);


### PR DESCRIPTION
Port of https://github.com/Klipper3d/klipper/pull/6892

> The stm32 hard_pwm.c code implements a run-time division to calculate the cycle time. It's possible to avoid this division on the older chips by using a slightly different MAX_PWM value (257 instead of 255). The host python code should automatically adjust to that new value.


## Checklist

- [x] pr title makes sense
- [~] added a test case if possible
- [~] if new feature, added to the readme
- [ ] ci is happy and green
