### PR TITLE
stm32: Add support for additional i2c bus

### DIFF
--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -32,6 +32,8 @@ DECL_ENUMERATION("i2c_bus", "i2c2a", 4);
 DECL_CONSTANT_STR("BUS_PINS_i2c2a", "PH4,PH5");
 DECL_ENUMERATION("i2c_bus", "i2c3a", 5);
 DECL_CONSTANT_STR("BUS_PINS_i2c3a", "PH7,PH8");
+DECL_ENUMERATION("i2c_bus", "i2c2_PF1_PF0", 6);
+DECL_CONSTANT_STR("BUS_PINS_i2c2_PF1_PF0", "PF1,PF0");
   #endif
 #endif
 
@@ -44,6 +46,7 @@ static const struct i2c_info i2c_bus[] = {
   #if CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4x5
     { I2C2, GPIO('H', 4), GPIO('H', 5) },
     { I2C3, GPIO('H', 7), GPIO('H', 8) },
+    { I2C2, GPIO('F', 1), GPIO('F', 0) },
   #endif
 #endif
 };


### PR DESCRIPTION
Port of https://github.com/Klipper3d/klipper/pull/6876

> This configuration is used by the Prusa xBuddy board (an stm32f427, which is very close to the stm32f429) for its peripheral I2C port, which is where the Hackerboard (GPIO expansion board) is connected.
>
> There is one additional I2C configuration on the stm32f4x5 boards which is not yet included in the Klipper code, which looks like it's I2C3 on PA8 and PC9, but I'm unable to test that on my hardware.

## Checklist

- [x] pr title makes sense
- [~] added a test case if possible
- [~] if new feature, added to the readme
- [ ] ci is happy and green
