### PR TITLE
Software SPI: make it respect rate limits

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -46,6 +46,7 @@ class MCU_SPI:
     ):
         self.mcu = mcu
         self.bus = bus
+        self.speed = speed
         # Config SPI object (set all CS pins high before spi_set_bus commands)
         self.oid = mcu.create_oid()
         if pin is None:
@@ -56,11 +57,17 @@ class MCU_SPI:
                 % (self.oid, pin, cs_active_high)
             )
         # Generate SPI bus config message
+        self.config_fmt_ticks = None
         if sw_pins is not None:
             self.config_fmt = (
                 "spi_set_software_bus oid=%d"
                 " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d"
                 % (self.oid, sw_pins[0], sw_pins[1], sw_pins[2], mode, speed)
+            )
+            self.config_fmt_ticks = (
+                "spi_set_sw_bus oid=%d"
+                " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d pulse_ticks=%%d"
+                % (self.oid, sw_pins[0], sw_pins[1], sw_pins[2], mode)
             )
         else:
             self.config_fmt = (
@@ -91,6 +98,14 @@ class MCU_SPI:
         if "%" in self.config_fmt:
             bus = resolve_bus_name(self.mcu, "spi_bus", self.bus)
             self.config_fmt = self.config_fmt % (bus,)
+        if self.config_fmt_ticks:
+            if self.mcu.try_lookup_command(
+                "spi_set_sw_bus oid=%c miso_pin=%u "
+                "mosi_pin=%u sclk_pin=%u "
+                "mode=%u pulse_ticks=%u"
+            ):
+                pulse_ticks = self.mcu.seconds_to_clock(1.0 / self.speed)
+                self.config_fmt = self.config_fmt_ticks % (pulse_ticks,)
         self.mcu.add_config_cmd(self.config_fmt)
         self.spi_send_cmd = self.mcu.lookup_command(
             "spi_send oid=%c data=%*s", cq=self.cmd_queue

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -117,9 +117,11 @@ SPI_CFG_CMDS = (
     "config_spi oid=%d pin=%s",  # Original
 )
 SPI_BUS_CMD = "spi_set_bus oid=%d spi_bus=%s mode=%d rate=%d"
-SW_SPI_BUS_CMD = (
-    "spi_set_software_bus oid=%d "
-    "miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d"
+SW_SPI_BUS_CMDS = (
+    "spi_set_sw_bus oid=%d miso_pin=%s mosi_pin=%s "
+    "sclk_pin=%s mode=%d pulse_ticks=%d",
+    "spi_set_software_bus oid=%d miso_pin=%s mosi_pin=%s "
+    "sclk_pin=%s mode=%d rate=%d",
 )
 SPI_SEND_CMD = "spi_send oid=%c data=%*s"
 SPI_XFER_CMD = "spi_transfer oid=%c data=%*s"
@@ -1451,6 +1453,8 @@ class MCUConnection:
         )
         pin_enums = self.enumerations.get("pin")
         if bus == "swspi":
+            mcu_freq = self.clocksync.print_time_to_clock(1)
+            pulse_ticks = mcu_freq // SD_SPI_SPEED
             cfgpins = self.board_config["spi_pins"]
             pins = [p.strip().upper() for p in cfgpins.split(",") if p.strip()]
             pin_err_msg = "Invalid Software SPI Pins: %s" % (cfgpins,)
@@ -1459,36 +1463,29 @@ class MCUConnection:
             for p in pins:
                 if p not in pin_enums:
                     raise SPIFlashError(pin_err_msg)
-            bus_cmd = SW_SPI_BUS_CMD % (
-                SPI_OID,
-                pins[0],
-                pins[1],
-                pins[2],
-                SPI_MODE,
-                SD_SPI_SPEED,
-            )
+            bus_cmds = [
+                SW_SPI_BUS_CMDS[0]
+                % (SPI_OID, pins[0], pins[1], pins[2], SPI_MODE, pulse_ticks),
+                SW_SPI_BUS_CMDS[1]
+                % (SPI_OID, pins[0], pins[1], pins[2], SPI_MODE, SD_SPI_SPEED),
+            ]
         else:
             if bus not in bus_enums:
                 raise SPIFlashError("Invalid SPI Bus: %s" % (bus,))
-            bus_cmd = SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, SD_SPI_SPEED)
+            bus_cmds = SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, SD_SPI_SPEED)
         if cs_pin not in pin_enums:
             raise SPIFlashError("Invalid CS Pin: %s" % (cs_pin,))
-        cfg_cmds = [ALLOC_OIDS_CMD % (1,), bus_cmd]
+        cfg_cmds = [
+            ALLOC_OIDS_CMD % (1,),
+        ]
         self._serial.send(cfg_cmds[0])
         spi_cfg_cmds = [
             SPI_CFG_CMDS[0] % (SPI_OID, cs_pin, False),
             SPI_CFG_CMDS[1] % (SPI_OID, cs_pin),
         ]
-        for cmd in spi_cfg_cmds:
-            try:
-                self._serial.send(cmd)
-            except self.proto_error:
-                if cmd == spi_cfg_cmds[-1]:
-                    raise
-            else:
-                cfg_cmds.insert(1, cmd)
-                break
-        self._serial.send(bus_cmd)
+        cfg_cmds.append(self._try_send_command(spi_cfg_cmds))
+        cfg_cmds.append(self._try_send_command(bus_cmds))
+        self._try_send_command(cfg_cmds)
         config_crc = zlib.crc32("\n".join(cfg_cmds).encode()) & 0xFFFFFFFF
         self._serial.send(FINALIZE_CFG_CMD % (config_crc,))
         config = self.get_mcu_config()
