### PR TITLE
Add alternating probe order to quad gantry level

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -862,6 +862,19 @@ class ProbePointsHelper:
             "use_probe_xy_offsets", use_offsets
         )
 
+        # Optionally alternate the physical probing order between full probing
+        # passes/retries. This avoids repeatedly traversing the same loop around
+        # the bed, which can help prevent Bowden tubes, umbilicals, and cable
+        # bundles from accumulating twist on large-format machines.
+        #
+        # The alternating order implementation is inspired by Lazar at Modix3D
+        # and the way he has solved this behavior in RepRapFirmware.
+        self.alternate_probe_direction = config.getboolean(
+            "alternate_probe_direction", False
+        )
+        self.start_reverse = config.getboolean("start_reverse", False)
+        self.report_probe_order = config.getboolean("report_probe_order", False)
+
         self.enforce_lift_speed = config.getboolean("enforce_lift_speed", False)
 
         # Probe retry configuration
@@ -870,6 +883,7 @@ class ProbePointsHelper:
         self.lift_speed = self.speed
         self.probe_offsets = (0.0, 0.0, 0.0)
         self.results = []
+        self._probe_pass_index = 0
 
     def get_probe_points(self):
         return self.probe_points
@@ -892,6 +906,44 @@ class ProbePointsHelper:
             return gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.0)
         return self.lift_speed
 
+    def _is_reverse_probe_pass(self):
+        if not self.alternate_probe_direction:
+            return False
+
+        use_reverse = bool(self._probe_pass_index % 2)
+        if self.start_reverse:
+            use_reverse = not use_reverse
+
+        return use_reverse
+
+    def _probe_point_index(self):
+        result_count = len(self.results)
+        if self._is_reverse_probe_pass():
+            return len(self.probe_points) - result_count - 1
+        return result_count
+
+    def _store_probe_result(self, position):
+        if self._is_reverse_probe_pass():
+            self.results.insert(0, position)
+        else:
+            self.results.append(position)
+
+    def _report_probe_order(self):
+        if not self.alternate_probe_direction or not self.report_probe_order:
+            return
+
+        probe_count = len(self.probe_points)
+        if self._is_reverse_probe_pass():
+            order = range(probe_count - 1, -1, -1)
+        else:
+            order = range(probe_count)
+
+        order_text = " -> ".join([str(index) for index in order])
+        self.gcode.respond_info(
+            "Probe pass %d point order: %s"
+            % (self._probe_pass_index + 1, order_text)
+        )
+
     def _lift_toolhead(self):
         toolhead = self.printer.lookup_object("toolhead")
         # Lift toolhead
@@ -906,7 +958,7 @@ class ProbePointsHelper:
         toolhead.manual_move([None, None, z_pos], speed)
 
     def _next_pos(self):
-        nextpos = list(self.probe_points[len(self.results)])
+        nextpos = list(self.probe_points[self._probe_point_index()])
         if self.use_offsets:
             nextpos[0] -= self.probe_offsets[0]
             nextpos[1] -= self.probe_offsets[1]
@@ -936,6 +988,9 @@ class ProbePointsHelper:
         self._lift_toolhead()
         if finalize:
             self.results = []
+            if not done:
+                self._probe_pass_index += 1
+                self._report_probe_order()
         if done:
             return True
         # Move to next XY probe point
@@ -956,6 +1011,8 @@ class ProbePointsHelper:
             method = "automatic"
 
         self.results = []
+        self._probe_pass_index = 0
+        self._report_probe_order()
 
         def_move_z = self.default_horizontal_move_z
         self.horizontal_move_z = gcmd.get_float("HORIZONTAL_MOVE_Z", def_move_z)
@@ -990,7 +1047,7 @@ class ProbePointsHelper:
                 break
             pos = probe.run_probe(gcmd, self.retry_session)
             logging.info(f"Probe pos:{pos}")
-            self.results.append(pos)
+            self._store_probe_result(pos)
         probe.multi_probe_end()
         self.retry_session.end()
 
@@ -1005,7 +1062,7 @@ class ProbePointsHelper:
     def _manual_probe_finalize(self, kin_pos):
         if kin_pos is None:
             return
