### PR TITLE
fix(delayed_gcode): add description like gcode_macro

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -329,10 +329,12 @@ gcode sequence:
 
 ```
 [delayed_gcode clear_display]
+description: Clear the LCD display message
 gcode:
   M117
 
 [gcode_macro load_filament]
+description: Load 50mm of filament
 gcode:
  G91
  G1 E50

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1875,6 +1875,10 @@ gcode:
 #   useful for initialization procedures or a repeating delayed_gcode.
 #   If set to 0 the delayed_gcode will not execute on startup.
 #   Default is 0.
+#description: Update the duration of a delayed_gcode
+#   This will add a short description used at the HELP command or while
+#   using the auto completion feature. Default "Update the duration of 
+#   a delayed_gcode"
 ```
 
 ### [save_variables]

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -19,7 +19,10 @@ class DelayedGcode:
         self.name = config.get_name().split()[1]
         self.gcode = self.printer.lookup_object("gcode")
         gcode_macro = self.printer.load_object(config, "gcode_macro")
-        self.cmd_desc = config.get("description", "Update the duration of a delayed_gcode")
+        self.cmd_desc = config.get(
+            "description",
+            "Update the duration of a delayed_gcode",
+        )
         self.timer_gcode = gcode_macro.load_template(config, "gcode")
         self.duration = config.getfloat("initial_duration", 0.0, minval=0.0)
         self.timer_handler = None

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -9,22 +9,29 @@ import logging
 
 class DelayedGcode:
     def __init__(self, config):
+        if len(config.get_name().split()) > 2:
+            raise config.error(
+                "Name of section '%s' contains illegal whitespace"
+                % (config.get_name())
+            )
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
         self.name = config.get_name().split()[1]
         self.gcode = self.printer.lookup_object("gcode")
         gcode_macro = self.printer.load_object(config, "gcode_macro")
+        self.cmd_desc = config.get("description", "Update the duration of a delayed_gcode")
         self.timer_gcode = gcode_macro.load_template(config, "gcode")
         self.duration = config.getfloat("initial_duration", 0.0, minval=0.0)
         self.timer_handler = None
         self.inside_timer = self.repeat = False
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
+
         self.gcode.register_mux_command(
             "UPDATE_DELAYED_GCODE",
             "ID",
             self.name,
             self.cmd_UPDATE_DELAYED_GCODE,
-            desc=self.cmd_UPDATE_DELAYED_GCODE_help,
+            desc=self.cmd_desc,
         )
 
     def _handle_ready(self):
@@ -46,8 +53,6 @@ class DelayedGcode:
             nextwake = eventtime + self.duration
         self.inside_timer = self.repeat = False
         return nextwake
-
-    cmd_UPDATE_DELAYED_GCODE_help = "Update the duration of a delayed_gcode"
 
     def cmd_UPDATE_DELAYED_GCODE(self, gcmd):
         self.duration = gcmd.get_float("DURATION", minval=0.0)


### PR DESCRIPTION
The `[delayed_gcode]` macro should also have a _description_ documentation section like `[gcode_macro]`.

This PR adds the functionality and also updates the docs.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible - none available for delayed_macro
- [X] if new feature, added to the readme
- [x] ci is happy and green
