### PR TITLE
Plugins Phase 1 - Ability to load plugins using package entrypoints

### DIFF
--- a/docs/Developing-Plugins.md
+++ b/docs/Developing-Plugins.md
@@ -1,0 +1,93 @@
+# Developing Plugins for Kalico
+
+Kalico now supports loading external plugins packaged as a python distribution. This document is meant as a light guide for plugin authors to get started packaging their plugin.
+
+Commonly, these plugins will simply be symlinked or copied into `klippy/extras/`. This has multiple downsides 
+ however. Moonraker will note that Kalico is "dirty" (there are changes to files) and future changes to Kalico may conflict with a plugin.
+
+`klippy/plugins/` was implemented to give a "safer" location for plugin authors to install to, however adoption has barely begun.
+
+To make the whole system more user-friendly, and prevent some of these issues from arising, Kalico has implemented a Python-standard plugin loading system.
+
+
+## A light overview of Python packaging
+
+Python packages (often distributed as `my_package-v0.0.0.tar.gz` or `my_package-v0.0.0.whl`) are effectively just an installable zip file, adding code to a python environment.
+
+Within these files you can define metadata that allows other packages to interact with yours in sepcific ways. 
+
+Kalico's official plugin support takes advantage of the Python [Entry Points for Plugins](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) system, allowing for easy installation and discovery.
+
+Once installed, a package with an entry-point under `klippy.plugins` can be discovered by Kalico and loaded at runtime (See `Printer.load_object()` in [`klippy/printer.py`](../klippy/printer.py)).
+
+A full example plugin can be found at [github.com/KalicoCrew/plugin-example](https://github.com/KalicoCrew/plugin-example)
+
+
+## Writing a new plugin from scratch
+
+At it's core, a Kalico plugin is a python script that exposes functions for loading the plugin based on a configuration.
+
+```python
+from __future__ import annotations
+import typing
+
+if typing.TYPE_CHECKING:
+    from klippy.configfile import ConfigWrapper
+
+
+class MyPlugin:
+    def __init__(self, config: ConfigWrapper):
+        self.printer = config.get_printer()
+        self.value = config.get("value")
+
+    def get_status(self, eventtime: float | None = None) -> dict:
+        "If defined, get_status is used to share information with other parts of Klippy"
+
+        return {
+            # In templates, `{printer.my_plugin.value}` will be available
+            "value": self.value  
+        }
+
+
+def load_config(config: ConfigWrapper) -> MyPlugin:
+    "Create an instance of MyPlugin when loaded as [my_plugin]"
+
+    return MyPlugin(config)
+
+
+# def load_config_prefix(config: ConfigWrapper) -> MyPlugin:
+#     """
+#     Create a named instance of MyPlugin, such as [my_plugin has_a_name]
+#
+#     config.get_name() would return the "my_plugin has_a_name". Often that name
+#      will be read as `config.get_name().split(maxsplit=1)[-1]` leaving only "has_a_name"
+#     """
+#
+#     return MyPlugin(config)
+```
+
+To package your plugin for use in Kalico, you need a build tool such as [`uv`](https://docs.astral.sh/uv/). 
+
+Next to `my_plugin.py`, create a file named `pyproject.toml`.
+
+```toml
+[project]
+name = "my_plugin"
+version = "0.1"
+description = "A good description of my plugin"
+readme = "readme.md"
+classifiers = [
+    "Environment :: Plugins",
+    "Framework :: Klippy",
+]
+
+[project.entry-points."klippy.plugins"]
+my_plugin = "my_plugin"
+```
+
+You will also want to create `readme.md` with some example documentation about how to configure and use your plugin
+
+At this point, you have the bare minimum to build and install your Kalico plugin.
+`uv build` will package your plugin, creating `dist/my_plugin-0.1.tar.gz` and `dist/my_plugin-0.1-py3-none-any.whl`.
+
+Kalico will discover the plugin on startup, expose the module's documentation to your frontend, and load the plugin when requested by the end users configuration.

--- a/docs/Developing-Plugins.md
+++ b/docs/Developing-Plugins.md
@@ -18,7 +18,7 @@ Within these files you can define metadata that allows other packages to interac
 
 Kalico's official plugin support takes advantage of the Python [Entry Points for Plugins](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) system, allowing for easy installation and discovery.
 
-Once installed, a package with an entry-point under `klippy.plugins` can be discovered by Kalico and loaded at runtime (See `Printer.load_object()` in [`klippy/printer.py`](../klippy/printer.py)).
+Once installed, a package with an entry-point under `kalico.plugins` can be discovered by Kalico and loaded at runtime (See `Printer.load_object()` in [`klippy/printer.py`](../klippy/printer.py)).
 
 A full example plugin can be found at [github.com/KalicoCrew/plugin-example](https://github.com/KalicoCrew/plugin-example)
 
@@ -81,7 +81,7 @@ classifiers = [
     "Framework :: Klippy",
 ]
 
-[project.entry-points."klippy.plugins"]
+[project.entry-points."kalico.plugins"]
 my_plugin = "my_plugin"
 ```
 

--- a/docs/_kalico/mkdocs.yml
+++ b/docs/_kalico/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
     - Exclude_Object.md
     - Using_PWM_Tools.md
   - Developer Documentation:
+    - Developing-Plugins.md
     - Code_Overview.md
     - Kinematics.md
     - Protocol.md

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -147,7 +147,7 @@ class Printer:
             f".{module_name}", "klippy.plugins"
         )
         entrypoints = importlib.metadata.entry_points(
-            group="klippy.plugins", name=module_name
+            group="kalico.plugins", name=module_name
         )
         if entrypoints:
             entrypoint = entrypoints[module_name]
@@ -156,6 +156,9 @@ class Printer:
                     f"Module '{section}' found in both extras and "
                     f"installed plugin {entrypoint.dist.name} (v{entrypoint.dist.version})"
                 )
+            logging.info(
+                f"Loading '{module_name}' from plugin {entrypoint.dist.name} ({entrypoint.dist.version})"
+            )
             mod = entrypoint.load()
         elif plugins_spec:
             if extras_spec and not get_danger_options().allow_plugin_override:
@@ -203,7 +206,7 @@ class Printer:
         ]:
             self.load_object(config, section_config, None)
         if self.get_start_args().get("debuginput") is not None:
-            self.load_object(config, "testing", None)
+            self.load_object(config, "testing")
         for m in [toolhead]:
             m.add_printer_objects(config)
         # Validate that there are no undefined parameters in the config file
@@ -554,7 +557,7 @@ def main():
     extra_git_desc += "\nRemote: %s" % (git_info["remote"])
     extra_git_desc += "\nTracked URL: %s" % (git_info["url"])
 
-    plugins = importlib.metadata.entry_points(group="klippy.plugins")
+    plugins = importlib.metadata.entry_points(group="kalico.plugins")
     for plugin in plugins:
         extra_git_desc += f"\nPlugin {plugin.dist.name}=={plugin.dist.version}"
         start_args["plugins"][plugin.dist.name] = plugin.dist.metadata.json
@@ -571,6 +574,7 @@ def main():
                 f"Git version: {repr(start_args['software_version'])}{extra_git_desc}",
                 f"CPU: {start_args['cpu_info']}",
                 f"Python: {repr(sys.version)}",
+                f"Plugins: {start_args['plugins']}",
             ]
         )
         logging.info(versions)

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -435,7 +435,13 @@ class WebHooks:
             "group_id": os.getgid(),
         }
         start_args = self.printer.get_start_args()
-        for sa in ["log_file", "config_file", "software_version", "cpu_info"]:
+        for sa in [
+            "log_file",
+            "config_file",
+            "software_version",
+            "cpu_info",
+            "plugins",
+        ]:
             response[sa] = start_args.get(sa)
         web_request.send(response)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,11 +11,6 @@ import os
 klippy.chelper.get_ffi()
 
 
-ROOT = pathlib.Path(__file__).parent.parent
-KLIPPY_PLUGINS = ROOT / "klippy" / "plugins"
-TESTING_PLUGIN = ROOT / "test" / "klippy_testing_plugin.py"
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--dictdir",
@@ -25,16 +20,17 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_sessionstart(session):
-    link_path = KLIPPY_PLUGINS / "testing.py"
-    if link_path.exists():
-        return
+# Use PYTHONPATH to enable the testing plugin
+TESTING_PLUGIN = pathlib.Path(__file__).parent / "kalico_testing_plugin"
 
-    os.symlink(TESTING_PLUGIN, link_path)
+
+def pytest_sessionstart(session):
+    old_python_path = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = f"{TESTING_PLUGIN}:{old_python_path}"
 
     @session.config.add_cleanup
     def clean_symlink():
-        os.unlink(link_path)
+        os.environ["PYTHONPATH"] = old_python_path
 
 
 @pytest.fixture

--- a/test/kalico_testing_plugin/kalico_testing_plugin-0.0.0.dist-info/METADATA
+++ b/test/kalico_testing_plugin/kalico_testing_plugin-0.0.0.dist-info/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.4
+Name: kalico_testing_plugin
+Version: 0.0.0

--- a/test/kalico_testing_plugin/kalico_testing_plugin-0.0.0.dist-info/entry_points.txt
+++ b/test/kalico_testing_plugin/kalico_testing_plugin-0.0.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[kalico.plugins]
+testing = kalico_testing_plugin

--- a/test/kalico_testing_plugin/kalico_testing_plugin/__init__.py
+++ b/test/kalico_testing_plugin/kalico_testing_plugin/__init__.py
@@ -1,0 +1,56 @@
+import ast
+import logging
+from klippy.extras import gcode_macro
+
+
+class KlippyTestingPlugin:
+    def __init__(self, config):
+        self.config = config
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object("gcode")
+        self.gcode_macro = self.printer.load_object(config, "gcode_macro")
+
+        self.printer.register_event_handler(
+            "gcode:command_error", self._command_error
+        )
+        self.printer.register_event_handler(
+            "gcode:unknown_command", self._unknown_command
+        )
+
+        self.gcode.register_command("ASSERT", self.cmd_ASSERT)
+
+    def _command_error(self):
+        self.printer.request_exit("error_exit")
+        self.printer.invoke_shutdown("Exception during testing")
+
+    def _unknown_command(self, cmd):
+        logging.error(f"Unknown command during test execution: {cmd}")
+        self.printer.request_exit("error_exit")
+        self.printer.invoke_shutdown(
+            f"Unknown command during test execution: {cmd}"
+        )
+
+    def cmd_ASSERT(self, gcmd):
+        "Evaluate an expression, raising an error if the return value is False"
+        expression = gcmd.get("TEST")
+
+        try:
+            template = gcode_macro.Template(
+                self.printer,
+                self.gcode_macro.env,
+                "ASSERT:runtime_expression",
+                expression,
+            )
+        except:
+            raise gcmd.error(f"ASSERT: Failed to parse '{expression}'")
+
+        context = self.gcode_macro.create_template_context()
+        statement = template.render(context)
+        value = ast.literal_eval(statement) if statement else None
+
+        if not value:
+            raise gcmd.error(f"ASSERT: {expression} == {value}")
+
+
+def load_config(config):
+    return KlippyTestingPlugin(config)

--- a/test/kalico_testing_plugin/pyproject.toml
+++ b/test/kalico_testing_plugin/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "kalico_testing_plugin"
+version = "0.0.0"
+
+[project.entry-points."kalico.plugins"]
+testing = "kalico_testing_plugin"


### PR DESCRIPTION
This enables plugins to provide a python entrypoint, and then users can just `pip install` plugins they need.

This extends the module loading to search the entrypoint `kalico.plugins` for modules matching the configured name. 

Entrypoints expose the normal `load_config(config: ConfigWrapper) -> object` or `load_config_prefix(config: ConfigWrapper) -> object` interface.

Supporting this is usually as simple as adding a `pyproject.toml` to the plugin's repository with `[project.entry-points."kalico.plugins"] my_plugin = "module"`.

This also starts some documentation on plugin development