### PR TITLE
heaters: make sensor sample loss tolerance configurable

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1144,6 +1144,9 @@ control:
 #   not recommended to set this unless there is an electrical
 #   requirement to switch the heater faster than 10 times a second.
 #   The default is 0.100 seconds.
+#lost_update_tolerance: 2
+#   Maximum number of consecutive sensor lost samples that can be
+#   recovered from.
 #min_extrude_temp: 170
 #   The minimum temperature (in Celsius) at which extruder move
 #   commands may be issued. The default is 170 Celsius.
@@ -3316,6 +3319,7 @@ target temperature.
 #pid_Ki:
 #pid_Kd:
 #pwm_cycle_time:
+#lost_update_tolerance:
 #min_temp:
 #max_temp:
 #   See the "extruder" section for the definition of the above

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -53,6 +53,9 @@ class Heater:
         self.sensor.setup_minmax(self.min_temp, self.max_temp)
         self.sensor.setup_callback(self.temperature_callback)
         self.pwm_delay = self.sensor.get_report_time_delta()
+        self.lost_update_tolerance = float(
+            config.getint("lost_update_tolerance", 2, minval=0) + 1
+        )
         # Setup temperature checks
         self.min_extrude_temp = config.getfloat(
             "min_extrude_temp",
@@ -163,7 +166,9 @@ class Heater:
             return
         pwm_time = read_time + self.pwm_delay
         self.next_pwm_time = (
-            pwm_time + MAX_HEAT_TIME - (3.0 * self.pwm_delay + 0.001)
+            pwm_time
+            + MAX_HEAT_TIME
+            - (self.lost_update_tolerance * self.pwm_delay + 0.001)
         )
         self.last_pwm_value = value
         self.mcu_pwm.set_pwm(pwm_time, value)


### PR DESCRIPTION
The heater code PWM update loop is dependant on receiving sensor updates. If more than 2 sensor samples are lost(for a 300ms interval sensor) the heater update deadline will be missed and the printer will shut down.

This makes the update loss tolerance configurable, retaining the original 2-sample tolerance.