### PR TITLE
docker image: remove unused packages

### DIFF
--- a/scripts/Dockerfile-build
+++ b/scripts/Dockerfile-build
@@ -12,7 +12,6 @@ RUN apt update \
       python3 python3-dev python3-venv libffi-dev build-essential \
       gcc-avr avr-libc \
       libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi \
-      pv libmpfr-dev libgmp-dev libmpc-dev texinfo bison flex \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -7,7 +7,6 @@ set -eu
 # Paths to tools installed by ci-install.sh
 MAIN_DIR=${PWD}
 BUILD_DIR=/ci_build
-export PATH=${BUILD_DIR}/pru-gcc/bin:${PATH}
 export PATH=${BUILD_DIR}/or1k-linux-musl-cross/bin:${PATH}
 PYTHON=${BUILD_DIR}/python-env/bin/python
 


### PR DESCRIPTION
As per https://github.com/Klipper3d/klipper/pull/6887 the packages removed in this PR were only used to build pru gcc and we have removed that from the ci long time ago.