### PR TITLE
Fix: TapAnalysis not getting all trapq moves

### DIFF
--- a/klippy/extras/load_cell/tap_analysis.py
+++ b/klippy/extras/load_cell/tap_analysis.py
@@ -433,6 +433,11 @@ class TapAnalysis:
         dist = self._move_dist(move, print_time)
         return self._move_pos(move, dist)
 
+    def log_trapq(self):
+        logging.info("TapAnalysis - Trapezoidal Movement Queue contents:")
+        for i, move in enumerate(self._moves):
+            logging.info(f"Move {i}: {move.to_dict()}")
+
     # adjust move_t of PROBE_CRUISE to match the toolhead position of PROBE_HALT
     def _recalculate_homing_end(self):
         homing_move = self._moves[PROBE_CRUISE]
@@ -452,14 +457,9 @@ class TapAnalysis:
     # extract and save TrapQueue moves
     def _extract_trapq(self, printer):
         trapq = printer.lookup_object("motion_report").trapqs["toolhead"]
-        moves, _ = trapq.extract_trapq(
-            float(self._time[0] + self._time_offset),
-            float(self._time[-1] + self._time_offset),
-        )
+        moves, _ = trapq.extract_trapq(float(self._time[0] + self._time_offset))
         for move in moves:
             self._moves.append(TrapezoidalMove(move, self._time_offset))
-            # DEBUG: enable to see trapq contents
-            # logging.info("trapq move: %s" % (moves_out[-1].to_dict(),))
 
     # perform analysis, throws exceptions
     def analyze(self, printer):
@@ -685,6 +685,7 @@ class TapAnalysisHelper:
         except TapValidationError as ve:
             tap_analysis.set_is_valid(False)
             tap_analysis.set_validation_error(ve)
+            tap_analysis.log_trapq()
         # tap classifier always gets to process the data
         try:
             self._tap_classifier.classify(tap_analysis, gcmd)

--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -120,7 +120,7 @@ class DumpTrapQ:
             "motion_report/dump_trapq", "name", name, api_resp
         )
 
-    def extract_trapq(self, start_time, end_time):
+    def extract_trapq(self, start_time, end_time=NEVER_TIME):
         ffi_main, ffi_lib = chelper.get_ffi()
         res = []
         while True:
@@ -180,7 +180,7 @@ class DumpTrapQ:
 
     def _process_batch(self, eventtime):
         qtime = self.last_batch_msg[0] + min(self.last_batch_msg[1], 0.100)
-        data, cdata = self.extract_trapq(qtime, NEVER_TIME)
+        data, cdata = self.extract_trapq(qtime)
         d = [
             (
                 m.print_time,


### PR DESCRIPTION
I saw this happen on a printer I'm testing. It randomly failed to get the most recent move out of the trapq because the calculated `end_time` was not quite late enough. I'm not sure _why_ its suddenly happening, but it simply doesn't have to happen. The goal is to `tail` the `trapq`, not select moves from the middle of it.

* Change `MotionReport` to default to extracting all remaining moves in the trapq when the `end_time` is not specified. This is the most common use-case and was already supported internally with a `magic` constant.
* Update TapAnalysis to use this call pattern so it always gets all the moves.
* Add logging of the extracted trapq moves when TapAnalysis throws an exception. 

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
