### PR TITLE
stm32: Add STM32H750 128KiB bootloader offset option

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -328,7 +328,7 @@ choice
     config STM32_FLASH_START_4000
         bool "16KiB bootloader" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F4x5 || MACH_STM32F103 || MACH_STM32F072 || MACH_STM32F411
     config STM32_FLASH_START_20000
-        bool "128KiB bootloader" if MACH_STM32H743 || MACH_STM32H723 || MACH_STM32F7
+        bool "128KiB bootloader" if MACH_STM32H743 || MACH_STM32H723 || MACH_STM32H750 || MACH_STM32F7
     config STM32_FLASH_START_20200
         bool "128KiB bootloader with 512 byte offset" if MACH_STM32F4x5 || MACH_STM32F427
 


### PR DESCRIPTION
add MACH_STM32H750 to the 128KiB bootloader offset choice in Kconfig, enabling flashing with Katapult on H750 boards.

closes #843