-        self.results.append(kin_pos)
+        self._store_probe_result(kin_pos)
         self._manual_probe_start()
 
 

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -113,7 +113,7 @@ class QuadGantryLevel:
     def _set_probe_order_for_pass(self, pass_index):
         self._active_probe_order = self._select_probe_order_for_pass(pass_index)
         self.probe_helper.probe_points = [
-            self._logical_probe_points[index] 
+            self._logical_probe_points[index]
             for index in self._active_probe_order
         ]
 

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -113,7 +113,8 @@ class QuadGantryLevel:
     def _set_probe_order_for_pass(self, pass_index):
         self._active_probe_order = self._select_probe_order_for_pass(pass_index)
         self.probe_helper.probe_points = [
-            self._logical_probe_points[index] for index in self._active_probe_order
+            self._logical_probe_points[index] 
+            for index in self._active_probe_order
         ]
 
         if self.alternate_probe_direction and self.report_probe_order:

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -37,6 +37,30 @@ class QuadGantryLevel:
             raise config.error(
                 "Need exactly 4 probe points for quad_gantry_level"
             )
+
+        # Keep a copy of the configured logical point order. The QGL math below
+        # expects positions[0], positions[1], positions[2], and positions[3] to
+        # represent the same physical gantry corners on every pass, regardless
+        # of the order in which those points were physically probed.
+        self._logical_probe_points = list(self.probe_helper.probe_points)
+        self._normal_probe_order = [0, 1, 2, 3]
+        self._reverse_probe_order = [3, 2, 1, 0]
+        self._active_probe_order = list(self._normal_probe_order)
+        self._qgl_pass_index = 0
+
+        # Optionally alternate the physical probing order between full QGL
+        # passes/retries. This avoids repeatedly traversing the same loop around
+        # the bed, which can help prevent Bowden tubes, umbilicals, and cable
+        # bundles from accumulating twist on large-format machines.
+        #
+        # The alternating order implementation is inspired by Lazar at Modix3D
+        # and the way he has solved this behavior in RepRapFirmware.
+        self.alternate_probe_direction = config.getboolean(
+            "alternate_probe_direction", False
+        )
+        self.start_reverse = config.getboolean("start_reverse", False)
+        self.report_probe_order = config.getboolean("report_probe_order", False)
+
         self.z_status = z_tilt.ZAdjustStatus(self.printer)
         self.z_helper = z_tilt.ZAdjustHelper(config, 4)
         self.gantry_corners = config.getlists(
@@ -46,6 +70,12 @@ class QuadGantryLevel:
             raise config.error(
                 "quad_gantry_level requires at least two gantry_corners"
             )
+
+        # Restore the configured point order if a command aborts mid-run.
+        self.printer.register_event_handler(
+            "gcode:command_error", self._handle_command_error
+        )
+
         # Register QUAD_GANTRY_LEVEL command
         self.gcode = self.printer.lookup_object("gcode")
         self.gcode.register_command(
@@ -58,12 +88,93 @@ class QuadGantryLevel:
         "Conform a moving, twistable gantry to the shape of a stationary bed"
     )
 
+    def _handle_command_error(self):
+        self._restore_logical_probe_order()
+
     def cmd_QUAD_GANTRY_LEVEL(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)
+        self._qgl_pass_index = 0
+        self._set_probe_order_for_pass(self._qgl_pass_index)
         self.probe_helper.start_probe(gcmd)
 
+    def _select_probe_order_for_pass(self, pass_index):
+        if not self.alternate_probe_direction:
+            return list(self._normal_probe_order)
+
+        use_reverse = bool(pass_index % 2)
+        if self.start_reverse:
+            use_reverse = not use_reverse
+
+        if use_reverse:
+            return list(self._reverse_probe_order)
+        return list(self._normal_probe_order)
+
+    def _set_probe_order_for_pass(self, pass_index):
+        self._active_probe_order = self._select_probe_order_for_pass(pass_index)
+        self.probe_helper.probe_points = [
+            self._logical_probe_points[index] for index in self._active_probe_order
+        ]
+
+        if self.alternate_probe_direction and self.report_probe_order:
+            order_text = " -> ".join(
+                [str(index) for index in self._active_probe_order]
+            )
+            self.gcode.respond_info(
+                "QGL pass %d probe order: %s" % (pass_index + 1, order_text)
+            )
+
+    def _restore_logical_probe_order(self):
+        self._active_probe_order = list(self._normal_probe_order)
+        self.probe_helper.probe_points = list(self._logical_probe_points)
+
+    def _map_positions_to_logical_order(self, positions):
+        # ProbePointsHelper returns positions in the order they were physically
+        # probed. Convert them back to the logical order expected by the QGL
+        # calculations below.
+        if len(positions) != 4 or len(self._active_probe_order) != 4:
+            return positions
+
+        logical_positions = [None, None, None, None]
+        for measured_position, logical_index in zip(
+            positions, self._active_probe_order
+        ):
+            logical_positions[logical_index] = measured_position
+
+        if any(position is None for position in logical_positions):
+            raise self.gcode.error(
+                "quad_gantry_level internal error: failed to map probe results"
+            )
+        return logical_positions
+
+    def _is_retry_done(self, retry_result):
+        return (
+            (isinstance(retry_result, str) and retry_result == "done")
+            or (isinstance(retry_result, float) and retry_result == 0.0)
+            or retry_result == 0
+        )
+
     def probe_finalize(self, offsets, positions):
+        positions = self._map_positions_to_logical_order(positions)
+
+        try:
+            result = self._probe_finalize(offsets, positions)
+        except Exception:
+            self._restore_logical_probe_order()
+            raise
+
+        if self._is_retry_done(result):
+            self._restore_logical_probe_order()
+        else:
+            # ProbePointsHelper will perform another full pass when RetryHelper
+            # requests another retry. Prepare the next pass order before giving
+            # control back to the helper.
+            self._qgl_pass_index += 1
+            self._set_probe_order_for_pass(self._qgl_pass_index)
+
+        return result
+
+    def _probe_finalize(self, offsets, positions):
         # Mirror our perspective so the adjustments make sense
         # from the perspective of the gantry
         z_positions = [self.horizontal_move_z - p[2] for p in positions]

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -37,30 +37,6 @@ class QuadGantryLevel:
             raise config.error(
                 "Need exactly 4 probe points for quad_gantry_level"
             )
-
-        # Keep a copy of the configured logical point order. The QGL math below
-        # expects positions[0], positions[1], positions[2], and positions[3] to
-        # represent the same physical gantry corners on every pass, regardless
-        # of the order in which those points were physically probed.
-        self._logical_probe_points = list(self.probe_helper.probe_points)
-        self._normal_probe_order = [0, 1, 2, 3]
-        self._reverse_probe_order = [3, 2, 1, 0]
-        self._active_probe_order = list(self._normal_probe_order)
-        self._qgl_pass_index = 0
-
-        # Optionally alternate the physical probing order between full QGL
-        # passes/retries. This avoids repeatedly traversing the same loop around
-        # the bed, which can help prevent Bowden tubes, umbilicals, and cable
-        # bundles from accumulating twist on large-format machines.
-        #
-        # The alternating order implementation is inspired by Lazar at Modix3D
-        # and the way he has solved this behavior in RepRapFirmware.
-        self.alternate_probe_direction = config.getboolean(
-            "alternate_probe_direction", False
-        )
-        self.start_reverse = config.getboolean("start_reverse", False)
-        self.report_probe_order = config.getboolean("report_probe_order", False)
-
         self.z_status = z_tilt.ZAdjustStatus(self.printer)
         self.z_helper = z_tilt.ZAdjustHelper(config, 4)
         self.gantry_corners = config.getlists(
@@ -70,12 +46,6 @@ class QuadGantryLevel:
             raise config.error(
                 "quad_gantry_level requires at least two gantry_corners"
             )
-
-        # Restore the configured point order if a command aborts mid-run.
-        self.printer.register_event_handler(
-            "gcode:command_error", self._handle_command_error
-        )
-
         # Register QUAD_GANTRY_LEVEL command
         self.gcode = self.printer.lookup_object("gcode")
         self.gcode.register_command(
@@ -88,94 +58,12 @@ class QuadGantryLevel:
         "Conform a moving, twistable gantry to the shape of a stationary bed"
     )
 
-    def _handle_command_error(self):
-        self._restore_logical_probe_order()
-
     def cmd_QUAD_GANTRY_LEVEL(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)
-        self._qgl_pass_index = 0
-        self._set_probe_order_for_pass(self._qgl_pass_index)
         self.probe_helper.start_probe(gcmd)
 
-    def _select_probe_order_for_pass(self, pass_index):
-        if not self.alternate_probe_direction:
-            return list(self._normal_probe_order)
-
-        use_reverse = bool(pass_index % 2)
-        if self.start_reverse:
-            use_reverse = not use_reverse
-
-        if use_reverse:
-            return list(self._reverse_probe_order)
-        return list(self._normal_probe_order)
-
-    def _set_probe_order_for_pass(self, pass_index):
-        self._active_probe_order = self._select_probe_order_for_pass(pass_index)
-        self.probe_helper.probe_points = [
-            self._logical_probe_points[index]
-            for index in self._active_probe_order
-        ]
-
-        if self.alternate_probe_direction and self.report_probe_order:
-            order_text = " -> ".join(
-                [str(index) for index in self._active_probe_order]
-            )
-            self.gcode.respond_info(
-                "QGL pass %d probe order: %s" % (pass_index + 1, order_text)
-            )
-
-    def _restore_logical_probe_order(self):
-        self._active_probe_order = list(self._normal_probe_order)
-        self.probe_helper.probe_points = list(self._logical_probe_points)
-
-    def _map_positions_to_logical_order(self, positions):
-        # ProbePointsHelper returns positions in the order they were physically
-        # probed. Convert them back to the logical order expected by the QGL
-        # calculations below.
-        if len(positions) != 4 or len(self._active_probe_order) != 4:
-            return positions
-
-        logical_positions = [None, None, None, None]
-        for measured_position, logical_index in zip(
-            positions, self._active_probe_order
-        ):
-            logical_positions[logical_index] = measured_position
-
-        if any(position is None for position in logical_positions):
-            raise self.gcode.error(
-                "quad_gantry_level internal error: failed to map probe results"
-            )
-        return logical_positions
-
-    def _is_retry_done(self, retry_result):
-        return (
-            (isinstance(retry_result, str) and retry_result == "done")
-            or (isinstance(retry_result, float) and retry_result == 0.0)
-            or retry_result == 0
-        )
-
     def probe_finalize(self, offsets, positions):
-        positions = self._map_positions_to_logical_order(positions)
-
-        try:
-            result = self._probe_finalize(offsets, positions)
-        except Exception:
-            self._restore_logical_probe_order()
-            raise
-
-        if self._is_retry_done(result):
-            self._restore_logical_probe_order()
-        else:
-            # ProbePointsHelper will perform another full pass when RetryHelper
-            # requests another retry. Prepare the next pass order before giving
-            # control back to the helper.
-            self._qgl_pass_index += 1
-            self._set_probe_order_for_pass(self._qgl_pass_index)
-
-        return result
-
-    def _probe_finalize(self, offsets, positions):
         # Mirror our perspective so the adjustments make sense
         # from the perspective of the gantry
         z_positions = [self.horizontal_move_z - p[2] for p in positions]


### PR DESCRIPTION
Adds optional alternating probe order support for quad gantry leveling.

When enabled, QGL alternates the physical probe travel direction between full probe passes/retries:

- Pass 1: 0 -> 1 -> 2 -> 3
- Pass 2: 3 -> 2 -> 1 -> 0
- Pass 3: 0 -> 1 -> 2 -> 3

The measured probe results are mapped back to their original logical point indices before the QGL calculations are performed. This preserves the existing leveling math while allowing the physical travel path to alternate between passes.

The main purpose is to reduce repeated cable, tube, Bowden, umbilical, and filament path twisting on large-format machines during repeated QGL retries.

The implementation is inspired by Lazar at Modix3D and his RepRapFirmware approach.

## Configuration

The feature is disabled by default, so existing configurations keep the current QGL behavior.

To enable alternating probe direction:

```ini
[quad_gantry_level]
alternate_probe_direction: True

# Start with reverse order on the first pass instead of the second pass.
# Default: False
start_reverse: False

# Report the selected probe order for each QGL pass.
# Useful for testing and debugging.
# Default: False
report_probe_order: False
```