### PR TITLE
Probe points alternating order

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1566,6 +1566,20 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #use_adjustments: False
 #   If set to true it uses the behaviour described by trails here:
 #   https://github.com/Trails5000/klipper/commit/47b5a91f96761961e693031fa514a0025a877117
+#alternate_probe_direction: False
+#   If True, alternate the physical probing direction between full
+#   probing passes/retries. The first pass uses the configured point
+#   order, and the next pass probes the same points in reverse order.
+#   The measured results are still returned in the configured logical
+#   point order, so the z_tilt calculations are unchanged. This can
+#   reduce repeated twisting of Bowden tubes, filament paths, umbilicals,
+#   and cable bundles on large-format machines. It also avoids the extra
+#   travel move from the last point back to the first point between retry
+#   passes. The default is False.
+#start_reverse: False
+#   If True and alternate_probe_direction is enabled, start the first
+#   probing pass in reverse order. Subsequent retry passes will continue
+#   alternating direction. The default is False.
 ```
 
 #### [z_tilt_ng]
@@ -1710,6 +1724,20 @@ Where x is the 0, 0 point on the bed
 #   By default, the first Z movement to reach `horizontal_move_z` uses `speed`.
 #   Set `enforce_lift_speed` to True to enforce the `lift_speed`.
 #   The default is False.
+#alternate_probe_direction: False
+#   If True, alternate the physical probing direction between full
+#   probing passes/retries. The first pass uses the configured point
+#   order, and the next pass probes the same points in reverse order.
+#   The measured results are still returned in the configured logical
+#   point order, so the quad gantry leveling calculations are unchanged.
+#   This can reduce repeated twisting of Bowden tubes, filament paths,
+#   umbilicals, and cable bundles on large-format machines. It also
+#   avoids the extra travel move from the last point back to the first
+#   point between retry passes. The default is False.
+#start_reverse: False
+#   If True and alternate_probe_direction is enabled, start the first
+#   probing pass in reverse order. Subsequent retry passes will continue
+#   alternating direction. The default is False.
 ```
 
 ### [skew_correction]

