### PR TITLE
Raise error if max ADC sample value exceeds 0xFFFF

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -696,9 +696,12 @@ class MCU_adc:
         self._inv_max_adc = 1.0 / max_adc
         self._report_clock = self._mcu.seconds_to_clock(self._report_time)
         min_sample = max(0, min(0xFFFF, int(self._min_sample * max_adc)))
-        max_sample = max(
-            0, min(0xFFFF, int(math.ceil(self._max_sample * max_adc)))
-        )
+        max_sample = max(0, int(math.ceil(self._max_sample * max_adc)))
+        if max_sample > 0xFFFF:
+            raise error(
+                "Maximum ADC sample value (MAX_ADC * oversampling) must not "
+                "be greater than 0xFFFF."
+            )
         self._mcu.add_config_cmd(
             "query_analog_in oid=%d clock=%d sample_ticks=%d sample_count=%d"
             " rest_ticks=%d min_value=%d max_value=%d range_check_count=%d"


### PR DESCRIPTION
Previously the maximum value would just silently be limited, causing confusing out-of-range errors on MCUs that allow for a higher value. This is also useful for any users who have changed the default oversampling value to something higher.

This does not allow for the usage of MCUs with higher bit-depth ADCs, but it will at least save the next person from the confusion that I went through.

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
