### PR TITLE
Reduce MPC minimum calibration temperature to 60C

### DIFF
--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -383,7 +383,7 @@ class MpcCalibrate:
         default_target_temp = (
             90.0 if self.heater.get_name() == "heater_bed" else 200.0
         )
-        target_temp = gcmd.get_float("TARGET", default_target_temp, minval=90.0)
+        target_temp = gcmd.get_float("TARGET", default_target_temp, minval=60.0)
         threshold_temp = gcmd.get_float(
             "THRESHOLD", max(50.0, min(100, target_temp - 100.0))
         )


### PR DESCRIPTION
My printer has a printed frame and I don't want to subject it to heating the bed to 90C, so I tried reducing the minimum to 60C and it works fine.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
