### PR TITLE
Dockable_probe : Insert/detach z position, fix typo

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2494,7 +2494,7 @@ control_pin:
 #   See the "probe" section for information on these parameters.
 ```
 
-### [dockable_probe]
+### ⚠️ [dockable_probe]
 
 Certain probes are magnetically coupled to the toolhead and stowed
 in a dock when not in use. One should define this section instead

--- a/docs/Dockable_Probe.md
+++ b/docs/Dockable_Probe.md
@@ -197,6 +197,26 @@ detach_position: 50, 150
 z_hop: 15
 ```
 
+### Additional G-codes
+
+If your probe has special setup/teardown steps (e.g., moving a servo), you can use the following configuration options to execute custom G-code before or after attaching/detaching the probe instead of overwriting [individual movements](#individual-movements) commands:
+
+- `pre_attach_gcode:`\
+  _Default Value: None_\
+  G-code to execute immediately before the probe is attached.
+
+- `post_attach_gcode:`\
+  _Default Value: None_\
+  G-code to execute immediately after the probe is attached.
+
+- `pre_detach_gcode:`\
+  _Default Value: None_\
+  G-code to execute immediately before the probe is detached.
+
+- `post_detach_gcode:`\
+  _Default Value: None_\
+  G-code to execute immediately after the probe is detached.
+
 ### Homing
 
 No configuration specific to the dockable probe is required. However, when
@@ -363,7 +383,7 @@ These commands are useful during setup to prevent the full attach/detach
 sequence from crashing into the bed or damaging the probe/dock.
 
 If your probe has special setup/teardown steps (e.g. moving a servo),
-accommodating that could be accomplished by overriding these gcodes.
+accommodating that could be accomplished by using [additional G_codes](#additional-g-codes) in configuration or overriding the following gcodes.
 
 `MOVE_TO_APPROACH_PROBE`
 

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -33,7 +33,7 @@ Please see {0}.md and config_Reference.md.
 
 VIRTUAL_Z_ENDSTOP_ERROR = """
 DockableProbe cannot be used as Z endstop if a z position
-is defined in approach/dock/extract/insert/detach position."
+is defined in approach/dock/extract."
 """
 
 
@@ -385,8 +385,6 @@ class DockableProbe:
             self.approach_position,
             self.dock_position,
             self.extract_position,
-            self.insert_position,
-            self.detach_position,
         ]
         if self in endstops and any(pos[2] is not None for pos in positions):
             raise self.printer.config_error(VIRTUAL_Z_ENDSTOP_ERROR)
@@ -700,10 +698,10 @@ class DockableProbe:
     def _get_closest_exitpoint(self, point1, point2):
         cx, cy = self.dock_position[:2]
         # Choose point2 if point1 is the dock position
-        if point1[:2] != (cx, cy):
+        if point1[:2] != [cx, cy]:
             dx, dy = point1[0] - cx, point1[1] - cy
             reference_point = point1[:2]
-        elif point2[:2] != (cx, cy):
+        elif point2[:2] != [cx, cy]:
             dx, dy = point2[0] - cx, point2[1] - cy
             reference_point = point2[:2]
         else:


### PR DESCRIPTION
According this reports https://discord.com/channels/1297243471442214913/1297243471442214918/1362423782463246366
Allow z position for insert and detach position when probe is used as z endstop #616 , Z movements could also be done by `pre/post_attach/detach_gcode`

fix a typo for #650  

complete doc for pre/post_gcodes

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
