### PR TITLE
spi_flash: fix spi bus switch (#6906)

### DIFF
--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -1485,7 +1485,6 @@ class MCUConnection:
         ]
         cfg_cmds.append(self._try_send_command(spi_cfg_cmds))
         cfg_cmds.append(self._try_send_command(bus_cmds))
-        self._try_send_command(cfg_cmds)
         config_crc = zlib.crc32("\n".join(cfg_cmds).encode()) & 0xFFFFFFFF
         self._serial.send(FINALIZE_CFG_CMD % (config_crc,))
         config = self.get_mcu_config()


### PR DESCRIPTION
Fixes abc76ee963d4154dce0bd56f2fdb946d5065cc86.

Klipper PR [#6906](https://github.com/Klipper3d/klipper/pull/6906)