### PR TITLE
Add support for HSE bypass on STM32.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [tmc2240: adjustable driver_CS and current_range](https://github.com/KalicoCrew/kalico/pull/556)
 
+- [core: support for STM32 MCUs with oscillators rather than crystals](https://github.com/KalicoCrew/kalico/pull/709)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -352,17 +352,17 @@ config ARMCM_RAM_VECTORTABLE
 choice
     prompt "Clock Reference" if LOW_LEVEL_OPTIONS
     config STM32_CLOCK_REF_8M
-        bool "8 MHz crystal"
+        bool "8 MHz external"
     config STM32_CLOCK_REF_12M
-        bool "12 MHz crystal"
+        bool "12 MHz external"
     config STM32_CLOCK_REF_16M
-        bool "16 MHz crystal"
+        bool "16 MHz external"
     config STM32_CLOCK_REF_20M
-        bool "20 MHz crystal"
+        bool "20 MHz external"
     config STM32_CLOCK_REF_24M
-        bool "24 MHz crystal"
+        bool "24 MHz external"
     config STM32_CLOCK_REF_25M
-        bool "25 MHz crystal"
+        bool "25 MHz external"
     config STM32_CLOCK_REF_INTERNAL
         bool "Internal clock"
 endchoice
@@ -385,6 +385,13 @@ config STM32F0_TRIM
         Default is 16 (use factory default). Each increment increases
         the clock rate by ~240KHz.
 
+choice
+    prompt "External Clock Type" if LOW_LEVEL_OPTIONS && !STM32_CLOCK_REF_INTERNAL && MACH_STM32G474
+    config STM32_CLOCK_HSE_CRYSTAL
+        bool "HSE Crystal"
+    config STM32_CLOCK_HSE_BYPASS
+        bool "HSE Bypass"
+endchoice
 
 ######################################################################
 # Communication inteface

--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -76,8 +76,12 @@ gpio_clock_enable(GPIO_TypeDef *regs)
     RCC->AHB2ENR;
 }
 
-#if !CONFIG_STM32_CLOCK_REF_INTERNAL
-DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PF0,PF1");
+#if CONFIG_STM32_CLOCK_REF_INTERNAL
+// No pins required.
+#elif CONFIG_STM32_CLOCK_HSE_BYPASS
+DECL_CONSTANT_STR("RESERVE_PINS_hse_clock", "PF0");
+#else // CONFIG_STM32_CLOCK_HSE_CRYSTAL
+DECL_CONSTANT_STR("RESERVE_PINS_hse_clock", "PF0,PF1");
 #endif
 
 static void
@@ -94,6 +98,9 @@ enable_clock_stm32g4(void)
         pll_base = 4000000;
 #endif
         uint32_t div = CONFIG_CLOCK_REF_FREQ / pll_base - 1;
+        if (CONFIG_STM32_CLOCK_HSE_BYPASS) {
+            RCC->CR |= RCC_CR_HSEBYP;
+        }
         RCC->CR |= RCC_CR_HSEON;
         while (!(RCC->CR & RCC_CR_HSERDY))
             ;


### PR DESCRIPTION
This allows for the usage of MCUs that use an external oscillator rather than a crystal.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
