### PR TITLE
sht3x: reads should be retried with at least 0.5s pause

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -276,8 +276,8 @@ class MCU_I2C:
             [self.oid, data], minclock=minclock, reqclock=reqclock
         )
 
-    def i2c_read(self, write, read_len):
-        return self.i2c_read_cmd.send([self.oid, write, read_len])
+    def i2c_read(self, write, read_len, retry=True):
+        return self.i2c_read_cmd.send([self.oid, write, read_len], retry)
 
 
 def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):

--- a/klippy/extras/sht3x.py
+++ b/klippy/extras/sht3x.py
@@ -60,6 +60,7 @@ class SHT3X:
         self.i2c = bus.MCU_I2C_from_config(
             config, default_addr=SHT3X_I2C_ADDR, default_speed=100000
         )
+        self._error = self.i2c.get_mcu().error
         self.report_time = config.getint("sht3x_report_time", 1, minval=1)
         self.deviceId = config.get("sensor_type")
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
@@ -109,7 +110,20 @@ class SHT3X:
     def _sample_sht3x(self, eventtime):
         try:
             # Read measurment
-            params = self.i2c.i2c_read(SHT3X_CMD["OTHER"]["FETCH"], 6)
+            retries = 5
+            params = None
+            error = None
+            while retries > 0 and params is None:
+                try:
+                    params = self.i2c.i2c_read(
+                        SHT3X_CMD["OTHER"]["FETCH"], 6, retry=False
+                    )
+                except self._error as e:
+                    error = e
+                    self.reactor.pause(self.reactor.monotonic() + 0.5)
+                    retries -= 1
+            if params is None:
+                raise error
 
             response = bytearray(params["response"])
             rtemp = response[0] << 8


### PR DESCRIPTION
Port of https://github.com/Klipper3d/klipper/pull/6975

> SHT3x would return a read NACK on host retries.
> When the MCU receives the I2C CMD, it reads out data. SHT3x clears the data buffer.
> The MCU fails to deliver a response to the host.
> The host retries, the device returns NACK,
> then the MCU goes into the shutdown state.
> 
> Make sure there is at least 0.5s between retries.

## Checklist

- [x] pr title makes sense
- [~] added a test case if possible
- [~] if new feature, added to the readme
- [x] ci is happy and green