--- a/docs/Kalico_Additions.md
+++ b/docs/Kalico_Additions.md
@@ -44,6 +44,7 @@
 - [`[z_tilt/quad_gantry_level] adaptive_horizontal_move_z`](./Config_Reference.md#z_tilt) adaptively decrease horizontal_move_z based on resulting error - z_tilt and QGL faster and safer!
 - [`[safe_z_home] home_y_before_x`](./Config_Reference.md#safe_z_home) let you home Y before X.
 - [`[z_tilt/quad_gantry_level/etc] use_probe_xy_offsets`](./Config_Reference.md#z_tilt) let you decide if the `[probe] XY offsets should be applied to probe positions.
+- [`[z_tilt/quad_gantry_level/etc] alternate_probe_direction`](./Config_Reference.md#z_tilt) alternates probing direction between retry passes to reduce cable, Bowden tube, umbilical, and filament path twisting, while avoiding the extra travel move back to the first point.
 
 ## Heaters, Fans, and PID changes
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -869,6 +869,13 @@ class ProbePointsHelper:
         self.use_offsets = config.getboolean(
             "use_probe_xy_offsets", use_offsets
         )
+        self.alternate_probe_direction = config.getboolean(
+            "alternate_probe_direction", False
+        )
+        if self.alternate_probe_direction:
+            self.start_reverse = config.getboolean("start_reverse", False)
+        else:
+            self.start_reverse = False
 
         self.enforce_lift_speed = config.getboolean("enforce_lift_speed", False)
 
@@ -878,6 +885,7 @@ class ProbePointsHelper:
         self.lift_speed = self.speed
         self.probe_offsets = (0.0, 0.0, 0.0)
         self.results = []
+        self._probe_pass_direction_reversed = False
 
     def get_probe_points(self):
         return self.probe_points
@@ -900,6 +908,12 @@ class ProbePointsHelper:
             return gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.0)
         return self.lift_speed
 
+    def _store_probe_result(self, position):
+        if self._probe_pass_direction_reversed:
+            self.results.insert(0, position)
+        else:
+            self.results.append(position)
+
     def _lift_toolhead(self):
         toolhead = self.printer.lookup_object("toolhead")
         # Lift toolhead
@@ -914,7 +928,13 @@ class ProbePointsHelper:
         toolhead.manual_move([None, None, z_pos], speed)
 
     def _next_pos(self):
-        nextpos = list(self.probe_points[len(self.results)])
+        result_count = len(self.results)
+        if self._probe_pass_direction_reversed:
+            point_index = len(self.probe_points) - result_count - 1
+        else:
+            point_index = result_count
+
+        nextpos = list(self.probe_points[point_index])
         if self.use_offsets:
             nextpos[0] -= self.probe_offsets[0]
             nextpos[1] -= self.probe_offsets[1]
@@ -944,6 +964,10 @@ class ProbePointsHelper:
         self._lift_toolhead()
         if finalize:
             self.results = []
+            if not done and self.alternate_probe_direction:
+                self._probe_pass_direction_reversed = (
+                    not self._probe_pass_direction_reversed
+                )
         if done:
             return True
         # Move to next XY probe point
@@ -964,6 +988,7 @@ class ProbePointsHelper:
             method = "automatic"
 
         self.results = []
+        self._probe_pass_direction_reversed = self.start_reverse
 
         def_move_z = self.default_horizontal_move_z
         self.horizontal_move_z = gcmd.get_float("HORIZONTAL_MOVE_Z", def_move_z)
@@ -998,7 +1023,7 @@ class ProbePointsHelper:
                 break
             pos = probe.run_probe(gcmd, self.retry_session)
             logging.info(f"Probe pos:{pos}")
-            self.results.append(pos)
+            self._store_probe_result(pos)
         probe.multi_probe_end()
         self.retry_session.end()
 
@@ -1013,7 +1038,7 @@ class ProbePointsHelper:
     def _manual_probe_finalize(self, kin_pos):
         if kin_pos is None:
             return
-        self.results.append(kin_pos)
+        self._store_probe_result(kin_pos)
         self._manual_probe_start()
 
 


### PR DESCRIPTION
Adds optional alternating probe order support to `ProbePointsHelper`.

This allows probing workflows that use `ProbePointsHelper`, such as QGL, Z_TILT, and other multi-point probing routines, to alternate the physical travel direction between full probing passes while still returning probe results in the original logical point order.

Example config:

```ini
alternate_probe_direction: True
# start_reverse: False
```

When enabled, full probing passes alternate like this:

Pass 1: 0 -> 1 -> 2 -> 3  
Pass 2: 3 -> 2 -> 1 -> 0  
Pass 3: 0 -> 1 -> 2 -> 3  

When probing in reverse order, the measured results are inserted at the front of the result list. This means callers still receive results in the same logical order as before, so existing leveling math does not need special handling.

The main benefit is on large-format machines where repeated retries can otherwise make the toolhead travel around the bed in the same direction over and over again. Alternating the order reduces accumulated twist in Bowden tubes, filament paths, umbilicals, CAN cables, and other cable bundles.

It also avoids an unnecessary travel move between retry passes. With the current fixed order, a new pass starts again at point 0 after the previous pass ended at the last point, for example:

Pass 1: 0 -> 1 -> 2 -> 3  
Extra travel: 3 -> 0  
Pass 2: 0 -> 1 -> 2 -> 3  

With alternating order, the next pass starts where the previous pass ended:

Pass 1: 0 -> 1 -> 2 -> 3  
Pass 2: 3 -> 2 -> 1 -> 0  

This makes the travel path shorter and more natural, especially on machines with large beds.

The feature is disabled by default and should preserve existing behavior unless explicitly enabled in config.

The implementation is inspired by Lazar at Modix3D and his RepRapFirmware approach.

## Test video

[![QGL alternating probe direction test](https://img.youtube.com/vi/OcW2Bjt_VR4/hqdefault.jpg)](https://www.youtube.com/shorts/OcW2Bjt_VR4)

Tested on a QGL machine with `alternate_probe_direction` enabled.

## Checklist

- [x] PR title makes sense
- [x] Added a test case if possible
- [x] If new feature, added to the README / docs
- [x] CI is happy and green