### PR TITLE
rp2040: define spi bus on pins 12,11,10

### DIFF
--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -29,6 +29,8 @@ DECL_ENUMERATION("spi_bus", "spi1_gpio12_gpio15_gpio14", 6);
 DECL_CONSTANT_STR("BUS_PINS_spi1_gpio12_gpio15_gpio14", "gpio12,gpio15,gpio14");
 DECL_ENUMERATION("spi_bus", "spi1_gpio24_gpio27_gpio26", 7);
 DECL_CONSTANT_STR("BUS_PINS_spi1_gpio24_gpio27_gpio26", "gpio24,gpio27,gpio26");
+DECL_ENUMERATION("spi_bus", "spi1_gpio12_gpio11_gpio10", 8);
+DECL_CONSTANT_STR("BUS_PINS_spi1_gpio12_gpio11_gpio10", "gpio12,gpio11,gpio10");
 
 //Deprecated "spi0a" style mappings
 DECL_ENUMERATION("spi_bus", "spi0a", 0);
@@ -65,6 +67,7 @@ static const struct spi_info spi_bus[] = {
     {spi1_hw, 8,  11, 10, RESETS_RESET_SPI1_BITS},
     {spi1_hw, 12, 15, 14, RESETS_RESET_SPI1_BITS},
     {spi1_hw, 24, 27, 26, RESETS_RESET_SPI1_BITS},
+    {spi1_hw, 12, 11, 10, RESETS_RESET_SPI1_BITS},
 };
 
 struct spi_config


### PR DESCRIPTION
Mellow FLY SHT36 Pro toolboard uses those pins

Klipper PR: https://github.com/Klipper3d/klipper/pull/6867
