### PR TITLE
Add options to change mode and group of linux mcu psuedoterminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [core: options for API server socket file mode, user, and group](https://github.com/KalicoCrew/kalico/pull/612)
 
+- [core: options to change mode and group of linux mcu psuedoterminal](https://github.com/KalicoCrew/kalico/pull/692)
+
 - [fan: normalising Fan PWM power](https://github.com/KalicoCrew/kalico/pull/44) ([klipper#6307](https://github.com/Klipper3d/klipper/pull/6307))
 
 - [fan: reverse FAN](https://github.com/KalicoCrew/kalico/pull/51) ([klipper#4983](https://github.com/Klipper3d/klipper/pull/4983))

--- a/src/linux/internal.h
+++ b/src/linux/internal.h
@@ -4,6 +4,7 @@
 
 #include <signal.h> // sigset_t
 #include <stdint.h> // uint32_t
+#include <sys/types.h> // mode_t gid_t
 #include "autoconf.h" // CONFIG_CLOCK_FREQ
 
 #define MAX_GPIO_LINES    288
@@ -18,7 +19,7 @@
 void report_errno(char *where, int rc);
 int set_non_blocking(int fd);
 int set_close_on_exec(int fd);
-int console_setup(char *name);
+int console_setup(char *name, mode_t mode, gid_t group);
 void console_sleep(sigset_t *sigset);
 
 // timer.c

--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -4,9 +4,13 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include <errno.h> // errno
 #include <sched.h> // sched_setscheduler sched_get_priority_max
 #include <stdio.h> // fprintf
 #include <string.h> // memset
+#include <stdlib.h> // strtoul
+#include <sys/types.h> // getgrent struct
+#include <grp.h> // getgrnam
 #include <unistd.h> // getopt
 #include <sys/mman.h> // mlockall MCL_CURRENT MCL_FUTURE
 #include "board/misc.h" // console_sendf
@@ -70,7 +74,9 @@ main(int argc, char **argv)
     orig_argv = argv;
     int opt, watchdog = 0, realtime = 0;
     char *serial = "/tmp/klipper_host_mcu";
-    while ((opt = getopt(argc, argv, "wrI:")) != -1) {
+    char *pty_group_name = NULL;
+    mode_t pty_mode = 0660;
+    while ((opt = getopt(argc, argv, "wrI:g:m:")) != -1) {
         switch (opt) {
         case 'w':
             watchdog = 1;
@@ -81,8 +87,28 @@ main(int argc, char **argv)
         case 'I':
             serial = optarg;
             break;
+        case 'g':
+            pty_group_name = optarg;
+            break;
+        case 'm':
+            errno = 0; // see man 2 strtoul
+            unsigned long int input_pty_mode = strtoul(optarg, NULL, 8);
+            if (errno) {
+                fprintf(stderr, "unable to parse pty mode: %s", optarg);
+                return -1;
+            }
+            if (input_pty_mode >  0777ul) {
+                fprintf(stderr,
+                        "mode %s invalid (setuid/gid/sticky not supported)",
+                        optarg);
+                return -1;
+            }
+            pty_mode = input_pty_mode;
+            break;
         default:
-            fprintf(stderr, "Usage: %s [-w] [-r] [-I path]\n", argv[0]);
+            fprintf(stderr,
+                    "Usage: %s [-w] [-r] [-I path] [-g group] [-m filemode]\n",
+                    argv[0]);
             return -1;
         }
     }
@@ -93,7 +119,17 @@ main(int argc, char **argv)
         if (ret)
             return ret;
     }
-    int ret = console_setup(serial);
+    gid_t pty_group_id = -1;
+    if (pty_group_name) {
+        struct group * pty_group = getgrnam(pty_group_name);
+        if (!pty_group) {
+            fprintf(stderr, "Unable to find group \"%s\"\n", pty_group_name);
+            return -1;
+        }
+        pty_group_id = pty_group->gr_gid;
+    }
+
+    int ret = console_setup(serial, pty_mode, pty_group_id);
     if (ret)
         return -1;
     if (watchdog) {


### PR DESCRIPTION
This is in a a similar vein to #612, in that it allows for running the different components of klipper as different users, to limit damage should one of them misbehave or get pwned.

It adds two arguments to the `linux` host mcu, allowing the operator to set a group and mode for the pty that the mcu will create.

This was previously submitted to upstream as: https://github.com/Klipper3d/klipper/pull/6188

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
