### PR TITLE
atsamd: switch PLL1 to 96 MHz

### DIFF
--- a/src/atsamd/samd51_clock.c
+++ b/src/atsamd/samd51_clock.c
@@ -15,6 +15,7 @@
 
 #define FREQ_MAIN CONFIG_CLOCK_FREQ
 #define FREQ_32K 32768
+#define FREQ_96M 96000000
 #define FREQ_48M 48000000
 #define FREQ_2M 2000000
 
@@ -147,11 +148,11 @@ clock_init_25m(void)
     // Switch main clock to 120Mhz PLL0
     gen_clock(CLKGEN_MAIN, GCLK_GENCTRL_SRC_DPLL0);
 
-    // Generate 48Mhz clock on PLL1 (with XOSC1 as reference)
-    uint32_t p1div = 50, p1mul = DIV_ROUND_CLOSEST(FREQ_48M, freq_xosc/p1div);
+    // Generate 96MHz clock on PLL1 (with XOSC1 as reference), divide by 2 for GCLK = 48 MHz
+    uint32_t p1div = 50, p1mul = DIV_ROUND_CLOSEST(FREQ_96M, freq_xosc/p1div);
     uint32_t p1ctrlb = OSCCTRL_DPLLCTRLB_DIV(p1div / 2 - 1);
     config_dpll(1, p1mul, p1ctrlb | OSCCTRL_DPLLCTRLB_REFCLK_XOSC1);
-    gen_clock(CLKGEN_48M, GCLK_GENCTRL_SRC_DPLL1);
+    gen_clock(CLKGEN_48M, GCLK_GENCTRL_SRC_DPLL1 | GCLK_GENCTRL_DIV(FREQ_96M / FREQ_48M));
 }
 
 // Initialize clocks from factory calibrated internal clock


### PR DESCRIPTION
PLL1 was set to run at 48 MHz and the 48MHz GCLK used for peripherals was directly generated from this.

However, the SAM D5x/E5x family only supports running the PLL with an output frequency in the range of 96 MHz to 200 MHz per the datasheet. In practice, in testing this resulted in extreme jitter of the PLL as core temperature increases, to the point where the output 48MHz frequency was out by _at least_ 0.5% and caused the USB peripheral to stop functioning correctly.

This commit switches the PLL to 96 MHz and instead divides that by 2 to get the required 48 MHz GCLK. No other changes are required to the surrounding code.

It is possible to run the PLL at 192 MHz and divide by 4 as well(or 144 MHz and divide by 3, but this would produce an uneven duty cycle). Per the data sheet specifications, this _may_ give slightly better jitter when divided down to the target 48 MHz, but the power consumption of the PLL also doubles. In practice, I found no reason to do this and was able to run USB with the core at 100° C with no issues.
