### PR TITLE
add filament_heat_capacity and filament_density to exposed status variables in control_mpc.py

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -89,6 +89,16 @@ The following information is available in the `configfile` object
   field (both strings). Additional fields may be available depending
   on the type of warning.
 
+## control_mpc
+
+The following information is available in the `extruder.control_stats` object
+(this object is automatically available if control type for [extruder](Config_Reference.md#extruder) config section is set to [mpc](MPC.md):
+- `loss_ambient`: The current/last ambient loss rate.
+- `loss_filament`: The current/last filament loss rate.
+- `filament_temp`: The current filament temperature.
+- `filament_heat_capacity`: The current specific heat capacity of filament in J/g/K.
+- `filament_density`: The current filament density in g/mm^3.
+
 ## display_status
 
 The following information is available in the `display_status` object

--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -362,6 +362,8 @@ class ControlMPC:
             "loss_ambient": self.last_loss_ambient,
             "loss_filament": self.last_loss_filament,
             "filament_temp": self.filament_temp_src,
+            "filament_heat_capacity": self.const_filament_heat_capacity,
+            "filament_density": self.const_filament_density,
         }
 
 


### PR DESCRIPTION
expose `filament_heat_capacity` and `filament_density` to for macros

these two vars are exposed to get current value for use in macros, useful in filament changer/mmu setups to prevent heating of the hotend during filament loads.
Existing macros exist to set these values from profiles or other methods, but all are preset and cannot be generically used.


example save/restore macro:
```ini
[gcode_macro Save_Filament_Heat]
# Use this before tool changes to remove the heating hotend when doing toolchange moves
description: Save the current filament heat value
variable_heatcap: -1
variable_dens: -1
gcode:
    {% set heatcap = printer.extruder.control_stats.filament_heat_capacity %}
    {% set dens = printer.extruder.control_stats.filament_density %}
    
    {% if heatcap > 0 %}
        MPC_SET HEATER=extruder FILAMENT_HEAT_CAPACITY=0 FILAMENT_DENSITY=0
        SET_GCODE_VARIABLE MACRO=Save_Filament_Heat VARIABLE=heatcap VALUE={heatcap}
        SET_GCODE_VARIABLE MACRO=Save_Filament_Heat VARIABLE=dens VALUE={dens}
    {% endif %}
    
[gcode_macro Restore_Filament_heat]
description: Restore saved filament heat value
gcode:
    # restore filament heat if a previous value was saved
    {% if not (printer["gcode_macro Save_Filament_Heat"].heatcap == -1) %}
        MPC_SET HEATER=extruder FILAMENT_HEAT_CAPACITY={printer["gcode_macro Save_Filament_Heat"].heatcap} FILAMENT_DENSITY={printer["gcode_macro Save_Filament_Heat"].dens}
    {% endif %}
```



issues:
I dont know the units of the ambient and filament loss rates.  maybe relevant to put in the docs, perhaps not.




## Checklist

- [*] pr title makes sense  -- sure
- [*] added a test case if possible  -- not a unit test case, but an example usage.
- [*] if new feature, added to the readme  -- i think i added to `status_reference.md` correctly.  I added the entire section for `control_mpc`
- [*] ci is happy and green  -- i hope so.
