### PR TITLE
docs: updated kiauh steps for KIAUH v4 or v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,16 @@ sudo systemctl restart klipper
 
 For users that are not comfortable using Git directly, [KIAUH v6](https://github.com/dw-0/kiauh) is able to use custom repositories.
 
-To do this, add the Kalico repo to KIAUH's custom repository config with the following steps:
+To do this, add the Kalico repo to KIAUH's custom repository config depending on your KIAUH version:
 
-1. Setup kalico as repository in KIAUH
+#### Setup Kalico as repository in KIAUH v6
 - `cd ~/kiauh`
 - `cp default.kiauh.cfg kiauh.cfg`
 - `nano kiauh.cfg`
 - add `https://github.com/KalicoCrew/kalico, main` for the main branch
 
     or `https://github.com/KalicoCrew/kalico, bleeding-edge-v2` for the bleeding edge branch
-- CTRL-X to save and exit 
-
-2. Select Kalico in KIAUH
+- CTRL-X to save and exit
 
 From the KIAUH menu select:
 
@@ -196,6 +194,21 @@ From the KIAUH menu select:
 
 -   Select Kalico from the list
 
+#### Setup Kalico as repository in KIAUH v4
+- Add the custom repo to your `klipper_repos.txt` in the `~kiauh` directory
+- `echo "https://github.com/KalicoCrew/kalico,main" >> ~/kiauh/klipper_repos.txt` for the main branch
+
+  or `echo "https://github.com/KalicoCrew/kalico,bleeding-edge-v2" >> ~/kiauh/klipper_repos.txt` for the bleeding edge branch
+
+From the KIAUH menu select:
+
+-   [6] Settings  
+-   1\) Set custom Klipper repository
+
+-   Select Kalico from the list
+
+
+*Repo changes will not persist across KIAUH versions.*
 
 ### Option 3. Adding a git-remote to the existing installation
 Can switch back to mainline klipper at any time via a `git checkout upstream_main`


### PR DESCRIPTION
Added additional instructions for KIAUH v4 and KIAUH v6 as v6 is not in full release yet. Due to changes in the KIAUH rewrite to v6, if you add the repos to your klipper_repos.txt copying from the latest readme update for using v4. You add an extra space between the repo link and branch to the .kiauh.ini after selecting the new repo and KIAUH will fail to load until that is corrected.

_Enter a good description of whats being changed and WHY

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
