### PR TITLE
Fix: ADS131M0X: use cacluated sample rate for rest_ticks

### DIFF
--- a/klippy/extras/load_cell/ads131m0x.py
+++ b/klippy/extras/load_cell/ads131m0x.py
@@ -241,7 +241,9 @@ class ADS131MxBase(LoadCellSensor):
         self.consecutive_fails = 0
         self.reset_chip()
         self.setup_chip()
-        rest_ticks = self.mcu.seconds_to_clock(1.0 / (10.0 * self.sps))
+        rest_ticks = self.mcu.seconds_to_clock(
+            1.0 / (10.0 * self.get_samples_per_second())
+        )
         self.query_ads131m0x_cmd.send([self.oid, rest_ticks])
         logging.info(f"{self.sensor_type} starting '{self.name}' measurements")
         self.ffreader.note_start()


### PR DESCRIPTION
The calculated sample rate takes the global chopper state into account which allows the real polling rate to be lower if global chopper is being used.

This allows for a little more headroom on constrained hardware.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
