### PR TITLE
PR: Add average delta metric to probe_accuracy results

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -674,11 +674,19 @@ class PrinterProbe:
         for i in range(len(positions)):
             deviation_sum += pow(positions[i][2] - avg_value, 2.0)
         sigma = (deviation_sum / len(positions)) ** 0.5
+        # calculate the average delta between successive probes
+        delta_sum = 0
+        for i in range(1, len(positions)):
+            delta_sum += abs(positions[i][2] - positions[i - 1][2])
+        avg_delta = delta_sum / (len(positions) - 1)
         # Show information
+        decimals = 6
         gcmd.respond_info(
-            "probe accuracy results: maximum %.6f, minimum %.6f, range %.6f, "
-            "average %.6f, median %.6f, standard deviation %.6f"
-            % (max_value, min_value, range_value, avg_value, median, sigma)
+            f"probe accuracy results: maximum {max_value:.{decimals}f}, "
+            f"minimum {min_value:.{decimals}f}, range {range_value:.{decimals}f}, "
+            f"average {avg_value:.{decimals}f}, median {median:.{decimals}f}, "
+            f"standard deviation {sigma:.{decimals}f}, "
+            f"average delta {avg_delta:.{decimals}f}"
         )
 
     def probe_calibrate_finalize(self, kin_pos):


### PR DESCRIPTION
This adds a new metric called `average delta` that averages the delta between each pair or probes in the set. This metric is less susceptible to variance in the measurements conditions that happen over the set of probes, such a temperature changes and hysteresis of components.

With the load cell probe, its now very possible to see things like the bed changing shape as it heat soaks. This is not the assumption of `PROBE_ACCURACY`, all of its metrics assume that there is absolutely zero change in the environment between all probes. But in the real world this isn't true. So we see "bad" accuracy results which are not the fault of the probe itself.

`average delta` gives you a better idea of how repeatable your probe is, regardless of the underlying environmental changes. `average delta` tells you: "If I took 1 more probe, how different would it be from the last one". This is really what users are trying to get from `PROBE_ACCURACY`, as they use it to decide how many probes to perform.

Comparing `average delta` to `range` and `standard deviation` also gives you some idea about what was going on during a `PROBE_ACCURACY` run. If they all basically agree the environment was essentially static and the probe variance was random noise. If `average delta` is significantly better then its likely something was moving around during the test.

## Checklist

- [✅] pr title makes sense
- [✅] added a test case if possible
- [✅] if new feature, added to the readme
- [✅] ci is happy and green
