### PR TITLE
Fix neopixel timing on RP2040 MCUs (merge from upstream)

### DIFF
--- a/src/neopixel.c
+++ b/src/neopixel.c
@@ -34,7 +34,7 @@ typedef unsigned int neopixel_time_t;
 static __always_inline neopixel_time_t
 nsecs_to_ticks(uint32_t ns)
 {
-    return timer_from_us(ns * 1000) / 1000000;
+    return DIV_ROUND_UP(timer_from_us(ns * 1000), 1000000);
 }
 
 static inline int


### PR DESCRIPTION
It looks like the solution for https://github.com/Klipper3d/klipper/pull/6873 is not merged, so the neopixel doesn't work on RP2040 boards (at least with the various BTT EBB boards and LEDs) in Kalico only, since this was fixed upstream last April with commit [5b2f810](https://github.com/Klipper3d/klipper/commit/5b2f8104c7106a2126949dcb0502dff5491023b2):

> The rp2040 operates at a fast internal clock with a relatively slow external timer and dividing down could result in a too small delay.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
