### PR TITLE
adc_temperature: add inline_resistor support to LinearResistance

### DIFF
--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -180,10 +180,8 @@ class LinearResistance:
 
     def calc_adc(self, temp):
         # Calculate adc reading from a temperature
-        r = self.li.reverse_interpolate(temp)
-        return (r + self.inline_resistor) / (
-            self.pullup + r + self.inline_resistor
-        )
+        r = self.li.reverse_interpolate(temp) + self.inline_resistor
+        return r / (self.pullup + r)
 
 
 # Custom defined sensors from the config file

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -162,6 +162,9 @@ class CustomLinearVoltage:
 class LinearResistance:
     def __init__(self, config, samples):
         self.pullup = config.getfloat("pullup_resistor", 4700.0, above=0.0)
+        self.inline_resistor = config.getfloat(
+            "inline_resistor", 0.0, minval=0.0
+        )
         try:
             self.li = LinearInterpolate([(r, t) for t, r in samples])
         except ValueError as e:
@@ -172,13 +175,15 @@ class LinearResistance:
     def calc_temp(self, adc):
         # Calculate temperature from adc
         adc = max(0.00001, min(0.99999, adc))
-        r = self.pullup * adc / (1.0 - adc)
+        r = self.pullup * adc / (1.0 - adc) - self.inline_resistor
         return self.li.interpolate(r)
 
     def calc_adc(self, temp):
         # Calculate adc reading from a temperature
         r = self.li.reverse_interpolate(temp)
-        return r / (self.pullup + r)
+        return (r + self.inline_resistor) / (
+            self.pullup + r + self.inline_resistor
+        )
 
 
 # Custom defined sensors from the config file


### PR DESCRIPTION
Some boards, such as the Nitehawk-SB v2.0 have a design fault on the chamber thermistor port, which have the pullup resistor on the wrong side of the series protection resistor. The result is that the computed resistance, and therefore the reported temperature, reads consistently high.

Adding `inline_resistor` as a parameter for these boards addresses the hardware bug in software, by allowing the use of the parameter for more than just NTC type temperature sensors.

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
