### PR TITLE
Load Cell Probe Calibration Tools

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6156,8 +6156,10 @@ sensor_type:
 #   The distance in mm to slowly raise the probe to perform precise Z=0
 #   measurments. This move occurs immediately after the probe detects contact.
 #   The distance needs to be approximatly 2x the distance required for the probe
-#   to break contact with the bed. Valid range is 0.01 to 2.0 mm.
-#   The default is 0.2 mm.
+#   to break contact with the bed. Can be automatically calibrated using
+#   `LOAD_CELL_PROBE_CALIBRATE CALIBRATION=PULLBACK_DISTANCE`.
+#   See [Pullback Distance Calibration](Load_Cell.md#pullback-distance-calibration).
+#   Valid range is 0.01 to 2.0 mm. The default is 0.2 mm.
 #pullback_speed:
 #   The speed in mm/s for the pullback move after probe trigger. Valid range is
 #   0.1 to 1.0 mm/s. The default is set to 1 micron (0.001mm) per sensor sample.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6173,7 +6173,9 @@ sensor_type:
 #   The average angle of the decompression line for clean taps. The further the
 #   measured decompression angle is from this angle, the worse its tap quality score.
 #   There is no default, this must be measured. It is a number in degrees
-#   between 0 and 90.
+#   between 0 and 90. Can be automatically calibrated using
+#   `LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DECOMPRESSION_ANGLE`.
+#   See [Decompression Angle Calibration](Load_Cell.md#decompression-angle-calibration).
 #max_approach_force: 50
 #max_departure_force: 25
 #max_baseline_force_delta: 25

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6119,7 +6119,10 @@ sensor_type:
 #drift_filter_cutoff_frequency: 0.8
 #   Enable optional continuous taring while homing & probing to reject drift.
 #   The value is a frequency, in Hz, below which drift will be ignored. This
-#   option requires the SciPy library. Default: None
+#   option requires the SciPy library. Can be automatically calibrated using 
+#   `LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DRIFT_FILTER`. 
+#   See [Drift Filter Calibration](Load_Cell.md#drift-filter-calibration).
+#   Default: None
 #drift_filter_delay: 2
 #   The delay, or 'order', of the drift filter. This controls the number of
 #   samples required to make a trigger detection. Can be 1 or 2, the default

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1123,6 +1123,14 @@ corresponding settings from the
 - `MIN_TAP_QUALITY=<percent>`
 - `DECOMPRESSION_ANGLE=<angle>`
 
