### PR TITLE
Add build test for unexpected run-time software divide

### DIFF
--- a/scripts/check-software-div.sh
+++ b/scripts/check-software-div.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Check if a binary appears to have a software library divide operator
+
+CFGFILE="$1"
+ELFOBJ="$2"
+OBJDUMP=objdump
+
+objdump -t ${ELFOBJ} | grep -Eq '\<(__[a-z0-9]*div|__[a-z0-9]*mod)'
+if [ $? -eq 0 ]; then
+
+    if grep -Eq '^CONFIG_HAVE_SOFTWARE_DIVIDE_REQUIRED=y$' ${CFGFILE}; then
+        echo ""
+        echo "Software divide detected and that is normal for this chip"
+        echo ""
+        exit 0
+    fi
+
+    echo ""
+    echo "ERROR: A software run-time divide operation was found"
+    echo ""
+    exit 99
+fi

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -44,6 +44,7 @@ compile()
         make olddefconfig
         make V=1 -j2
         size out/*.elf
+        ./scripts/check-software-div.sh .config out/*.elf
         finish_test mcu_compile "$TARGET"
         cp out/klipper.dict ${1}/$(basename ${TARGET} .config).dict
     done

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -271,11 +271,5 @@ config HAVE_BOOTLOADER_REQUEST
     bool
 config HAVE_LIMITED_CODE_SIZE
     bool
-
-config INLINE_STEPPER_HACK
-    # Enables gcc to inline stepper_event() into the main timer irq handler
+config HAVE_SOFTWARE_DIVIDE_REQUIRED
     bool
-    depends on HAVE_GPIO
-    default y
-
-source "src/extras/Kconfig"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -273,3 +273,11 @@ config HAVE_LIMITED_CODE_SIZE
     bool
 config HAVE_SOFTWARE_DIVIDE_REQUIRED
     bool
+
+config INLINE_STEPPER_HACK
+    # Enables gcc to inline stepper_event() into the main timer irq handler
+    bool
+    depends on HAVE_GPIO
+    default y
+
+source "src/extras/Kconfig"

--- a/src/atsamd/Kconfig
+++ b/src/atsamd/Kconfig
@@ -14,6 +14,9 @@ config ATSAMD_SELECT
     select HAVE_CHIPID
     select HAVE_STEPPER_BOTH_EDGE
     select HAVE_BOOTLOADER_REQUEST
+    select HAVE_LIMITED_CODE_SIZE if FLASH_SIZE < 0x10000
+    # Software divide needed to convert rate to baud in spi.c
+    select HAVE_SOFTWARE_DIVIDE_REQUIRED if MACH_SAMD21
 
 config HAVE_SERCOM
     depends on HAVE_GPIO_I2C || HAVE_GPIO_SPI

--- a/src/hc32f460/Kconfig
+++ b/src/hc32f460/Kconfig
@@ -9,7 +9,9 @@ config HC32F460_SELECT
     select HAVE_GPIO_ADC
     select HAVE_STRICT_TIMING
     select HAVE_GPIO_HARD_PWM
-    select HAVE_STEPPER_BOTH_EDGE
+    select HAVE_STEPPER_OPTIMIZED_BOTH_EDGE
+    # Software divide used by Huada SDK
+    select HAVE_SOFTWARE_DIVIDE_REQUIRED
 
 config BOARD_DIRECTORY
     string

--- a/src/hc32f460/Kconfig
+++ b/src/hc32f460/Kconfig
@@ -9,7 +9,7 @@ config HC32F460_SELECT
     select HAVE_GPIO_ADC
     select HAVE_STRICT_TIMING
     select HAVE_GPIO_HARD_PWM
-    select HAVE_STEPPER_OPTIMIZED_BOTH_EDGE
+    select HAVE_STEPPER_BOTH_EDGE
     # Software divide used by Huada SDK
     select HAVE_SOFTWARE_DIVIDE_REQUIRED
 

--- a/src/lcd_hd44780.c
+++ b/src/lcd_hd44780.c
@@ -23,19 +23,19 @@ struct hd44780 {
  * Transmit functions
  ****************************************************************/
 
