### PR TITLE
Belay ENABLE and DISABLE

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -277,10 +277,10 @@ The following commands are available when a
 [belay config section](Config_Reference.md#belay) is enabled.
 
 #### BELAY_ENABLE
-`BELAY_ENABLE BELAY==<config_name>`: Enable compensation for belay specified by `BELAY`.
+`BELAY_ENABLE BELAY=<config_name>`: Enable compensation for belay specified by `BELAY`.
 
 #### BELAY_DISABLE
-`BELAY_DISABLE BELAY==<config_name>`: Disable compensation for belay specified by `BELAY`. This setting will not persist across restarts.
+`BELAY_DISABLE BELAY=<config_name>`: Disable compensation for belay specified by `BELAY`. This setting will not persist across restarts.
 
 #### QUERY_BELAY
 `QUERY_BELAY BELAY=<config_name>`: Queries the state of the belay

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -276,6 +276,12 @@ is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
 The following commands are available when a
 [belay config section](Config_Reference.md#belay) is enabled.
 
+#### BELAY_ENABLE
+`BELAY_ENABLE BELAY==<config_name>`: Enable compensation for belay specified by `BELAY`.
+
+#### BELAY_DISABLE
+`BELAY_DISABLE BELAY==<config_name>`: Disable compensation for belay specified by `BELAY`. This setting will not persist across restarts.
+
 #### QUERY_BELAY
 `QUERY_BELAY BELAY=<config_name>`: Queries the state of the belay
 specified by `BELAY`.

--- a/klippy/extras/belay.py
+++ b/klippy/extras/belay.py
@@ -69,6 +69,21 @@ class Belay:
 
         # register commands
         self.gcode.register_mux_command(
+            "BELAY_ENABLE",
+            "BELAY",
+            self.name,
+            self.cmd_BELAY_ENABLE,
+            desc=self.cmd_BELAY_ENABLE_help,
+        )
+        self.gcode.register_mux_command(
+            "BELAY_DISABLE",
+            "BELAY",
+            self.name,
+            self.cmd_BELAY_DISABLE,
+            desc=self.cmd_BELAY_DISABLE_help,
+        )
+
+        self.gcode.register_mux_command(
             "QUERY_BELAY",
             "BELAY",
             self.name,
@@ -208,6 +223,19 @@ class Belay:
         self.handle_disable()
         self._set_extruder_stepper(gcmd.get("STEPPER"))
         self.handle_enable()
+
+
+    cmd_BELAY_ENABLE_help = "Manually enable Belay"
+    cmd_BELAY_DISABLE_help = "Manually disable Belay"
+
+    def cmd_BELAY_ENABLE(self, gcmd):
+        self.handle_enable()
+        gcmd.respond_info("Belay manually enabled")
+
+    def cmd_BELAY_DISABLE(self, gcmd):
+        self.handle_disable()
+        gcmd.respond_info("Belay manually disabled")
+
 
     def get_status(self, eventtime):
         return {"last_state": self.last_state, "enabled": self.enabled}


### PR DESCRIPTION
Hi,

I have a large printer with an extremely long PTFE tube, so I'm using a secondary extruder to pull filament from 10 kg spools, and Belay to compensate for missed steps, etc.
During load and unload macros, the Belay module unpredictably changes the steps (depending on its state) of my "pull" extruder.

For this reason, I added two G-code commands: BELAY_ENABLE and BELAY_DISABLE.
![A](https://github.com/user-attachments/assets/dc117abd-3f6b-4889-8690-6ad900608cb8)
![B](https://github.com/user-attachments/assets/3cb22eb6-6ccd-405c-b37e-10313f42ca6d)

I think this is useful, which is why I'm submitting this PR.