### PR TITLE
Fix: corrected build flags used in fat_fs for building

### DIFF
--- a/scripts/spi_flash/fatfs_lib.py
+++ b/scripts/spi_flash/fatfs_lib.py
@@ -69,10 +69,10 @@ def check_fatfs_build(printfunc=lambda o: o):
     ofiles.extend(chelper.get_abs_files(srcdir, SPI_FLASH_HEADERS))
     destlib = os.path.join(srcdir, DEST_LIB)
     if chelper.check_build_code(srcfiles + ofiles + [__file__], destlib):
-        if chelper.check_gcc_option(chelper.SSE_FLAGS):
+        if chelper.check_gcc_option(chelper.NATIVE_FLAGS):
             cmd = "%s %s %s" % (
                 chelper.GCC_CMD,
-                chelper.SSE_FLAGS,
+                chelper.NATIVE_FLAGS,
                 chelper.COMPILE_ARGS,
             )
         else:


### PR DESCRIPTION
Commit e22a1cf introduced new "NATIVE_FLAGS" for building the c components of klippy/chelper.
the fatfs_lib (used for sdcard flash/spi flash, made use of the now defunct "SSE_FLAGS", since this change, spi_flash no longer works, because it relied on the SSE_FLAGS variable from chelper.

This PR changes the now broken "SSE_FLAGS" with the newly introduces "NATIVE_FLAGS" for building the c components of fatfs_lib.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
