### PR TITLE
axis_twist_compensation: Fix AttributeError on klippy connect state

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -152,8 +152,7 @@ class Calibrater:
     def _handle_connect(self):
         self.probe = self.printer.lookup_object("probe", None)
         if self.probe is None:
-            config = self.printer.lookup_object("configfile")
-            raise config.error(
+            raise self.printer.config_error(
                 "AXIS_TWIST_COMPENSATION requires [probe] to be defined"
             )
         self.lift_speed = self.probe.get_lift_speed()


### PR DESCRIPTION
axis_twist_compensation on klippy:connect state checks for the presence of the 'probe' object, but if it is missing, it causes an error in the 'PrinterConfig' object, which does not have such an attribute.

Klipper PR https://github.com/Klipper3d/klipper/pull/6881