@@ -1502,6 +1499,16 @@ class MCUConnection:
         except OSError:
             logging.exception("SD Card Mount Failure")
             raise SPIFlashError("Failed to Initialize SD Card. Is it inserted?")
+
+    def _try_send_command(self, cmd_list):
+        for cmd in cmd_list:
+            try:
+                self._serial.send(cmd)
+            except self.proto_error:
+                if cmd == cmd_list[-1]:
+                    raise
+            else:
+                return cmd
 
     def _configure_mcu_sdiobus(self, printfunc=logging.info):
         bus = self.board_config["sdio_bus"]

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -20,11 +20,10 @@ struct spi_software {
 };
 
 void
-command_spi_set_software_bus(uint32_t *args)
+command_spi_set_sw_bus(uint32_t *args)
 {
     uint8_t mode = args[4];
-    uint32_t rate = args[5];
-    uint8_t div = 0;
+    uint32_t pulse_ticks = args[5];
     if (mode > 3)
         shutdown("Invalid spi config");
 
@@ -34,14 +33,12 @@ command_spi_set_software_bus(uint32_t *args)
     ss->mosi = gpio_out_setup(args[2], 0);
     ss->sclk = gpio_out_setup(args[3], 0);
     ss->mode = mode;
-    while (((CONFIG_CLOCK_FREQ/2) >> div) > rate)
-        div++;
-    ss->sck_ticks = 1 << div;
+    ss->sck_ticks = pulse_ticks;
     spidev_set_software_bus(spi, ss);
 }
-DECL_COMMAND(command_spi_set_software_bus,
-             "spi_set_software_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
-             " mode=%u rate=%u");
+DECL_COMMAND(command_spi_set_sw_bus,
+             "spi_set_sw_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
+             " mode=%u pulse_ticks=%u");
 
 void
 spi_software_prepare(struct spi_software *ss)

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -4,7 +4,9 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "autoconf.h"   // CONFIG_*
 #include "board/gpio.h" // gpio_out_setup
+#include "board/misc.h" // timer_read_time
 #include "basecmd.h" // oid_alloc
 #include "command.h" // DECL_COMMAND
 #include "sched.h" // sched_shutdown
@@ -13,6 +15,7 @@
 struct spi_software {
     struct gpio_in miso;
     struct gpio_out mosi, sclk;
+    uint32_t sck_ticks;
     uint8_t mode;
 };
 
@@ -20,6 +23,8 @@ void
 command_spi_set_software_bus(uint32_t *args)
 {
     uint8_t mode = args[4];
+    uint32_t rate = args[5];
+    uint8_t div = 0;
     if (mode > 3)
         shutdown("Invalid spi config");
 
@@ -29,6 +34,9 @@ command_spi_set_software_bus(uint32_t *args)
     ss->mosi = gpio_out_setup(args[2], 0);
     ss->sclk = gpio_out_setup(args[3], 0);
     ss->mode = mode;
+    while (((CONFIG_CLOCK_FREQ/2) >> div) > rate)
+        div++;
+    ss->sck_ticks = 1 << div;
     spidev_set_software_bus(spi, ss);
 }
 DECL_COMMAND(command_spi_set_software_bus,
@@ -41,30 +49,49 @@ spi_software_prepare(struct spi_software *ss)
     gpio_out_write(ss->sclk, ss->mode & 0x02);
 }
 
+static void
+spi_delay(uint32_t end)
+{
+    while (timer_is_before(timer_read_time(), end));
+}
+
 void
 spi_software_transfer(struct spi_software *ss, uint8_t receive_data
                       , uint8_t len, uint8_t *data)
 {
+    uint32_t t1 = ss->sck_ticks >> 1;
+    uint32_t t2 = ss->sck_ticks - t1;
+    uint32_t end = timer_read_time() + t1;
     while (len--) {
         uint8_t outbuf = *data;
         uint8_t inbuf = 0;
-        for (uint_fast8_t i = 0; i < 8; i++) {
-            if (ss->mode & 0x01) {
+        if (ss->mode & 0x01) {
+            for (uint_fast8_t i = 0; i < 8; i++) {
+                spi_delay(end);
                 // MODE 1 & 3
                 gpio_out_toggle(ss->sclk);
                 gpio_out_write(ss->mosi, outbuf & 0x80);
+                end = timer_read_time() + t2;
                 outbuf <<= 1;
-                gpio_out_toggle(ss->sclk);
                 inbuf <<= 1;
+                spi_delay(end);
+                gpio_out_toggle(ss->sclk);
                 inbuf |= gpio_in_read(ss->miso);
-            } else {
+                end = timer_read_time() + t1;
+            }
+        } else {
+            for (uint_fast8_t i = 0; i < 8; i++) {
+                spi_delay(end);
                 // MODE 0 & 2
                 gpio_out_write(ss->mosi, outbuf & 0x80);
-                outbuf <<= 1;
                 gpio_out_toggle(ss->sclk);
+                end = timer_read_time() + t2;
+                outbuf <<= 1;
                 inbuf <<= 1;
+                spi_delay(end);
                 inbuf |= gpio_in_read(ss->miso);
                 gpio_out_toggle(ss->sclk);
+                end = timer_read_time() + t1;
             }
         }
 


### PR DESCRIPTION
Software SPI right now works as fast as it can.
That is fine, but it will be better if it respects the configured limit.

Should fix the too-fast RP2040: https://klipper.discourse.group/t/fly-sht36-pro-rp2040-spi/22586/4

Klipper PR:https://github.com/Klipper3d/klipper/pull/6856