-static uint32_t
+static __always_inline uint32_t
 nsecs_to_ticks(uint32_t ns)
 {
     return timer_from_us(ns * 1000) / 1000000;
 }
 
-static inline void
-ndelay(uint32_t nsecs)
+static void
+ndelay(uint32_t ticks)
 {
     if (CONFIG_MACH_AVR)
         // Slower MCUs don't require a delay
         return;
-    uint32_t end = timer_read_time() + nsecs_to_ticks(nsecs);
+    uint32_t end = timer_read_time() + ticks;
     while (timer_is_before(timer_read_time(), end))
         irq_poll();
 }
@@ -54,7 +54,7 @@ hd44780_xmit_bits(uint8_t toggle, struct gpio_out e, struct gpio_out d4
         gpio_out_toggle(d6);
     if (toggle & 0x80)
         gpio_out_toggle(d7);
-    ndelay(230);
+    ndelay(nsecs_to_ticks(230));
     gpio_out_toggle(e);
 }
 
@@ -65,7 +65,7 @@ hd44780_xmit_byte(struct hd44780 *h, uint8_t data)
     struct gpio_out e = h->e, d4 = h->d4, d5 = h->d5, d6 = h->d6, d7 = h->d7;
     hd44780_xmit_bits(h->last ^ data, e, d4, d5, d6, d7);
     h->last = data << 4;
-    ndelay(500 - 230);
+    ndelay(nsecs_to_ticks(500 - 230));
     hd44780_xmit_bits(data ^ h->last, e, d4, d5, d6, d7);
 }
 

--- a/src/lcd_st7920.c
+++ b/src/lcd_st7920.c
@@ -22,19 +22,19 @@ struct st7920 {
  * Transmit functions
  ****************************************************************/
 
-static uint32_t
+static __always_inline uint32_t
 nsecs_to_ticks(uint32_t ns)
 {
     return timer_from_us(ns * 1000) / 1000000;
 }
 
-static inline void
-ndelay(uint32_t nsecs)
+static void
+ndelay(uint32_t ticks)
 {
     if (CONFIG_MACH_AVR)
         // Slower MCUs don't require a delay
         return;
-    uint32_t end = timer_read_time() + nsecs_to_ticks(nsecs);
+    uint32_t end = timer_read_time() + ticks;
     while (timer_is_before(timer_read_time(), end))
         irq_poll();
 }
@@ -53,9 +53,9 @@ st7920_xmit_byte(struct st7920 *s, uint8_t data)
             gpio_out_toggle(sid);
             data = ~data;
         }
-        ndelay(200);
+        ndelay(nsecs_to_ticks(200));
         gpio_out_toggle(sclk);
-        ndelay(200);
+        ndelay(nsecs_to_ticks(200));
         data <<= 1;
         gpio_out_toggle(sclk);
     }

--- a/src/neopixel.c
+++ b/src/neopixel.c
@@ -31,7 +31,7 @@
 
 typedef unsigned int neopixel_time_t;
 
-static neopixel_time_t
+static __always_inline neopixel_time_t
 nsecs_to_ticks(uint32_t ns)
 {
     return timer_from_us(ns * 1000) / 1000000;

--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -14,6 +14,8 @@ config RPXXXX_SELECT
     select HAVE_GPIO_HARD_PWM
     select HAVE_STEPPER_BOTH_EDGE
     select HAVE_BOOTLOADER_REQUEST
+    # Software divide needed on rp2040 in spi rate, i2c rate, hard_pwm rate
+    select HAVE_SOFTWARE_DIVIDE_REQUIRED if MACH_RP2040
 
 config BOARD_DIRECTORY
     string


### PR DESCRIPTION
The older micro-controllers (AVR and cortex-m0) have to implement integer division in software. This software code is often bloated (600+ bytes of code) and can fill up the flash. With minor tweaks it is often possible to avoid using division.

The new build check introduced here will report a build error if any new run-time software divide operations are added to the AVR or STM32 code. This should help alert if a closer look at a change is needed.

This is based on top of https://github.com/Klipper3d/klipper/pull/6892 , as we need that fix to be able to verify the stm32 builds.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6893