### PR TITLE
Hack docker progress for ci builds so that ::group: is recognized

### DIFF
--- a/.github/workflows/ci-build_test.yaml
+++ b/.github/workflows/ci-build_test.yaml
@@ -35,7 +35,13 @@ jobs:
 
       - name: Test Klipper build (changes to the firmware)
         if: steps.changes.outputs.klipper == 'true'
-        run: docker build -f scripts/Dockerfile-build -t dangerklippers/klipper-build:latest .
+        run: |
+          apt-get update && apt-get install -y expect
+          # Clean up docker output so that github ::group: instructions
+          # get recognized
+          unbuffer docker build --progress=plain -f scripts/Dockerfile-build \
+            -t dangerklippers/klipper-build:latest . 2>&1 \
+            | sed -u -E 's/^#[0-9]+ [0-9.]+ ?//g'
 
       - name: Ensure scripts/klippy-dependencies.txt is up to date
         if: steps.changes.outputs.dependencies == 'true'

--- a/.github/workflows/ci-build_test.yaml
+++ b/.github/workflows/ci-build_test.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Test Klipper build (changes to the firmware)
         if: steps.changes.outputs.klipper == 'true'
         run: |
-          apt-get update && apt-get install -y expect
+          sudo apt-get update && sudo apt-get install -y expect
           # Clean up docker output so that github ::group: instructions
           # get recognized
           unbuffer docker build --progress=plain -f scripts/Dockerfile-build \

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,3 +23,4 @@ src-$(CONFIG_WANT_HX71X) += sensor_hx71x.c
 src-$(CONFIG_WANT_ADS1220) += sensor_ads1220.c
 src-$(CONFIG_WANT_SENSOR_ANGLE) += sensor_angle.c
 src-$(CONFIG_NEED_SENSOR_BULK) += sensor_bulk.c
+


### PR DESCRIPTION
Turns out all the ::group: bits are already there in the output, but docker
build is putting step numbers and timing in front. --progress=plain should
prevent that.


