### PR TITLE
PR: Add `horizontal_z_clearance` option to `[bed_mesh]`

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1273,6 +1273,11 @@ Visual Examples:
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#horizontal_z_clearance:
+#   A relative height (in mm) that the toolhead will lift at each mesh
+#   point before moving to the next one. If enabled, the `horizontal_move_z`
+#   value is only used for the travel move to the first mesh point. The default
+#   is None.
 #mesh_radius:
 #   Defines the radius of the mesh to probe for round beds. Note that
 #   the radius is relative to the coordinate specified by the

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -491,6 +491,7 @@ class BedMeshCalibrate:
             self.probe_finalize,
             self._get_adjusted_points(),
             use_offsets=True,
+            enable_horizontal_z_clearance=True,
         )
         self.probe_helper.minimum_points(3)
         self.gcode = self.printer.lookup_object("gcode")

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -830,6 +830,7 @@ class ProbePointsHelper:
         default_points=None,
         option_name="points",
         use_offsets=False,
+        enable_horizontal_z_clearance: bool = False,
     ):
         self.printer = config.get_printer()
         self.finalize_callback = finalize_callback
@@ -842,7 +843,14 @@ class ProbePointsHelper:
                 option_name, seps=(",", "\n"), parser=float, count=2
             )
         def_move_z = config.getfloat("horizontal_move_z", 5.0)
-        self.default_horizontal_move_z = def_move_z
+        self.horizontal_move_z = self.default_horizontal_move_z = def_move_z
+        # horizontal_z_clearance mode is off by default
+        self.enable_horizontal_z_clearance = enable_horizontal_z_clearance
+        self.horizontal_z_clearance = self.default_horizontal_z_clearance = None
+        if enable_horizontal_z_clearance:
+            z_clearance = config.getfloat("horizontal_z_clearance", None)
+            self.default_horizontal_z_clearance = z_clearance
+            self.horizontal_z_clearance = z_clearance
         self.adaptive_horizontal_move_z = config.getboolean(
             "adaptive_horizontal_move_z", False
         )
@@ -891,7 +899,11 @@ class ProbePointsHelper:
         if not self.results and not self.enforce_lift_speed:
             # Use full speed to first probe position
             speed = self.speed
-        toolhead.manual_move([None, None, self.horizontal_move_z], speed)
+        z_pos = self.horizontal_move_z
+        # use horizontal_z_clearance for inter-point moves
+        if self.horizontal_z_clearance is not None and self.results:
+            z_pos = toolhead.get_position()[2] + self.horizontal_z_clearance
+        toolhead.manual_move([None, None, z_pos], speed)
 
     def _next_pos(self):
         nextpos = list(self.probe_points[len(self.results)])
@@ -947,6 +959,10 @@ class ProbePointsHelper:
 
         def_move_z = self.default_horizontal_move_z
         self.horizontal_move_z = gcmd.get_float("HORIZONTAL_MOVE_Z", def_move_z)
+        if self.enable_horizontal_z_clearance:
+            self.horizontal_z_clearance = gcmd.get_float(
+                "HORIZONTAL_Z_CLEARANCE", self.default_horizontal_z_clearance
+            )
 
         enforce_lift_speed = gcmd.get_int(
             "ENFORCE_LIFT_SPEED", None, minval=0, maxval=1


### PR DESCRIPTION
This change adds an option to ProbePointsHelper that will lift the z axis by `horizontal_z_clearance` before moving to the next point to ensure that the toolhead clears the bed. This makes the height "adaptive", it follows the slope of the bed as bed mesh does. This is an alternate behavior to `horizontal_move_z`, which moves the toolhead to a fixed height.

Moving the toolhead to a height relative to the bed at each mesh point reduces the amount of Z travel required to safely perform a bed mesh. This saves z travel time time on probes allowing for slower probing speeds with less force applied to the bed without increasing overall mesh time vs `horizontal_move_z`.

For this change the config option only works for [bed_mesh]. For reference, Prusa's firmware has separate setting for the first probe, between probes and after the last probe: https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/f26c91ba57b004e570a73fb9c9cda0ce3e433b40/include/marlin/Configuration_MK4.h#L1001

## Checklist

- [✅] pr title makes sense
- [✅] added a test case if possible
- [✅] if new feature, added to the readme
- [✅] ci is happy and green
