### PR TITLE
stm32: make i2c distinguish I2C NACKs

### DIFF
--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -219,16 +219,18 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
     uint32_t timeout = timer_read_time() + timer_from_us(5000);
     int ret = I2C_BUS_SUCCESS;
 
-    // Send start, address, reg
-    i2c->CR2 = (I2C_CR2_START | config.addr |
-               (reg_len << I2C_CR2_NBYTES_Pos));
-    while (reg_len--) {
-        ret = i2c_wait(i2c, I2C_ISR_TXIS, timeout);
-        if (ret != I2C_BUS_SUCCESS)
-            goto abrt;
-        i2c->TXDR = *reg++;
+    if (reg_len) {
+        // Send start, address, reg
+        i2c->CR2 = (I2C_CR2_START | config.addr |
+                   (reg_len << I2C_CR2_NBYTES_Pos));
+        while (reg_len--) {
+            ret = i2c_wait(i2c, I2C_ISR_TXIS, timeout);
+            if (ret != I2C_BUS_SUCCESS)
+                goto abrt;
+            i2c->TXDR = *reg++;
+        }
+        i2c_wait(i2c, I2C_ISR_TC, timeout);
     }
-    i2c_wait(i2c, I2C_ISR_TC, timeout);
 
     // send restart, read data
     i2c->CR2 = (I2C_CR2_START | I2C_CR2_RD_WRN | config.addr |


### PR DESCRIPTION
Port of:
 - https://github.com/Klipper3d/klipper/pull/6974
 - https://github.com/Klipper3d/klipper/pull/6977

> Some devices can return a read NACK on host retries.
> When the MCU receives the I2C CMD, reads out data, but fails to deliver a response to the host.
> The host retries, the device returns START READ NACK, and the MCU goes into the shutdown state.
> 
> Well, this is an optional patch, it simply allows for to detection of that condition.
> Tested on my STM32H7 with STH31, with report time 0.49s.
> 
> (SHT3x returns NACK if data is tried to be read again, before new measurements; new measurements happen every 0.5s).

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
