### PR TITLE
docs: Fix typos in installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,14 +1,14 @@
 # Installation
 
-These instructions assume the software will run on a linux based host
-running a Kalico compatible front end. It is recommended that a
-SBC(Small Board Computer) such as a Raspberry Pi or Debian based Linux
+These instructions assume the software will run on a Linux-based host
+running a Kalico-compatible front end. It is recommended that a
+SBC(Small Board Computer) such as a Raspberry Pi or Debian-based Linux
 device be used as the host machine (see the
 [FAQ](FAQ.md#can-i-run-kalico-on-something-other-than-a-raspberry-pi-3)
 for other options).
 
-For the purposes of these instructions host relates to the Linux device and
-mcu relates to the printboard. SBC relates to the term Small Board Computer
+For the purposes of these instructions, host relates to the Linux device and
+mcu relates to the printer board. SBC relates to the term Small Board Computer
 such as the Raspberry Pi.
 
 ## Obtain a Kalico Configuration File
@@ -56,12 +56,12 @@ make an informed decision.
 ## Obtaining an OS image for SBC's
 
 There are many ways to obtain an OS image for Kalico for SBC use, most depend on
-what front end you wish to use. Some manafactures of these SBC boards also provide
-their own Kalico-centric images.
+what front end you wish to use. Some manufacturers of these SBC boards also provide
+their own Klipper-centric images, which are also compatible with Kalico.
 
-The two main Moonraker based front ends are [Fluidd](https://docs.fluidd.xyz/)
+The two main Moonraker-based front ends are [Fluidd](https://docs.fluidd.xyz/)
 and [Mainsail](https://docs.mainsail.xyz/), the latter of which has a premade install
-image ["MainsailOS"](https://docs-os.mainsail.xyz), this has the option for Raspberry Pi
+image ["MainsailOS"](https://docs-os.mainsail.xyz/), this has the option for Raspberry Pi
 and some OrangePi variants.
 
 Fluidd can be installed via KIAUH(Klipper Install And Update Helper), which
@@ -73,12 +73,12 @@ process is explained in [OctoPrint.md](OctoPrint.md)
 ## Installing via KIAUH
 
 Normally you would start with a base image for your SBC, RPiOS Lite for example,
-or in the case of a x86 Linux device, Ubuntu Server. Please note that Desktop
+or in the case of an x86 Linux device, Ubuntu Server. Please note that Desktop
 variants are not recommended due to certain helper programs that can stop some
-Kalico functions working and even mask access to some print boards.
+Kalico functions from working and even mask access to some printer boards.
 
 KIAUH can be used to install Kalico and its associated programs on a variety
-of Linux based systems that run a form of Debian. More information can be found
+of Linux-based systems that run a form of Debian. More information can be found
 at https://github.com/dw-0/kiauh
 
 ## Building and flashing the micro-controller
@@ -106,7 +106,7 @@ make
 If the comments at the top of the
 [printer configuration file](#obtain-a-kalico-configuration-file)
 describe custom steps for "flashing" the final image to the printer
-control board then follow those steps and then proceed to
+control board, then follow those steps and then proceed to
 [configuring OctoPrint](OctoPrint.md#configuring-octoprint-to-use-kalico).
 
 Otherwise, the following steps are often used to "flash" the printer
@@ -132,12 +132,12 @@ run the command again, the missing item will be your print board(see the
 [FAQ](FAQ.md#wheres-my-serial-port) for more information).
 
 For common micro-controllers with STM32 or clone chips, LPC chips and
-others it is usual that these need an initial Kalico flash via SD card.
+others, it is usual that these need an initial Kalico flash via SD card.
 
 When flashing with this method, it is important to make sure that the
 print board is not connected with USB to the host, due to some boards
 being able to feed power back to the board and stopping a flash from
-occuring.
+occurring.
 
 For common micro-controllers using Atmega chips, for example the 2560,
 the code can be flashed with something
@@ -172,7 +172,7 @@ The next step is to copy the
 the host.
 
 Arguably the easiest way to set the Kalico configuration file is using the
-built in editors in Mainsail or Fluidd. These will allow the user to open
+built-in editors in Mainsail or Fluidd. These will allow the user to open
 the configuration examples and save them to be printer.cfg.
 
 Another option is to use a desktop editor that supports editing files
@@ -183,7 +183,7 @@ named "printer.cfg" in the home directory of the pi user
 (ie, /home/pi/printer.cfg).
 
 Alternatively, one can also copy and edit the file directly on the
-host via ssh. That may look something like the following (be
+host via SSH. That may look something like the following (be
 sure to update the command to use the appropriate printer config
 filename):
 
@@ -214,9 +214,9 @@ the `[mcu]` section to look something similar to:
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
 
-After creating and editing the file it will be necessary to issue a
+After creating and editing the file, it will be necessary to issue a
 "restart" command in the command console to load the config. A
-"status" command will report the printer is ready if the Kalico
+"status" command will report that the printer is ready if the Kalico
 config file is successfully read and the micro-controller is
 successfully found and configured.
 
@@ -225,10 +225,10 @@ Kalico to report a configuration error. If an error occurs, make any
 necessary corrections to the printer config file and issue "restart"
 until "status" reports the printer is ready.
 
-Kalico reports error messages via the command console and via pop up in
+Kalico reports error messages via the command console and pop-ups in
 Fluidd and Mainsail. The "status" command can be used to re-report error
-messages. A log is available and usually located in ~/printer_data/logs
-this is named klippy.log
+messages. A log is available and usually located at
+`~/printer_data/logs/klippy.log`.
 
 After Kalico reports that the printer is ready, proceed to the
 [config check document](Config_checks.md) to perform some basic checks


### PR DESCRIPTION
Fixed typos, hyphenation, and minor phrasing for better readability.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6874