### PR TITLE
stm32: Allow stm32g4 chips to select a bootloader

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -305,7 +305,7 @@ config STM32_DFU_ROM_ADDRESS
 choice
     prompt "Bootloader offset"
     config STM32_FLASH_START_2000
-        bool "8KiB bootloader" if (MACH_STM32F1 || MACH_STM32F070 || MACH_STM32G0 || MACH_STM32F0x2) && !MACH_AT32F403
+        bool "8KiB bootloader" if MACH_STM32F1 || MACH_STM32F070 || MACH_STM32G0 || MACH_STM32G4 || MACH_STM32F0x2
     config STM32_FLASH_START_5000
         bool "20KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_7000


### PR DESCRIPTION
## Summary
Cherry-picks upstream Klipper commit [9090377bb](https://github.com/Klipper3d/klipper/commit/9090377bbc28e3bd31a9d46746052048d91a5199) which adds `MACH_STM32G4` to the 8KiB bootloader condition in `src/stm32/Kconfig`, exposing the Bootloader Offset option for STM32G431 (and other G4) chips so they can be flashed via Katapult (CAN/USB).

Fixes #871.