+### LOAD_CELL_PROBE_CALIBRATE
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=<calibration_type> [<parameters>]`: 
+Run automated calibration routines for load cell probe parameters. All calibrations
+probe a bed mesh and save results for the current session (use `SAVE_CONFIG` to persist).
+
+Calibration commands will be added in future commits. See 
+[Load Cell Calibration](Load_Cell.md#calibration) for detailed usage.
+
 ### [manual_probe]
 
 The manual_probe module is automatically loaded.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1128,8 +1128,40 @@ corresponding settings from the
 Run automated calibration routines for load cell probe parameters. All calibrations
 probe a bed mesh and save results for the current session (use `SAVE_CONFIG` to persist).
 
-Calibration commands will be added in future commits. See 
-[Load Cell Calibration](Load_Cell.md#calibration) for detailed usage.
+Available calibration types:
+- `DRIFT_FILTER`: Calibrate drift_filter_cutoff_frequency
+
+All calibrations accept [BED_MESH_CALIBRATE](#bed_mesh_calibrate) parameters for 
+controlling mesh point generation (PROFILE, MESH_MIN, MESH_MAX, PROBE_COUNT, ALGORITHM, etc.).
+See [Load Cell Calibration](Load_Cell.md#calibration) for detailed usage and examples.
+
+#### DRIFT_FILTER Calibration
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DRIFT_FILTER [MAXIMUM_Z_POSITION=<pos>] 
+[MAX_Z_VELOCITY=<vel>] [APPROACH_SPEED=<speed>] [SEGMENT_DURATION=<duration>] 
+[SLOPE_PERCENTILE=<pct>] [MAX_DRIFT_RATE=<drift_rate>] 
+[MAX_CUTOFF_FREQUENCY=<freq>] [CUTOFF_INCREMENT=<inc>] [<bed_mesh_parameters>]`
+
+Calibrates the drift filter cutoff frequency by measuring force drift during slow Z 
+descents at each mesh point. The drift filter removes slow force changes caused by 
+bowden tube movement, keeping the signal centered on zero.
+
+- **MAXIMUM_Z_POSITION**: Starting height for drift measurement. If not specified, 
+  defaults to the `maximum_z_position` from printer config.
+- **MAX_Z_VELOCITY**: Maximum speed for Z moves between points. If not specified, 
+  defaults to the `max_z_velocity` from printer config.
+- **APPROACH_SPEED**: Descent speed in mm/s during measurement (slower collects more 
+  data). The default is 10.0. Maximum value is 50.0.
+- **SEGMENT_DURATION**: Time window in seconds for drift analysis. The default is 5.0.
+- **SLOPE_PERCENTILE**: Which percentile of slopes must meet criteria (higher is 
+  stricter). The default is 99.0 (valid range: 0-100).
+- **MAX_DRIFT_RATE**: Maximum acceptable drift rate in grams/second. The 
+  default is 1.0.
+- **MAX_CUTOFF_FREQUENCY**: Upper limit for filter frequency in Hz. The default is 20.0.
+- **CUTOFF_INCREMENT**: Step size in Hz when searching for optimal frequency. The 
+  default is 0.1.
+
+See [Drift Filter Calibration](Load_Cell.md#drift-filter-calibration) for interpretation 
+and troubleshooting.
 
 ### [manual_probe]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1130,6 +1130,7 @@ probe a bed mesh and save results for the current session (use `SAVE_CONFIG` to 
 
 Available calibration types:
 - `DRIFT_FILTER`: Calibrate drift_filter_cutoff_frequency
+- `PULLBACK_DISTANCE`: Calibrate pullback_distance
 
 All calibrations accept [BED_MESH_CALIBRATE](#bed_mesh_calibrate) parameters for 
 controlling mesh point generation (PROFILE, MESH_MIN, MESH_MAX, PROBE_COUNT, ALGORITHM, etc.).
@@ -1160,8 +1161,20 @@ bowden tube movement, keeping the signal centered on zero.
 - **CUTOFF_INCREMENT**: Step size in Hz when searching for optimal frequency. The 
   default is 0.1.
 
-See [Drift Filter Calibration](Load_Cell.md#drift-filter-calibration) for interpretation 
-and troubleshooting.
+See [Drift Filter Calibration](Load_Cell.md#drift-filter-calibration)
+
+#### PULLBACK_DISTANCE Calibration  
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=PULLBACK_DISTANCE [PULLBACK_DISTANCE=<dist>]
+[<bed_mesh_parameters>]`
+
+Optimizes the `pullback_distance` parameter by measuring actual decompression distances during 
+normal probing across the bed. Computes a safe minimum using statistical analysis:
+`(mean + 3σ) × 2.0`.
+
+- **PULLBACK_DISTANCE**: Temporary pullback distance in mm to use during calibration 
+  testing. The default is 1.0 (valid range: 0.5-2.0).
+
+See [Pullback Distance Calibration](Load_Cell.md#pullback-distance-calibration)
 
 ### [manual_probe]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1131,6 +1131,7 @@ probe a bed mesh and save results for the current session (use `SAVE_CONFIG` to 
 Available calibration types:
 - `DRIFT_FILTER`: Calibrate drift_filter_cutoff_frequency
 - `PULLBACK_DISTANCE`: Calibrate pullback_distance
+- `DECOMPRESSION_ANGLE`: Calibrate decompression_angle
 
 All calibrations accept [BED_MESH_CALIBRATE](#bed_mesh_calibrate) parameters for 
 controlling mesh point generation (PROFILE, MESH_MIN, MESH_MAX, PROBE_COUNT, ALGORITHM, etc.).
@@ -1175,6 +1176,20 @@ normal probing across the bed. Computes a safe minimum using statistical analysi
   testing. The default is 1.0 (valid range: 0.5-2.0).
 
 See [Pullback Distance Calibration](Load_Cell.md#pullback-distance-calibration)
+
+#### DECOMPRESSION_ANGLE Calibration
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DECOMPRESSION_ANGLE [<bed_mesh_parameters>]`
+
+Enables and calibrates the tap quality checking system. Measures the pullback angle 
+across clean probes to establish a baseline.
+
+No calibration-specific parameters.
+
+**Prerequisites**: Run DRIFT_FILTER and PULLBACK_DISTANCE calibrations first. Ensure 
+nozzle is completely clean.
+
+See [Decompression Angle Calibration](Load_Cell.md#decompression-angle-calibration)
+for choosing thresholds and interpreting results.
 
 ### [manual_probe]
 

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -241,6 +241,40 @@ PROBE HOME=Z
 
 Load cell probes support automated calibrations with the `LOAD_CELL_PROBE_CALIBRATE` command (([docs](G-Codes.md#load_cell_probe_calibrate))). These calibration tools probe a bed mesh or move the Z axis and analyze the results to determine optimal settings. All calibrations use the same mesh points as `BED_MESH_CALIBRATE` and save parameters for the current session (use `SAVE_CONFIG` to persist).
 
+#### Drift Filter Calibration
+
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DRIFT_FILTER`
+
+Calibrates the drift filter cutoff frequency. The drift filter removes slow force changes caused by bowden tube movement during probing, keeping the signal centered on zero.
+
+**Prerequisites:** This feature requires the SciPy library. See [Installing SciPy](#installing-scipy).
+
+The calibration moves from maximum Z to `horizontal_move_z` at each mesh point, recording force data. It tests increasing filter frequencies until drift is eliminated, then returns the lowest frequency that works at all positions.
+
+**Hints**
+* If the probe triggers early, before touching the bed, this is probably the reason why.
+* If the machine cannot complete Z homing, you can manually home it and run this calibration.
+* This calibration can be slow. Using fewer mesh points can speed things up and still give usable results, e.g. `PROBE_COUNT=3,3`. All [BED_MESH_CALIBRATE](G-Codes.md#bed_mesh_calibrate) parameters for mesh point generation.
+
+**Example output:**
+```
+// Minimum drift filter cutoff: 5.2Hz
+// drift_filter_cutoff_frequency=5.2
+// This has been saved for the current session.
+// The SAVE_CONFIG command will update the printer config file with the above and restart the printer.
+```
+
+**Normal range:** 1-20Hz. Lower values indicate minimal drift, higher values suggest more bowden movement.
+
+**Partial failures:** If some positions exceed the 20Hz limit, the calibration uses the highest successful frequency but warns. This may still be usable if only a few positions failed.
+
+**Troubleshooting:**
+If the calibration fails, look at the bowden tube motion during the calibration. Bowden tube routing should minimize snagging and sudden shaking.
+
+**Re-calibrate when:**
+- Bowden tube routing changes
+- Experiencing probe failures when probing from max Z
+
 ### Probing Temperature
 
 Keep nozzle temperature below the filament oozing point during homing and probing. 140°C is a good starting point for all filament types.
@@ -319,9 +353,9 @@ The circle strategy is a feature of `[probe]`. When the load cell probe detects 
 
 ## Advanced Configuration
 
-### Continuous Tare Filtering
+### Drift Filter (Continuous Taring)
 
-Load cell probes support a filter on the MCU that compensates for drift from external forces such as bowden tubes and umbilical cables. If the probe triggers before touching the bed this is probably the reason why. This is sometimes called *continuous taring* and is intended for toolhead-mounted sensors experiencing variable external forces during a probe.
+Load cell probes support a drift filter on the MCU that compensates for external forces such as bowden tubes and umbilical cables. If the probe triggers before touching the bed this is probably the reason why. This is sometimes called *continuous taring* and is intended for toolhead-mounted sensors experiencing variable external forces during a probe.
 
 #### Installing SciPy
 
@@ -335,20 +369,13 @@ Pre-compiled builds are available for Python 3 on 32-bit Raspberry Pi systems.
 
 #### Filter Tuning
 
-The `drift_filter_cutoff_frequency` parameter should be selected based on observed drift during normal operation.
+The `drift_filter_cutoff_frequency` parameter can be automatically calibrated using `LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DRIFT_FILTER`. See [Drift Filter Calibration](#drift-filter-calibration) for details.
 
-Basic tuning guidelines:
-- Start with `drift_filter_cutoff_frequency: 0.5` Hz
-- Prusa uses 0.8 Hz (MK4) and 11.2 Hz (XL); this range is reasonable for experimentation
-- Increase only until bowden tube drift is eliminated
-- Setting too high causes slow triggering and excessive force
-- Keep `trigger_force` low (default 75 g); the drift filter maintains internal readings near zero
-- Keep `force_safety_limit` conservative (default 2 kg) during tuning
-- Keep `drift_safety_limit` conservative (default 1 kg) during tuning
-- **Note:** Over-aggressive `drift_filter_cutoff_frequency` can distort tap shape and timing, triggering validation failures (e.g., `TAP_BREAK_CONTACT_TOO_LATE`). Reduce cutoff frequency or probing speed if such errors appear.
+**Manual tuning:** If you prefer manual tuning, start with `drift_filter_cutoff_frequency: 0.5` Hz and increase only until bowden tube drift is eliminated. Setting too high causes slow triggering and excessive force. Keep `trigger_force` low (default 75 g); the drift filter maintains internal readings near zero.
 
-Tuning of the other filter parameters is beyond the scope of this documentation. 
-A Jupyter notebook is provided in [scripts/filter_workbench.ipynb](../scripts/filter_workbench.ipynb) with an example of a detailed analysis.
+**Note:** Over-aggressive `drift_filter_cutoff_frequency` can distort tap shape and timing, triggering validation failures (e.g., `TAP_BREAK_CONTACT_TOO_LATE`). Reduce cutoff frequency or probing speed if such errors appear.
+
+Manual tuning of other filter parameters is beyond the scope of this documentation. A Jupyter notebook is provided in [scripts/filter_workbench.ipynb](../scripts/filter_workbench.ipynb) with an example of detailed analysis.
 
 ### Tap Validation
 

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -237,6 +237,10 @@ Load cell probes support homing the Z axis. Homing is less accurate than probing
 PROBE HOME=Z
 ```
 
+### Calibration
+
+Load cell probes support automated calibrations with the `LOAD_CELL_PROBE_CALIBRATE` command (([docs](G-Codes.md#load_cell_probe_calibrate))). These calibration tools probe a bed mesh or move the Z axis and analyze the results to determine optimal settings. All calibrations use the same mesh points as `BED_MESH_CALIBRATE` and save parameters for the current session (use `SAVE_CONFIG` to persist).
+
 ### Probing Temperature
 
 Keep nozzle temperature below the filament oozing point during homing and probing. 140°C is a good starting point for all filament types.

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -275,6 +275,24 @@ If the calibration fails, look at the bowden tube motion during the calibration.
 - Bowden tube routing changes
 - Experiencing probe failures when probing from max Z
 
+#### Pullback Distance Calibration
+
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=PULLBACK_DISTANCE`
+
+Optimizes the `pullback_distance` parameter for faster probing. The default is conservative; calibration may reduce it based on the probes measured decompression behavior. The calibration probes a bed mesh and measures the decompression distance at each point (Z travel from decompression start to contact break). It calculates a safe minimum: `(mean + 3σ) × 2.0`. It accepts all [BED_MESH_CALIBRATE](G-Codes.md#bed_mesh_calibrate) parameters for mesh point generation.
+
+**Example output:**
+```
+// Decompression Distance: mean=0.0607mm, min=0.0498mm, max=0.0758mm, std=0.0080mm
+// pullback_distance=0.1693
+// This has been saved for the current session.
+// The SAVE_CONFIG command will update the printer config file with the above and restart the printer.
+```
+
+The most likely cause of a high standard deviation is contamination on the nozzle. Make sure the nozzle is clean prior to running the calibration. Another likely cause is a "springy" bed. If the bed flexes significantly during probing it may not be suitable for a load cell probe.
+
+Re-calibrate when changes are made to `probe_speed` or `trigger_force`, these affect overshoot which determines the required pullback distance.
+
 ### Probing Temperature
 
 Keep nozzle temperature below the filament oozing point during homing and probing. 140°C is a good starting point for all filament types.

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -293,6 +293,37 @@ The most likely cause of a high standard deviation is contamination on the nozzl
 
 Re-calibrate when changes are made to `probe_speed` or `trigger_force`, these affect overshoot which determines the required pullback distance.
 
+#### Decompression Angle Calibration
+
+`LOAD_CELL_PROBE_CALIBRATE CALIBRATION=DECOMPRESSION_ANGLE` ([docs](G-Codes.md#load_cell_probe_calibrate))
+
+Enables and calibrates tap quality checking. This detects nozzle ooze during probing by comparing tap geometry to a clean baseline. See [Tap Quality Components](#tap-quality-components) for details on how the score is calculated.
+
+**Prerequisites:** Run DRIFT_FILTER and PULLBACK_DISTANCE calibrations first. Ensure nozzle is completely clean.
+
+The calibration probes the bed mesh and measures the decompression line slope at each point. It calculates the mean angle.
+
+Accepts all [BED_MESH_CALIBRATE](G-Codes.md#bed_mesh_calibrate) parameters for mesh point generation.
+
+**Example output:**
+```
+// DECOMPRESSION_ANGLE_CALIBRATION Complete:
+// Tap Quality average: 87.7%, min: 70.8%, max: 95.2%, std dev: 4.4%
+// 
+// Mean Decompression Angle: 78.6 degrees
+// decompression_angle=78.6
+// This has been saved for the current session.
+// The SAVE_CONFIG command will update the printer config file and restart the printer.
+```
+
+**Choosing a threshold:** The calibration does not automatically set `min_tap_quality`. The default is 40%. In testing the observed tap quality score drops quite significantly before any actual Z error can be detected. Taps with a small amount of ooze have a very different `tap_quality` mean and standard deviation than clean taps. Choose based on experience:
+- Higher thresholds (70-80%): Stricter, may cause retries on acceptable taps
+- Lower thresholds (5-20%): Too permissive, only catches severe ooze
+
+**Re-calibrate when:**
+- `pullback_speed` or load cell sample rate changes
+- Tap quality warnings become too frequent or too rare
+
 ### Probing Temperature
 
 Keep nozzle temperature below the filament oozing point during homing and probing. 140°C is a good starting point for all filament types.
@@ -450,7 +481,7 @@ The classifier uses ratio metrics to make it more transferable between different
 | Dwell Force Drop               | The drop in force during the dwell over the compression force.                                                                                                                    | While some drop is not unusual, large drops are associated with plastic oozing out from between the nozzle and the bed. |
 | Normalized Decompression Angle | How closely the slope of the decompression line matches the ideal decompression slope.  Normalized as `(actual - expected) / expected`                                            | Ooze can pull on the nozzle, changing the slope. This ruins the accuracy of the measurement.                            |
 
-These factors are all combined to give the final quality score. The only component that has to be measured on the printer is the **Normalized Decompression Angle**.
+These factors are all combined to give the final quality score. The only component that has to be measured on the printer is the **Normalized Decompression Angle**. This can be automatically set with [Decompression Angle Calibration](#decompression-angle-calibration). Until this is angle is set the tap quality classifier is off.
 
 Each component has a maximum cutoff value. If the component is above the cutoff, the tap quality score drops to 0%. Each value is a percentage of the compression force:
 

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -8,6 +8,8 @@ import json
 import logging
 import math
 
+from klippy.gcode import GCodeCommand
+
 from . import probe
 from .danger_options import get_danger_options
 
@@ -289,6 +291,11 @@ class BedMesh:
                         "Mesh Leveling: Error splitting move "
                     )
         self.last_position[:] = newpos
+
+    def generate_points(
+        self, gcmd: GCodeCommand, profile_name: str = "default"
+    ):
+        return self.bmc.generate_points(gcmd, profile_name)
 
     def get_status(self, eventtime=None):
         return self.status
@@ -998,14 +1005,20 @@ class BedMeshCalibrate:
             adj_pts.append(self.zero_ref_pos)
         return adj_pts
 
-    cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
-
-    def cmd_BED_MESH_CALIBRATE(self, gcmd):
-        self._profile_name = gcmd.get("PROFILE", "default")
+    def generate_points(
+        self, gcmd: GCodeCommand, profile_name: str = "default"
+    ):
+        self._profile_name = gcmd.get("PROFILE", profile_name)
         if not self._profile_name.strip():
             raise gcmd.error("Value for parameter 'PROFILE' must be specified")
         self.bedmesh.set_mesh(None)
         self.update_config(gcmd)
+        return self._get_adjusted_points()
+
+    cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
+
+    def cmd_BED_MESH_CALIBRATE(self, gcmd):
+        self.generate_points(gcmd)
         self.probe_helper.start_probe(gcmd)
 
     def probe_finalize(self, offsets, positions):

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -1011,5 +1011,8 @@ class LoadCellPrinterProbe:
         printer_probe = PrinterProbe(config, wrapper)
         self._printer.add_object("probe", printer_probe)
 
+    def add_client(self, callback):
+        self._tap_analysis_helper.add_client(callback)
+
     def get_status(self, eventtime):
         return self._tapping_move.get_status(eventtime)

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -26,6 +26,7 @@ from .load_cell import (
     LoadCellSampleCollector,
 )
 from .tap_analysis import TapAnalysis, TapAnalysisHelper, TapClassifierModule
+from .tap_quality_classifier import TapQualityClassifier
 
 # constants for fixed point numbers
 Q2_INT_BITS = 2
@@ -1321,6 +1322,7 @@ class LoadCellPrinterProbe:
         self._config = config
         self._printer = config.get_printer()
         self._load_cell = LoadCell(config, sensor)
+        self._tap_classifier = tap_classifier
         # Read all user configuration and build modules
         name = config.get_name()
         self._tap_analysis_helper = TapAnalysisHelper(
@@ -1390,6 +1392,15 @@ class LoadCellPrinterProbe:
             self._drift_filter_calibration.calibrate(gcmd)
         elif calibration == "PULLBACK_DISTANCE":
             self._pullback_distance_calibration.calibrate(gcmd)
+        elif calibration == "DECOMPRESSION_ANGLE" and isinstance(
+            self._tap_classifier, TapQualityClassifier
+        ):
+            self._tap_classifier.calibrate(gcmd)
+        elif not calibration:
+            raise gcmd.error(
+                "CALIBRATION must be one of DRIFT_FILTER, "
+                "PULLBACK_DISTANCE or DECOMPRESSION_ANGLE"
+            )
         else:
             raise gcmd.error(f"Unknown CALIBRATION value '{calibration}'")
 

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from klippy import mcu
 from klippy.configfile import ConfigWrapper, PrinterConfig
 from klippy.extras.bed_mesh import BedMesh
 from klippy.extras.homing import PrinterHoming
-from klippy.extras.probe import PrinterProbe
+from klippy.extras.probe import PrinterProbe, ProbePointsHelper
 from klippy.gcode import GCodeCommand, GCodeDispatch
 from klippy.printer import Printer
 from klippy.toolhead import ToolHead
@@ -25,7 +25,7 @@ from .load_cell import (
     LoadCell,
     LoadCellSampleCollector,
 )
-from .tap_analysis import TapAnalysisHelper, TapClassifierModule
+from .tap_analysis import TapAnalysis, TapAnalysisHelper, TapClassifierModule
 
 # constants for fixed point numbers
 Q2_INT_BITS = 2
@@ -419,6 +419,13 @@ class LoadCellProbeConfigHelper:
 
     def is_pullback_move_disabled(self) -> bool:
         return self._disable_pullback_move
+
+    def set_pullback_distance(self, value):
+        self._pullback_distance_param.set(value)
+
+    def save_pullback_distance(self, value):
+        self._pullback_distance_param.set(value)
+        self._pullback_distance_param.save()
 
     def get_rest_time(self) -> float:
         return self._rest_time
@@ -1192,6 +1199,118 @@ class DriftFilterCalibration:
         return math.nan
 
 
+class PullbackDistanceCalibration:
+    def __init__(
+        self,
+        config: ConfigWrapper,
+        config_helper: LoadCellProbeConfigHelper,
+        register_tap_callback: Callable,
+    ):
+        self._config = config
+        self._config_helper = config_helper
+        self._register_tap_callback = register_tap_callback
+        self._printer = config.get_printer()
+        self._bed_mesh_config = None
+        if config.has_section("bed_mesh"):
+            self._bed_mesh_config = config.getsection("bed_mesh")
+        self._calibrating = False
+        self._gcmd: Optional[GCodeCommand] = None
+        self._distances: list[float] = []
+        self._forces: list[float] = []
+
+    @staticmethod
+    def _decompression_distance(tap: TapAnalysis) -> tuple[float, float]:
+        if not tap.is_valid():
+            return math.nan, math.nan
+
+        tap_points = tap.get_tap_points()
+        decompression_start_z = tap.get_toolhead_position(tap_points[3].time)[2]
+        decompression_start_force = tap_points[3].force
+        break_contact_z = tap.get_toolhead_position(tap_points[4].time)[2]
+        break_contact_force = tap_points[4].force
+        return (
+            abs(decompression_start_z - break_contact_z),
+            abs(decompression_start_force - break_contact_force),
+        )
+
+    def _tap_callback(self, tap: TapAnalysis):
+        if not self._calibrating or isinstance(tap, dict):
+            return self._calibrating
+        decomp_dist, decomp_force = self._decompression_distance(tap)
+        if math.isnan(decomp_dist):
+            # TODO: consider if we want to allow this...
+            return self._calibrating
+        self._distances.append(decomp_dist)
+        self._forces.append(decomp_force)
+        self._gcmd.respond_info(
+            f"Decompression distance: {self._distances[-1]:.3f}mm, force: "
+            f"{self._forces[-1]:.0f}g"
+        )
+        return self._calibrating
+
+    def _finalize_callback(self, probe_offsets, results):
+        pass
+
+    def calibrate(self, gcmd: GCodeCommand):
+        self._gcmd = gcmd
+        gcmd.respond_info("Starting pullback_distance calibration...")
+        bed_mesh: BedMesh = self._printer.lookup_object(
+            "bed_mesh", default=None
+        )
+        if bed_mesh is None:
+            raise gcmd.error("bed_mesh not configured")
+
+        original_pullback_distance = self._config_helper.get_pullback_distance()
+        pullback_distance = gcmd.get_float(
+            "PULLBACK_DISTANCE", default=1.0, minval=0.5, maxval=2.0
+        )
+        self._config_helper.set_pullback_distance(pullback_distance)
+        self._calibrating: bool = True
+        self._register_tap_callback(self._tap_callback)
+        self._distances = []
+        self._forces = []
+
+        try:
+            points = bed_mesh.generate_points(
+                gcmd, "pullback_distance_calibrate"
+            )
+            points_helper = ProbePointsHelper(
+                self._bed_mesh_config,
+                self._finalize_callback,
+                points,
+                use_offsets=True,
+                enable_horizontal_z_clearance=True,
+            )
+            points_helper.start_probe(gcmd)
+        finally:
+            self._calibrating = False
+            self._register_tap_callback(None)
+            # restore state in case of an error
+            self._config_helper.set_pullback_distance(
+                original_pullback_distance
+            )
+
+        min_distance = min(self._distances)
+        max_distance = max(self._distances)
+        mean_distance = float(np.mean(self._distances))
+        mean_force = float(np.mean(self._forces))
+        distance_std = float(np.std(self._distances))
+        pullback_distance = (mean_distance + (3.0 * distance_std)) * 2.0
+        deflection_per_kg = (mean_distance / mean_force) * 1000.0
+
+        self._config_helper.save_pullback_distance(pullback_distance)
+        gcmd.respond_info(
+            f"Decompression Distance: mean={mean_distance:.4f}mm, "
+            f"min={min_distance:.4f}mm, max={max_distance:.4f}mm, "
+            f"std={distance_std:.4f}mm\n"
+            f"pullback_distance={pullback_distance:.4f}\n"
+            f"deflection per kilogram={deflection_per_kg:.1f}mm\n"
+            "This has been saved for the current session.\n"
+            "The SAVE_CONFIG command will update the printer config file "
+            "with the above and restart the printer."
+        )
+
+
 class LoadCellPrinterProbe:
     def __init__(
         self,
@@ -1207,7 +1326,7 @@ class LoadCellPrinterProbe:
         self._tap_analysis_helper = TapAnalysisHelper(
             self._printer, name, tap_classifier
         )
-        config_helper = LoadCellProbeConfigHelper(config, self._load_cell)
+        self._config_helper = LoadCellProbeConfigHelper(config, self._load_cell)
         self._mcu = self._load_cell.get_sensor().get_mcu()
         trigger_dispatch = mcu.TriggerDispatch(self._mcu)
         continuous_tare_filter_helper = ContinuousTareFilterHelper(
@@ -1218,21 +1337,21 @@ class LoadCellPrinterProbe:
             config,
             self._load_cell,
             continuous_tare_filter_helper.get_sos_filter(),
-            config_helper,
+            self._config_helper,
             trigger_dispatch,
         )
         self._load_cell_primitives = LoadCellPrimitives(
             config,
             self._mcu_load_cell_probe,
             continuous_tare_filter_helper,
-            config_helper,
+            self._config_helper,
         )
         homing_move = HomingMove(config, self._load_cell_primitives)
         self._tapping_move = TappingMove(
             config,
             self._load_cell_primitives,
             self._tap_analysis_helper,
-            config_helper,
+            self._config_helper,
         )
         # printer integration
         LoadCellProbeCommands(config, self._load_cell_primitives)
@@ -1247,6 +1366,11 @@ class LoadCellPrinterProbe:
             continuous_tare_filter_helper,
             self._load_cell_primitives.tare,
             self._load_cell,
+        )
+        self._pullback_distance_calibration = PullbackDistanceCalibration(
+            config,
+            self._config_helper,
+            self._tap_analysis_helper.set_calibration_callback,
         )
         self._register_macros()
 
@@ -1264,6 +1388,8 @@ class LoadCellPrinterProbe:
         calibration: str = gcmd.get("CALIBRATION")
         if calibration == "DRIFT_FILTER":
             self._drift_filter_calibration.calibrate(gcmd)
+        elif calibration == "PULLBACK_DISTANCE":
+            self._pullback_distance_calibration.calibrate(gcmd)
         else:
             raise gcmd.error(f"Unknown CALIBRATION value '{calibration}'")
 

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -3,16 +3,21 @@
 # Copyright (C) 2025  Gareth Farrington <gareth@waves.ky>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import math
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
 from klippy import mcu
-from klippy.configfile import ConfigWrapper
+from klippy.configfile import ConfigWrapper, PrinterConfig
+from klippy.extras.bed_mesh import BedMesh
 from klippy.extras.homing import PrinterHoming
 from klippy.extras.probe import PrinterProbe
-from klippy.gcode import GCodeCommand
+from klippy.gcode import GCodeCommand, GCodeDispatch
+from klippy.printer import Printer
+from klippy.toolhead import ToolHead
 
 from . import sos_filter
 from .interfaces import LoadCellSensor
@@ -34,9 +39,9 @@ Q16_FRAC_BITS = 32 - (1 + Q16_INT_BITS)
 class ParamHelper:
     def __init__(
         self,
-        config,
-        name,
-        type_name,
+        config: ConfigWrapper,
+        name: str,
+        type_name: str,
         default=None,
         minval=None,
         maxval=None,
@@ -44,6 +49,7 @@ class ParamHelper:
         below=None,
         max_len=None,
     ):
+        self._printer: Printer = config.get_printer()
         self._config_section = config.get_name()
         self._config_error = config.error
         self.name = name
@@ -153,6 +159,13 @@ class ParamHelper:
             return self._get_float(config, gcmd, minval, maxval, above, below)
         else:
             return self._get_float_list(config, gcmd, above, below)
+
+    def set(self, value):
+        self.value = value
+
+    def save(self):
+        configfile: PrinterConfig = self._printer.lookup_object("configfile")
+        configfile.set(self._config_section, self.name, self.value)
 
 
 def intParamHelper(config, name, default=None, minval=None, maxval=None):
@@ -327,6 +340,10 @@ class ContinuousTareFilterHelper:
 
     def get_sos_filter(self) -> sos_filter.SosFilter:
         return self._sos_filter
+
+    def save_drift_filter_cutoff_frequency(self, value):
+        self._drift_param.set(value)
+        self._drift_param.save()
 
 
 # check results from the collector for errors and raise an exception is found
@@ -962,6 +979,219 @@ class LoadCellEndstopWrapper:
         return status
 
 
+class DriftFilterCalibration:
+    def __init__(
+        self,
+        config: ConfigWrapper,
+        config_helper: ContinuousTareFilterHelper,
+        tare_callback,
+        load_cell: LoadCell,
+    ):
+        self._config_helper = config_helper
+        self._tare_callback = tare_callback
+        self._load_cell = load_cell
+        self._printer: Printer = config.get_printer()
+        self._horizontal_move_z: float = 5.0
+        if config.has_section("bed_mesh"):
+            bed_mesh_config = config.getsection("bed_mesh")
+            self._horizontal_move_z: float = bed_mesh_config.getfloat(
+                "horizontal_move_z", 5.0, note_valid=False
+            )
+        self._max_z_position: Optional[float] = None
+        if config.has_section("stepper_z"):
+            zconfig = config.getsection("stepper_z")
+            self._max_z_position = zconfig.getfloat(
+                "position_max", None, note_valid=False
+            )
+        if self._max_z_position is None:
+            raise config.error("Printer has no configured maximum z-position")
+        pconfig = config.getsection("printer")
+        self._max_z_velocity: float = pconfig.getfloat(
+            "max_z_velocity", None, note_valid=False
+        )
+        if self._max_z_velocity is None:
+            raise config.error("Printer has no configured maximum z-velocity")
+
+    def calibrate(self, gcmd: GCodeCommand):
+        try:
+            import scipy.signal as signal
+
+            _ = signal
+        except:
+            raise gcmd.error("Drift Filter requires the SciPy module")
+        toolhead: ToolHead = self._printer.lookup_object("toolhead")
+        # delta kinematics have a z limit that is lower than stepper limit:
+        kinematics = toolhead.get_kinematics()
+        if hasattr(kinematics, "limit_z"):
+            self._max_z_position = kinematics.limit_z
+        probe = self._printer.lookup_object("probe")
+        bed_mesh: BedMesh = self._printer.lookup_object(
+            "bed_mesh", default=None
+        )
+        if bed_mesh is None:
+            raise gcmd.error("bed_mesh not configured")
+
+        # Calibration parameters
+        max_z_position = gcmd.get_float(
+            "MAXIMUM_Z_POSITION", minval=0, default=self._max_z_position
+        )
+        max_z_velocity = gcmd.get_float(
+            "MAX_Z_VELOCITY", minval=0, default=self._max_z_velocity
+        )
+        approach_speed = gcmd.get_float(
+            "APPROACH_SPEED", 10.0, above=0.0, maxval=50.0
+        )
+        segment_duration = gcmd.get_float("SEGMENT_DURATION", 5.0, above=0.0)
+        slope_percentile = gcmd.get_float(
+            "SLOPE_PERCENTILE", 99.0, minval=0.0, maxval=100.0
+        )
+        max_drift_rate = gcmd.get_float("MAX_DRIFT_RATE", 1.0, above=0.0)
+        max_cutoff_frequency = gcmd.get_float(
+            "MAX_CUTOFF_FREQUENCY", 20.0, above=0.0
+        )
+        cutoff_increment = gcmd.get_float("CUTOFF_INCREMENT", 0.1, above=0.0)
+
+        gcmd.respond_info("Starting drift filter calibration...")
+        points = bed_mesh.generate_points(gcmd, "drift_filter_calibrate")
+        # Get actual approach speed (limited by Z max speed)
+        approach_speed = min(approach_speed, max_z_velocity)
+
+        gcmd.respond_info(
+            f"Collecting drift data at {len(points)} points\n"
+            f"Z range: {max_z_position:.1f} -> {self._horizontal_move_z:.1f}mm\n"
+            f"Approach speed: {approach_speed:.1f}mm/s"
+        )
+
+        # Get probe offsets for XY positioning
+        max_filter_cutoff = cutoff_increment
+        # Get sampling rate from sensor
+        probe_offset_x, probe_offset_y, _ = probe.get_offsets()
+        sample_rate: int = self._load_cell.get_sensor().get_samples_per_second()
+        failed_count = 0
+        for i, point in enumerate(points):
+            # Adjust for probe offset (this should be 0 for a nozzle probe)
+            point = [
+                point[0] - probe_offset_x,
+                point[1] - probe_offset_y,
+                max_z_position,
+            ]
+            # Move to XY position at max Z
+            toolhead.manual_move(point, max_z_velocity)
+            toolhead.wait_moves()
+            # Tare the sensor (probing_move behavior)
+            self._tare_callback(gcmd)
+            # Start collecting samples
+            collector: LoadCellSampleCollector = self._load_cell.get_collector()
+            print_time = toolhead.get_last_move_time()
+            collector.start_collecting(min_time=print_time)
+            try:
+                # Start the downward move
+                point[2] = self._horizontal_move_z
+                toolhead.manual_move(point, approach_speed)
+                toolhead.wait_moves()
+                move_end_time = toolhead.get_last_move_time()
+            except Exception as ex:
+                collector.stop_collecting()
+                raise ex
+            # Stop collecting
+            samples, errors = collector.collect_until(move_end_time)
+            if errors:
+                raise gcmd.error("Load cell errors detected!")
+            force = np.array(samples)[:, 1]
+            cutoff_freq = self._run_calibration(
+                force,
+                sample_rate,
+                segment_duration,
+                slope_percentile,
+                max_cutoff_frequency,
+                max_filter_cutoff,
+                cutoff_increment,
+                max_drift_rate,
+                gcmd,
+            )
+            if math.isnan(cutoff_freq):
+                failed_count += 1
+            else:
+                max_filter_cutoff = cutoff_freq
+        self._config_helper.save_drift_filter_cutoff_frequency(
+            round(max_filter_cutoff, 4)
+        )
+        if failed_count > 0:
+            raise gcmd.error(
+                f"WARNING: {failed_count} calibrations failed with the "
+                f"max_cutoff_frequency={max_cutoff_frequency}Hz"
+            )
+        gcmd.respond_info(
+            f"Minimum drift filter cutoff: {max_filter_cutoff:.1f}Hz\n"
+            f"drift_filter_cutoff_frequency={max_filter_cutoff:.1f}\n"
+            "This has been saved for the current session.\n"
+            "The SAVE_CONFIG command will update the printer config file "
+            "with the above and restart the printer."
+        )
+
+    @staticmethod
+    def _calculate_segment_slopes(force_data, sampling_rate, segment_duration):
+        """Split the graph into segments and calculate a slope for each."""
+        segment_samples = int(segment_duration * sampling_rate)
+        num_segments = len(force_data) // segment_samples
+        segments = np.array_split(force_data, num_segments)
+        slopes = []
+        for segment in segments:
+            time = np.arange(len(segment)) / sampling_rate
+            coefficients = np.polyfit(time, segment, 1)
+            slopes.append(coefficients[0])
+        return np.array(slopes)
+
+    @staticmethod
+    def _apply_drift_filter(force_data, cutoff_freq, sampling_rate):
+        import scipy.signal as signal
+
+        sos = signal.butter(
+            1, cutoff_freq, fs=sampling_rate, btype="highpass", output="sos"
+        )
+        # use zi to immediately have the filter start in a steady state at 0
+        zi = signal.sosfilt_zi(sos)
+        zi = zi * force_data[0]
+        filtered_data, zo = signal.sosfilt(sos, force_data, zi=zi)
+        return filtered_data
+
+    def _run_calibration(
+        self,
+        force_data: np.ndarray,
+        sampling_rate: float,
+        segment_duration: float,
+        slope_percentile: float,
+        max_cutoff_frequency: float,
+        cutoff: float,
+        cutoff_increment: float,
+        max_drift_rate: float,
+        gcmd: GCodeCommand,
+    ):
+        current_cutoff = cutoff
+        while current_cutoff <= max_cutoff_frequency:
+            filtered_data = self._apply_drift_filter(
+                force_data, current_cutoff, sampling_rate
+            )
+            filtered_slopes = self._calculate_segment_slopes(
+                filtered_data, sampling_rate, segment_duration
+            )
+            post_filter_pct = float(
+                np.percentile(np.abs(filtered_slopes), slope_percentile)
+            )
+            if post_filter_pct <= max_drift_rate:
+                gcmd.respond_info(
+                    f"Cutoff frequency: {current_cutoff:.4f} Hz\n"
+                )
+                return current_cutoff
+            current_cutoff += cutoff_increment
+        gcmd.respond_info(
+            f"Calibration FAILED\n"
+            f"Could not meet criteria within the {max_cutoff_frequency}Hz "
+            f"limit\n"
+        )
+        return math.nan
+
+
 class LoadCellPrinterProbe:
     def __init__(
         self,
@@ -969,6 +1199,7 @@ class LoadCellPrinterProbe:
         sensor: LoadCellSensor,
         tap_classifier: TapClassifierModule,
     ):
+        self._config = config
         self._printer = config.get_printer()
         self._load_cell = LoadCell(config, sensor)
         # Read all user configuration and build modules
@@ -990,26 +1221,33 @@ class LoadCellPrinterProbe:
             config_helper,
             trigger_dispatch,
         )
-        load_cell_primitives = LoadCellPrimitives(
+        self._load_cell_primitives = LoadCellPrimitives(
             config,
             self._mcu_load_cell_probe,
             continuous_tare_filter_helper,
             config_helper,
         )
-        homing_move = HomingMove(config, load_cell_primitives)
+        homing_move = HomingMove(config, self._load_cell_primitives)
         self._tapping_move = TappingMove(
             config,
-            load_cell_primitives,
+            self._load_cell_primitives,
             self._tap_analysis_helper,
             config_helper,
         )
         # printer integration
-        LoadCellProbeCommands(config, load_cell_primitives)
+        LoadCellProbeCommands(config, self._load_cell_primitives)
         wrapper = LoadCellEndstopWrapper(
             config, homing_move, self._tapping_move
         )
         printer_probe = PrinterProbe(config, wrapper)
         self._printer.add_object("probe", printer_probe)
+        # calibration macro setup:
+        self._drift_filter_calibration = DriftFilterCalibration(
+            config,
+            continuous_tare_filter_helper,
+            self._load_cell_primitives.tare,
+            self._load_cell,
+        )
         self._register_macros()
 
     def _register_macros(self):
@@ -1024,8 +1262,8 @@ class LoadCellPrinterProbe:
 
     def cmd_LOAD_CELL_PROBE_CALIBRATE(self, gcmd: GCodeCommand):
         calibration: str = gcmd.get("CALIBRATION")
-        if calibration == "TEST":
-            gcmd.respond_info(f"CALIBRATION is {calibration}")
+        if calibration == "DRIFT_FILTER":
+            self._drift_filter_calibration.calibrate(gcmd)
         else:
             raise gcmd.error(f"Unknown CALIBRATION value '{calibration}'")
 

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -1010,6 +1010,24 @@ class LoadCellPrinterProbe:
         )
         printer_probe = PrinterProbe(config, wrapper)
         self._printer.add_object("probe", printer_probe)
+        self._register_macros()
+
+    def _register_macros(self):
+        gcode_dispatch: GCodeDispatch = self._printer.lookup_object("gcode")
+        gcode_dispatch.register_command(
+            "LOAD_CELL_PROBE_CALIBRATE",
+            self.cmd_LOAD_CELL_PROBE_CALIBRATE,
+            desc=self.cmd_LOAD_CELL_PROBE_CALIBRATE_help,
+        )
+
+    cmd_LOAD_CELL_PROBE_CALIBRATE_help: str = "Run a calibration routine"
+
+    def cmd_LOAD_CELL_PROBE_CALIBRATE(self, gcmd: GCodeCommand):
+        calibration: str = gcmd.get("CALIBRATION")
+        if calibration == "TEST":
+            gcmd.respond_info(f"CALIBRATION is {calibration}")
+        else:
+            raise gcmd.error(f"Unknown CALIBRATION value '{calibration}'")
 
     def add_client(self, callback):
         self._tap_analysis_helper.add_client(callback)

--- a/klippy/extras/load_cell/tap_analysis.py
+++ b/klippy/extras/load_cell/tap_analysis.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
 
+import copy
 import logging
 import math
 import time
@@ -667,9 +668,10 @@ class TapAnalysis:
 # Orchestrate TapAnalysis and TapClassifier. Handle timing, error capture,
 # event broadcast, clients & logging
 class TapAnalysisHelper:
-    def __init__(self, printer, name, tap_classifier):
+    def __init__(self, printer, name, tap_classifier: TapClassifierModule):
         self._printer = printer
         self._tap_classifier = tap_classifier
+        self._calibration_cb = None
         # webhooks support
         self._clients = ApiClientHelper(printer)
         header = {"header": ["probe_tap_event"]}
@@ -686,6 +688,11 @@ class TapAnalysisHelper:
             tap_analysis.set_is_valid(False)
             tap_analysis.set_validation_error(ve)
             tap_analysis.log_trapq()
+        # notify calibration tool, if any:
+        if self._calibration_cb and not self._calibration_cb(
+            copy.deepcopy(tap_analysis)
+        ):
+            self._calibration_cb = None
         # tap classifier always gets to process the data
         try:
             self._tap_classifier.classify(tap_analysis, gcmd)
@@ -713,3 +720,6 @@ class TapAnalysisHelper:
     # get internal tap events
     def add_client(self, callback):
         self._clients.add_client(callback)
+
+    def set_calibration_callback(self, callback):
+        self._calibration_cb = callback

--- a/klippy/extras/load_cell/tap_quality_classifier.py
+++ b/klippy/extras/load_cell/tap_quality_classifier.py
@@ -5,16 +5,22 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
 
+import logging
 import math
 from typing import Any, Optional
 
+import numpy as np
+
+from klippy import Printer
 from klippy.configfile import ConfigWrapper, PrinterConfig
+from klippy.extras.bed_mesh import BedMesh
 from klippy.extras.load_cell.tap_analysis import (
     ForcePoint,
     TapAnalysis,
     TapClassifierModule,
     TapValidationError,
 )
+from klippy.extras.probe import ProbePointsHelper
 from klippy.gcode import GCodeCommand
 
 
@@ -119,16 +125,100 @@ class TapQualityClassifierConfig:
 # 2) Tap quality metric must be more than the minimum_tap_quality
 class TapQualityClassifier(TapClassifierModule):
     def __init__(self, config: ConfigWrapper):
-        self.printer = config.get_printer()
+        self.printer: Printer = config.get_printer()
+        self.bed_mesh_config = None
+        if config.has_section("bed_mesh"):
+            self.bed_mesh_config = config.getsection("bed_mesh")
         self.config: TapQualityClassifierConfig = TapQualityClassifierConfig(
             config
         )
+        self._calibrating = False
+        self._tap_analyses = []
 
     def set_minimum_tap_quality(self, minimum_tap_quality: float):
         self.config.set_minimum_tap_quality(minimum_tap_quality)
 
     def set_decompression_angle(self, decompression_angle: float):
         self.config.set_decompression_angle(decompression_angle)
+
+    def _calculate_mean_decompression_angle(self) -> float:
+        angles = []
+        for tap_analysis in self._tap_analyses:
+            if not tap_analysis.is_valid():
+                continue
+            lines = tap_analysis.get_tap_lines()
+            decompression_line = lines[3]
+            angle = abs(self._slope_to_degrees(decompression_line.slope))
+            angles.append(angle)
+
+        return float(np.mean(angles))
+
+    def _recalculate_tap_qualities(self) -> list[float]:
+        qualities: list[float] = []
+        for tap_analysis in self._tap_analyses:
+            if not tap_analysis.is_valid():
+                continue
+            quality = self.calculate_tap_quality(tap_analysis)
+            qualities.append(quality)
+        return qualities
+
+    def _finalize_callback(self, probe_offsets, results):
+        pass
+
+    def calibrate(self, gcmd):
+        gcmd.respond_info("Starting DECOMPRESSION_ANGLE_CALIBRATION...")
+        bed_mesh: BedMesh = self.printer.lookup_object("bed_mesh", default=None)
+        if bed_mesh is None:
+            raise gcmd.error("bed_mesh not configured")
+
+        self._calibrating = True
+        self._tap_analyses = []
+        try:
+            logging.info("Probing Mesh Points...")
+            points = bed_mesh.generate_points(gcmd, "tap_quality_calibrate")
+            points_helper = ProbePointsHelper(
+                self.bed_mesh_config,
+                self._finalize_callback,
+                points,
+                use_offsets=True,
+                enable_horizontal_z_clearance=True,
+            )
+            points_helper.start_probe(gcmd)
+        finally:
+            self._calibrating = False
+        if self._tap_analyses is None:
+            raise gcmd.error("No taps were collected!")
+        gcmd.respond_info(f"Collected {len(self._tap_analyses)} taps")
+
+        for tap in self._tap_analyses:
+            if not tap.is_valid():
+                gcmd.respond_error(
+                    "Some taps failed! Make sure the nozzle is clean and free of ooze."
+                )
+        qualities = self._recalculate_tap_qualities()
+        if not qualities:
+            gcmd.respond_error(
+                "Not taps passed the quality check! Make sure the nozzle is "
+                "clean and free of ooze."
+            )
+        mean_quality = float(np.mean(qualities))
+        std_quality = float(np.std(qualities))
+        gcmd.respond_info(
+            "DECOMPRESSION_ANGLE_CALIBRATION Complete"
+            f"Tap Quality average: {mean_quality:.1f}%, "
+            f"min: {min(qualities):.1f}%, max: {max(qualities):.1f}% "
+            f"std dev: {std_quality:.1f}%"
+        )
+
+        # decompression angle
+        mean_angle = self._calculate_mean_decompression_angle()
+        self.set_decompression_angle(mean_angle)
+        gcmd.respond_info(
+            f"\nMean Decompression Angle: {mean_angle:.1f} degrees"
+            f"\ndecompression_angle={mean_angle:.1f}\n This has been saved "
+            f"for the current session.\nThe SAVE_CONFIG command will "
+            f"update the printer config file and restart the printer."
+        )
 
     @staticmethod
     def _slope_to_degrees(slope: float, time_scale=0.1, gram_scale=25):
@@ -154,15 +244,7 @@ class TapQualityClassifier(TapClassifierModule):
             max_force = max(max_force, force)
         return max_force - min_force
 
-    def classify(self, tap_analysis: TapAnalysis, gcmd: GCodeCommand):
-        # This module cant rescue bad data
-        if not tap_analysis.is_valid():
-            return
-
-        # if the user does not configure an angle, don't classify the tap
-        if self.config.decompression_angle is None:
-            return
-
+    def calculate_tap_quality(self, tap_analysis: TapAnalysis) -> float:
         # unpack tap points with names
         tap_points = tap_analysis.get_tap_points()
         approach_start_point = tap_points[0]
@@ -176,17 +258,6 @@ class TapQualityClassifier(TapClassifierModule):
         compression_force = abs(
             compression_end_point.force - compression_start_point.force
         )
-
-        # compression check: did we meet the minimum force requirement?
-        if compression_force < tap_analysis.get_trigger_force():
-            raise TapValidationError(
-                "LOW_COMPRESSION_FORCE",
-                f"Compression force, {compression_force}g, was less than the "
-                f"trigger force ({tap_analysis.get_trigger_force()}g)",
-            )
-
-        if gcmd is not None:
-            self.config.customize(gcmd)
 
         # These 2 metrics are expected to approach 0.0 in an ideal tap. If
         # they are large that usually indicates the tap is fouled.
@@ -241,6 +312,46 @@ class TapQualityClassifier(TapClassifierModule):
             * (1.0 - dwell_force_drop_pct)
             * (1.0 - normalized_decompression_angle)
         )
+
+        return tap_quality
+
+    def classify(self, tap_analysis: TapAnalysis, gcmd: GCodeCommand):
+        if self._calibrating:
+            self._tap_analyses.append(tap_analysis)
+
+        # This module cant rescue bad data
+        if not tap_analysis.is_valid():
+            return
+
+        # if the user has not configured an angle, don't classify the tap
+        if self.config.decompression_angle is None:
+            return
+
+        # unpack tap points with names
+        tap_points = tap_analysis.get_tap_points()
+        compression_start_point = tap_points[1]
+        compression_end_point = tap_points[2]
+
+        # only the compression force in the compression line
+        compression_force = abs(
+            compression_end_point.force - compression_start_point.force
+        )
+
+        # compression check: did we meet the minimum force requirement?
+        if compression_force < tap_analysis.get_trigger_force():
+            raise TapValidationError(
+                "LOW_COMPRESSION_FORCE",
+                f"Compression force, {compression_force}g, was less than the "
+                f"trigger force ({tap_analysis.get_trigger_force()}g)",
+            )
+
+        if gcmd is not None:
+            self.config.customize(gcmd)
+
+        tap_quality = self.calculate_tap_quality(tap_analysis)
+
+        lines = tap_analysis.get_tap_lines()
+        decompression_line = lines[3]
 
         # TODO: should this be a debugging option? logged?
         # log info to console for now...


### PR DESCRIPTION
These are the 3 calibration tools that are mostly finished. This gives users a method for finding values for some of the trivky but essential settings for the load cell probe:

* `CALIBRATION=DRIFT_FILTER` - this calibrates the drift filter frequency setting used to eliminate load cell force drift caused by bowden tubes. It does this by tapping into the machnies bed mesh configuration. It visits each mesh point and moves the toolhead from the top of the machines build volume down to 10mm above the build plate. The force data is collected and the minimum filter frequency needed to eliminate the observed drift is calculated. This measurement is repeated for every mesh point and the peak value is reported as the optimal drift filter value.

* `CALIBRATION=PULLBACK_DISTANCE` - The pullback distance is the distance that the toolhead lifts when performing Tap Analysis. This distance needs to be tuned based on the observed machine characteristics. Less stiff machines, and machines with slower sensors have more overshoot at the maximum probing speed. Using too large of a value is slow, so we want to minimize this value while allowing probes with the highest amount of overshoot to succeed. This calibration performs a bed mesh with a very large `pullback_distance` value at the maximum configured probing or homing speed. It looks at the position of the elbow in all of the pullback moves and tries to optimize such that there is enough pullback distance in the worst case.

* `CALIBRATION=DECOMPRESSION_ANGLE` - This performs a standard bed mesh pattern at the standard probing speed and calculates the average of the decompression angle value. This setting is required to enable Tap Quality checking.


## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
