### PR TITLE
Fix get_lift_speed signature in ProbePointsHelper

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -529,7 +529,9 @@ class ProbePointsHelper:
     def use_xy_offsets(self, use_offsets):
         self.use_offsets = use_offsets
 
-    def get_lift_speed(self):
+    def get_lift_speed(self, gcmd=None):
+        if gcmd is not None:
+            return gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.0)
         return self.lift_speed
 
     def _lift_toolhead(self):


### PR DESCRIPTION
The one in probe_points_helper doesn't match the PrinterProbe one, and it leads to
an exception if a caller does call it with gcmd. `z_tilt_ng` does this.
