### PR TITLE
clog_detect: Adds nozzle clog detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [extruder: cold_extrude](https://github.com/KalicoCrew/kalico/pull/750)
 
+- [clog_detect: extrusion monitoring](https://github.com/KalicoCrew/kalico/pull/887)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6179,11 +6179,17 @@ Multiple named sections are supported for multi-toolhead configurations —
 one section per tool, each bound to its own `extruder` and `load_cell`.
 
 The extruder's TMC stepper driver must be configured for stall detection before
-this module will function. For TMC2209 and TMC2208, `driver_sgthrs` must be set
-to a non-zero value and `coolstep_threshold` must be configured to enable stall
-guard at typical extrusion velocities. For TMC5160 and TMC2130, the `LOST_STEPS`
-register is used directly and no additional driver configuration is required.
-See the relevant `[tmc2209]` or `[tmc5160]` documentation for details.
+this module will function. Requirements vary by driver:
+- **TMC2209, TMC2208**: set `driver_sgthrs` to a non-zero value and configure
+  `coolstep_threshold` to enable stall guard at typical extrusion velocities.
+- **TMC2240**: set `driver_sg4_thrs` to a non-zero value and configure
+  `coolstep_threshold`. The dedicated StallGuard4 registers (`SG4_RESULT`,
+  `SG4_THRS`) are used in preference to the legacy `sg_result` field.
+- **TMC5160, TMC2130**: no additional driver configuration is required; the
+  `LOST_STEPS` register is used directly.
+
+See the relevant `[tmc2209]`, `[tmc2240]`, or `[tmc5160]` documentation for
+details.
 
 See the [clog_detect GCode commands](G-Codes.md#clog_detect) for runtime
 control via `CLOG_DETECTION`.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6167,7 +6167,7 @@ sensor_type:
 
 See [Tap Quality Components](Load_Cell.md#tap-quality-components) for more details on maximum for tap quality.
 
-### [clog_detect]
+### ⚠️ [clog_detect]
 
 Clog Detection.
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6169,63 +6169,60 @@ See [Tap Quality Components](Load_Cell.md#tap-quality-components) for more detai
 
 ### [clog_detect]
 
-Clog Detection. Detects a clogged nozzle by combining two signals: sustained
-downward force on a load cell, and extruder motor stall events reported by a
-TMC driver. Both conditions must occur together to avoid false positives.
-Detection is armed automatically after the first load cell tare (e.g. at the
-start of a homing sequence).
+Clog Detection.
 
-Multiple named sections are supported for multi-toolhead configurations —
-one section per tool, each bound to its own `extruder` and `load_cell`.
+Monitors the extruder stepper motor for stall events.
+When a stall is detected, this then reads the load cell force, and determines
+whether this indicates a clog.
 
-The extruder's TMC stepper driver must be configured for stall detection before
-this module will function. Requirements vary by driver:
-- **TMC2209, TMC2208**: set `driver_sgthrs` to a non-zero value and configure
-  `coolstep_threshold` to enable stall guard at typical extrusion velocities.
-- **TMC2240**: set `driver_sg4_thrs` to a non-zero value and configure
-  `coolstep_threshold`. The dedicated StallGuard4 registers (`SG4_RESULT`,
-  `SG4_THRS`) are used in preference to the legacy `sg_result` field.
-- **TMC5160, TMC2130**: no additional driver configuration is required; the
-  `LOST_STEPS` register is used directly.
+If both signals meet the threshold criteria (TMC StallGuard, force),
+this triggers a clog detection event, and executes the provided gcode.
 
-See the relevant `[tmc2209]`, `[tmc2240]`, or `[tmc5160]` documentation for
-details.
+In mutli-tool setups, where there is one load cell and extruder per tool,
+it is possible to define these independently, so that clog detection is applied
+to all tools. In this scenario, only the active extruder is ever monitored.
+
+See [Clog Detection](TMC_Drivers.md#clog-detection) in TMC_Drivers.md for
+full setup and tuning guidance.
 
 See the [clog_detect GCode commands](G-Codes.md#clog_detect) for runtime
 control via `CLOG_DETECTION`.
 
+For single extruder setups, this can be simplified:
+
 ```
-[clog_detect my_name]
-#load_cell: load_cell_probe
-#   The name of the [load_cell] or [load_cell_probe] section to read force
-#   data from. The default is "load_cell_probe".
-#extruder: extruder
-#   The name of the extruder this detector is bound to. In multi-toolhead
-#   setups, detection is skipped when this extruder is not the active tool.
-#   The default is "extruder".
-#skipped_steps: 20
-#   The estimated number of lost steps required to trigger clog detection.
-#   For TMC drivers with a LOST_STEPS register (e.g. TMC5160), this is a
-#   count of actual lost steps. For drivers using SG_RESULT (e.g. TMC2209),
-#   this is an estimate derived from the commanded extruder position delta
-#   during each stall event. The default is 20.
+[clog_detect]
 #force: 4000
-#   The downward force magnitude in grams that must be present for stall
-#   events to be counted. Force is read from the load cell as a negative
-#   value; this parameter is a positive magnitude and the comparison is
-#   applied internally. The default is 4000g.
-#poll_rate: 4
-#   How many times per second to check the force and stall conditions.
-#   The default is 4.
-#force_hysteresis: 1.0
-#   Time in seconds that force must remain above the threshold before the
-#   stall count is reset. This allows stall events to accumulate across the
-#   brief pressure-relief cycles characteristic of a clogged nozzle.
-#   The default is 1.0 seconds.
+#   The downward force magnitude in grams that must be present when a stall
+#   is detected for clog detection to trigger.
+#   The default is 4000g.
 #clog_detected_gcode:
 #   An optional GCode command or macro to run when a clog is detected.
-#   The detected state is not cleared automatically — use CLOG_DETECTION RESET=1
-#   to re-arm detection. The default is no action.
+#   The detected state is not cleared automatically.
+#   Use CLOG_DETECTION RESET=1 to re-arm the detection.
+#   The default is no action.
+```
+
+For a multi-extruder, multi-tool configurations:
+
+```
+[clog_detect T1]
+#load_cell: load_cell_probe T1
+#   The name of the [load_cell] or [load_cell_probe] section to read force
+#   data from.
+#   The default is "load_cell_probe".
+#extruder: extruder1
+#   The name of the extruder this detector is bound to.
+#   The default is "extruder".
+#force: 4000
+#   The downward force magnitude in grams that must be present when a stall
+#   is detected for clog detection to trigger.
+#   The default is 4000g.
+#clog_detected_gcode:
+#   An optional GCode command or macro to run when a clog is detected.
+#   The detected state is not cleared automatically.
+#   Use CLOG_DETECTION NAME=T1 RESET=1 to re-arm the detection.
+#   The default is no action.
 ```
 
 ## Board specific hardware support

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6172,12 +6172,21 @@ See [Tap Quality Components](Load_Cell.md#tap-quality-components) for more detai
 Clog Detection. Detects a clogged nozzle by combining two signals: sustained
 downward force on a load cell, and extruder motor stall events reported by a
 TMC driver. Both conditions must occur together to avoid false positives.
+Detection is armed automatically after the first load cell tare (e.g. at the
+start of a homing sequence).
 
 Multiple named sections are supported for multi-toolhead configurations —
 one section per tool, each bound to its own `extruder` and `load_cell`.
 
-See the [clog_detect GCode commands](G-Codes.md#clog_detect) for the
-`CLOG_DETECT_RESET` command.
+The extruder's TMC stepper driver must be configured for stall detection before
+this module will function. For TMC2209 and TMC2208, `driver_sgthrs` must be set
+to a non-zero value and `coolstep_threshold` must be configured to enable stall
+guard at typical extrusion velocities. For TMC5160 and TMC2130, the `LOST_STEPS`
+register is used directly and no additional driver configuration is required.
+See the relevant `[tmc2209]` or `[tmc5160]` documentation for details.
+
+See the [clog_detect GCode commands](G-Codes.md#clog_detect) for runtime
+control via `CLOG_DETECTION`.
 
 ```
 [clog_detect my_name]
@@ -6202,10 +6211,15 @@ See the [clog_detect GCode commands](G-Codes.md#clog_detect) for the
 #poll_rate: 4
 #   How many times per second to check the force and stall conditions.
 #   The default is 4.
+#force_hysteresis: 1.0
+#   Time in seconds that force must remain above the threshold before the
+#   stall count is reset. This allows stall events to accumulate across the
+#   brief pressure-relief cycles characteristic of a clogged nozzle.
+#   The default is 1.0 seconds.
 #clog_detected_gcode:
 #   An optional GCode command or macro to run when a clog is detected.
-#   The detected state is not cleared automatically — use
-#   CLOG_DETECT_RESET to reset it. The default is no action.
+#   The detected state is not cleared automatically — use CLOG_DETECTION RESET
+#   to re-arm detection. The default is no action.
 ```
 
 ## Board specific hardware support

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6224,7 +6224,7 @@ control via `CLOG_DETECTION`.
 #   The default is 1.0 seconds.
 #clog_detected_gcode:
 #   An optional GCode command or macro to run when a clog is detected.
-#   The detected state is not cleared automatically — use CLOG_DETECTION RESET
+#   The detected state is not cleared automatically — use CLOG_DETECTION RESET=1
 #   to re-arm detection. The default is no action.
 ```
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6167,6 +6167,47 @@ sensor_type:
 
 See [Tap Quality Components](Load_Cell.md#tap-quality-components) for more details on maximum for tap quality.
 
+### [clog_detect]
+
+Clog Detection. Detects a clogged nozzle by combining two signals: sustained
+downward force on a load cell, and extruder motor stall events reported by a
+TMC driver. Both conditions must occur together to avoid false positives.
+
+Multiple named sections are supported for multi-toolhead configurations —
+one section per tool, each bound to its own `extruder` and `load_cell`.
+
+See the [clog_detect GCode commands](G-Codes.md#clog_detect) for the
+`CLOG_DETECT_RESET` command.
+
+```
+[clog_detect my_name]
+#load_cell: load_cell_probe
+#   The name of the [load_cell] or [load_cell_probe] section to read force
+#   data from. The default is "load_cell_probe".
+#extruder: extruder
+#   The name of the extruder this detector is bound to. In multi-toolhead
+#   setups, detection is skipped when this extruder is not the active tool.
+#   The default is "extruder".
+#skipped_steps: 20
+#   The estimated number of lost steps required to trigger clog detection.
+#   For TMC drivers with a LOST_STEPS register (e.g. TMC5160), this is a
+#   count of actual lost steps. For drivers using SG_RESULT (e.g. TMC2209),
+#   this is an estimate derived from the commanded extruder position delta
+#   during each stall event. The default is 20.
+#force: 4000
+#   The downward force magnitude in grams that must be present for stall
+#   events to be counted. Force is read from the load cell as a negative
+#   value; this parameter is a positive magnitude and the comparison is
+#   applied internally. The default is 4000g.
+#poll_rate: 4
+#   How many times per second to check the force and stall conditions.
+#   The default is 4.
+#clog_detected_gcode:
+#   An optional GCode command or macro to run when a clog is detected.
+#   The detected state is not cleared automatically — use
+#   CLOG_DETECT_RESET to reset it. The default is no action.
+```
+
 ## Board specific hardware support
 
 ### [sx1509]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1102,13 +1102,13 @@ configured.
 name suffix (e.g. `T0` for `[clog_detect T0]`). `NAME` is optional when only
 one `[clog_detect]` section is configured; it is required when multiple
 sections are configured.
-- `CLOG_DETECTION RESET` — clears the `clog_detected` state and re-arms
+- `CLOG_DETECTION RESET=1` — clears the `clog_detected` state and re-arms
   detection. The detected state is not cleared automatically, even after the
   `clog_detected_gcode` macro has run.
 - `CLOG_DETECTION ENABLED=true` — enables detection for the instance.
 - `CLOG_DETECTION ENABLED=false` — disables detection for the instance without
   removing the configuration.
-- `CLOG_DETECTION RESET NAME=T0` — resets the instance named `T0`.
+- `CLOG_DETECTION RESET=1 NAME=T0` — resets the instance named `T0`.
 
 ### [manual_probe]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1097,18 +1097,18 @@ The following commands are available when a
 configured.
 
 ### CLOG_DETECTION
-`CLOG_DETECTION [NAME=<name>] [RESET] [ENABLED=<true/false>]`: Controls a
+`CLOG_DETECTION [NAME=<name>] [RESET=1] [ENABLED=<true/false>]`: Controls a
 [clog_detect] instance. `NAME` identifies the target instance by its section
 name suffix (e.g. `T0` for `[clog_detect T0]`). `NAME` is optional when only
 one `[clog_detect]` section is configured; it is required when multiple
 sections are configured.
-- `CLOG_DETECTION RESET=1` — clears the `clog_detected` state and re-arms
+- `CLOG_DETECTION RESET=1` - clears the `clog_detected` state and re-arms
   detection. The detected state is not cleared automatically, even after the
   `clog_detected_gcode` macro has run.
-- `CLOG_DETECTION ENABLED=true` — enables detection for the instance.
-- `CLOG_DETECTION ENABLED=false` — disables detection for the instance without
+- `CLOG_DETECTION RESET=1 NAME=T0` - resets the instance named `T0`.
+- `CLOG_DETECTION ENABLED=true` - enables detection for the instance.
+- `CLOG_DETECTION ENABLED=false` - disables detection for the instance without
   removing the configuration.
-- `CLOG_DETECTION RESET=1 NAME=T0` — resets the instance named `T0`.
 
 ### [manual_probe]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1090,6 +1090,20 @@ corresponding settings from the
 - `MIN_TAP_QUALITY=<percent>`
 - `DECOMPRESSION_ANGLE=<angle>`
 
+### [clog_detect]
+
+The following commands are enabled if a
+[clog_detect config section](Config_Reference.md#clog_detect) has been enabled.
+
+### CLOG_DETECT_RESET
+`CLOG_DETECT_RESET [NAME=<name>]`: Clears the clog detected state for a
+[clog_detect] instance. Once a clog is detected, the state remains set until
+this command is issued — it is not cleared automatically, even after the
+`clog_detected_gcode` macro has run. For example:
+- `CLOG_DETECT_RESET NAME=T0` — resets the instance named `T0`.
+- `CLOG_DETECT_RESET` — resets the only instance when a single `[clog_detect]`
+  section is configured. If multiple sections are configured, `NAME` is required.
+
 ### [manual_probe]
 
 The manual_probe module is automatically loaded.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1092,17 +1092,23 @@ corresponding settings from the
 
 ### [clog_detect]
 
-The following commands are enabled if a
-[clog_detect config section](Config_Reference.md#clog_detect) has been enabled.
+The following commands are available when a
+[clog_detect config section](Config_Reference.md#clog_detect) has been
+configured.
 
-### CLOG_DETECT_RESET
-`CLOG_DETECT_RESET [NAME=<name>]`: Clears the clog detected state for a
-[clog_detect] instance. Once a clog is detected, the state remains set until
-this command is issued — it is not cleared automatically, even after the
-`clog_detected_gcode` macro has run. For example:
-- `CLOG_DETECT_RESET NAME=T0` — resets the instance named `T0`.
-- `CLOG_DETECT_RESET` — resets the only instance when a single `[clog_detect]`
-  section is configured. If multiple sections are configured, `NAME` is required.
+### CLOG_DETECTION
+`CLOG_DETECTION [NAME=<name>] [RESET] [ENABLED=<true/false>]`: Controls a
+[clog_detect] instance. `NAME` identifies the target instance by its section
+name suffix (e.g. `T0` for `[clog_detect T0]`). `NAME` is optional when only
+one `[clog_detect]` section is configured; it is required when multiple
+sections are configured.
+- `CLOG_DETECTION RESET` — clears the `clog_detected` state and re-arms
+  detection. The detected state is not cleared automatically, even after the
+  `clog_detected_gcode` macro has run.
+- `CLOG_DETECTION ENABLED=true` — enables detection for the instance.
+- `CLOG_DETECTION ENABLED=false` — disables detection for the instance without
+  removing the configuration.
+- `CLOG_DETECTION RESET NAME=T0` — resets the instance named `T0`.
 
 ### [manual_probe]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1090,7 +1090,7 @@ corresponding settings from the
 - `MIN_TAP_QUALITY=<percent>`
 - `DECOMPRESSION_ANGLE=<angle>`
 
-### [clog_detect]
+### ⚠️  [clog_detect]
 
 The following commands are available when a
 [clog_detect config section](Config_Reference.md#clog_detect) has been

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -394,6 +394,155 @@ gcode:
     G1 X5 F1200
 ```
 
+## Clog Detection
+
+Clog detection allows the printer to automatically identify a blocked nozzle
+during printing. When a nozzle clogs, the extruder motor begins to stall under
+the increased pressure. The TMC driver's DIAG pin asserts in hardware when a
+stall is detected. Kalico reads this signal and, if the load cell also reports
+elevated force on the nozzle at the same moment, triggers a configurable GCode
+response.
+
+See the [clog_detect config reference](Config_Reference.md#clog_detect) and
+[GCode commands](G-Codes.md#clog_detect) for configuration details.
+
+### Prerequisites
+
+1. A load cell probe configured as `[load_cell_probe]` (or `[load_cell]`).
+2. A StallGuard-capable TMC stepper driver on the extruder - **tmc2209**,
+   **tmc2208**, **tmc2240**, **tmc5160**, or **tmc2130**.
+3. The DIAG pin of the TMC driver connected to the micro-controller and
+   configured as `diag_pin` in the extruder's TMC section.
+   Not all independent toolhead boards do this, so it is worth checking for 
+   it against the hardware schematic.
+
+### StallGuard version and StealthChop
+
+**TMC2209 and TMC2208** use StallGuard4, which is designed to operate in
+**StealthChop mode**. For these drivers, `stealthchop_threshold` should be set
+to a high value (e.g. `99999`) so StealthChop remains active during extrusion.
+In StealthChop, the `sg_result` register gives a clear differential - higher
+values during normal extrusion, lower values during a stall.
+
+Setting `stealthchop_threshold: 0` forces SpreadCycle and causes `sg_result` to
+saturate at a low value regardless of load, removing the differential and
+preventing the DIAG pin from asserting correctly. Therefore, it is recommended to
+enable StealthChop, rather than disable it.
+
+**TMC5160, TMC2130, and TMC2660** use StallGuard2, which only operates in
+SpreadCycle. For these drivers, StealthChop should instead be disabled
+(`stealthchop_threshold: 0`).
+
+**TMC2240** uses its dedicated StallGuard4 registers (`SG4_RESULT`, `SG4_THRS`)
+and follows the same guidance as TMC2209.
+
+### Configure printer.cfg for clog detection
+
+The `diag_pin` must be set in the extruder's TMC section.
+
+An example TMC2209 configuration:
+
+```
+[tmc2209 extruder]
+uart_pin: PC11
+tx_pin: PC10
+diag_pin: PC13                # MCU pin connected to TMC DIAG pin
+driver_SGTHRS: 255            # Start here - 255 is most sensitive, 0 is least
+stealthchop_threshold: 99999  # Keep StealthChop on for TMC2209/2208
+coolstep_threshold: 1         # Activate StallGuard at any extrusion speed
+run_current: 0.5
+...
+
+[clog_detect]
+load_cell: load_cell_probe
+extruder: extruder
+force: 4000
+clog_detected_gcode:
+    RESPOND TYPE=error MSG="Clog detected!"
+```
+
+An example TMC5160 configuration:
+
+```
+[tmc5160 extruder]
+spi_pin: ...
+diag1_pin: ^!PA1         # Pin connected to TMC DIAG1 pin
+driver_SGT: -64          # -64 is most sensitive value, 63 is least
+stealthchop_threshold: 0 # StallGuard2 requires SpreadCycle
+run_current: 0.8
+...
+
+[clog_detect]
+load_cell: load_cell_probe
+extruder: extruder
+force: 4000
+clog_detected_gcode:
+    RESPOND TYPE=error MSG="Clog detected!"
+```
+
+### Tuning the StallGuard threshold
+
+The goal is to find a `driver_SGTHRS` value where `sg_result` is clearly above
+the stall threshold during normal extrusion, and clearly below it during a clog.
+
+#### Find the normal extrusion baseline
+
+Home the printer, heat the nozzle to printing temperature, and extrude at a
+typical printing speed. While extruding, query the driver:
+
+```
+DUMP_TMC STEPPER=extruder
+```
+
+Note the `sg_result` value. This is your **normal baseline** - for a TMC2209 in
+StealthChop it will typically be in the range of 100-150.
+
+#### Find the clog sg_result
+
+Simulate a partial clog by extruding at 10-20°C below normal printing temperature,
+or by briefly impeding the filament path. Run `DUMP_TMC STEPPER=extruder` again
+during the extrusion and note the reduced `sg_result`. This is your
+**clog value** - it should be noticeably lower than the normal baseline.
+
+You can also adjust the threshold on the fly without restarting:
+
+```
+SET_TMC_FIELD STEPPER=extruder FIELD=SGTHRS VALUE=60
+```
+
+#### Choose the threshold
+
+Set `driver_SGTHRS` so that `2 * SGTHRS` falls between the normal and clog
+values, closer to the normal baseline to avoid false positives:
+
+```
+recommended = (normal_baseline + clog_value) / 4
+```
+
+For example, with a normal baseline of 142 and a clog value of 16:
+
+```
+recommended = (142 + 16) / 4 = 40
+```
+
+A value of 40–65 would be appropriate. Lower values reduce false positives;
+higher values improve sensitivity to mild clogs.
+
+Update `driver_SGTHRS` in the config once a reliable value is found.
+
+#### Verify with the load cell
+
+The `force` threshold in `[clog_detect]` acts as a second gate. Even if the
+extruder stalls briefly for a non-clog reason (e.g. during a retraction), the
+load cell must also report elevated nozzle force before detection fires. This
+significantly reduces false positives. The default of 4000g is a good starting
+point - adjust downward (e.g. 3000g) if partial clogs are not being caught.
+
+Note that if motor current, extrusion speed, or hardware is changed, the tuning
+process should be repeated.
+
+---
+
 ## Querying and diagnosing driver settings
 
 The `[DUMP_TMC command](G-Codes.md#dump_tmc) is a useful tool when

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -53,7 +53,9 @@ class ClogDetect:
         self._tmc = None
         self._stall_mode = None
         self._steps_per_mm = None
-        self._sgthrs = 0
+        self._sg_register = ""
+        self._sg_field = ""
+        self._sg_threshold = 0
         self._mcu = None
         self._stall_count = 0.0
         self._prev_pos = None
@@ -103,15 +105,30 @@ class ClogDetect:
             )
         if self._tmc.fields.lookup_register("lost_steps") is not None:
             self._stall_mode = "lost_steps"
+        elif self._tmc.fields.lookup_register("sg4_result") is not None:
+            self._stall_mode = "sg_result"
+            self._steps_per_mm = 1.0 / stepper.get_step_dist()
+            self._sg_register = "SG4_RESULT"
+            self._sg_field = "sg4_result"
+            sg4_thrs = self._tmc.fields.get_field("sg4_thrs")
+            if sg4_thrs == 0:
+                raise self._printer.config_error(
+                    "clog_detect: driver_sg4_thrs must be non-zero for"
+                    " stall detection on extruder '%s'" % (stepper_name,)
+                )
+            self._sg_threshold = 2 * sg4_thrs
         elif self._tmc.fields.lookup_register("sg_result") is not None:
             self._stall_mode = "sg_result"
             self._steps_per_mm = 1.0 / stepper.get_step_dist()
-            self._sgthrs = self._tmc.fields.get_field("sgthrs")
-            if self._sgthrs == 0:
+            self._sg_register = "SG_RESULT"
+            self._sg_field = "sg_result"
+            sgthrs = self._tmc.fields.get_field("sgthrs")
+            if sgthrs == 0:
                 raise self._printer.config_error(
                     "clog_detect: driver_sgthrs must be non-zero for"
                     " stall detection on extruder '%s'" % (stepper_name,)
                 )
+            self._sg_threshold = 2 * sgthrs
         else:
             raise self._printer.config_error(
                 "clog_detect: the driver for extruder '%s' does not support"
@@ -120,9 +137,8 @@ class ClogDetect:
         self._mcu = stepper.get_mcu()
         if self._stall_mode == "sg_result":
             logging.info(
-                "clog_detect: sgthrs=%d, stall threshold sg_result <= %d",
-                self._sgthrs,
-                2 * self._sgthrs,
+                "clog_detect: stall threshold %s <= %d",
+                self._sg_field, self._sg_threshold,
             )
         logging.info(
             "clog_detect: using %s mode for '%s'",
@@ -185,11 +201,11 @@ class ClogDetect:
                     )
             self._prev_lost_steps = lost
         else:
-            val = self._tmc.mcu_tmc.get_register("SG_RESULT")
-            sg = self._tmc.fields.get_field("sg_result", val)
+            val = self._tmc.mcu_tmc.get_register(self._sg_register)
+            sg = self._tmc.fields.get_field(self._sg_field, val)
             print_time = self._mcu.estimated_print_time(eventtime)
             pos_now = self._extruder.find_past_position(print_time)
-            if sg <= 2 * self._sgthrs and self._prev_pos is not None:
+            if sg <= self._sg_threshold and self._prev_pos is not None:
                 added = (pos_now - self._prev_pos) * self._steps_per_mm
                 self._stall_count = max(0.0, self._stall_count + added)
                 logging.info(

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -3,23 +3,26 @@
 # Copyright (C) 2026 Ella Fox <ella@fox.gal>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+
 import logging
 
-LOST_STEPS_MAX = 1 << 20
+# Detects clogged nozzles using two concurrent signals:
+# 1. The extruder TMC driver's DIAG pin asserts when the motor stalls
+#    (sg_result ≤ 2 × SGTHRS, driven by hardware in real time)
+# 2. The load cell reads downward force above the configured threshold
+#
+# When both conditions are met simultaneously, a clog is detected.
+# The DIAG pin is inferred from the diag_pin setting in the extruder's TMC section.
 
-# This aims to detect clogged nozzles by reading the state of two signals:
-# 1. When the extruder motor stalls (TMC stall/lost steps)
-# 2. The load cell reaches a sustained downward (negative) force
-#
-# Both of these signals must occur, in order to avoid false positives.
-#
-# This is only possible where the load cell is part of the filament path.
-# A good use case for this is where the load cell is also a probe,
-# such as when there is a load cell applied to a hotend's heatsink.
-#
-# The implementation is left open so that any load cell can be used.
-# It may also be possible to implement clog detection by using a load cell
-# in-line with the reverse-bowden tube.
+_TMC_PREFIXES = (
+    "tmc2209",
+    "tmc2208",
+    "tmc2240",
+    "tmc5160",
+    "tmc2130",
+    "tmc2660",
+    "tmc2262",
+)
 
 
 class ClogDetect:
@@ -29,201 +32,77 @@ class ClogDetect:
             "load_cell", default="load_cell_probe"
         )
         self._extruder_name = config.get("extruder", default="extruder")
-
-        # Number of skipped steps required to trigger a clog detection event
-        # Default may not be sensible yet. Need to find a good place to start.
-        self._skipped_steps = config.getfloat("skipped_steps", default=20.0)
-
-        # Undetermined whether this is a sensible force to look for.
-        # The threshold for a sensible default probably sits somewhere in the >2kg range
-        # The extruder under normal operating conditions is unlikely to exert more than that
         self._force_threshold = config.getfloat("force", default=4000.0)
-
-        # Frequency in which this runs the detection routine.
-        # 4Hz is the same as filament_motion_sensor's defaults
-        # 1Hz is the update rate to TMC stall guard
-        # Somewhere in this middle ground is the sweet spot no doubt.
-        self._poll_rate = config.getfloat("poll_rate", default=4.0)
         self._clog_detected_gcode = config.get(
             "clog_detected_gcode", default=None
         )
         self._load_cell = None
         self._extruder = None
         self._toolhead = None
-        self._tmc = None
-        self._stall_mode = None
-        self._steps_per_mm = None
-        self._sg_register = ""
-        self._sg_field = ""
-        self._sg_threshold = 0
-        self._mcu = None
-        self._stall_count = 0.0
-        self._prev_pos = None
-        self._prev_lost_steps = None
-        self._force_hysteresis = config.getfloat(
-            "force_hysteresis", default=1.0, minval=0.0
-        )
         self._clog_detected = False
-        self._force_quiet_ticks = 0
-        self._force_active = False
         self._enabled = True
+        self._tared = False
+        # Find diag_pin from the extruder's TMC section at config time
+        diag_pin = None
+        tmc_name = None
+        for prefix in _TMC_PREFIXES:
+            section = "%s %s" % (prefix, self._extruder_name)
+            if config.has_section(section):
+                tmc_cfg = config.getsection(section)
+                diag_pin = tmc_cfg.get("diag_pin", None)
+                if diag_pin is not None:
+                    tmc_name = section
+                    break
+        if diag_pin is None:
+            raise config.error(
+                "clog_detect: no diag_pin found in any TMC section for"
+                " extruder '%s'. Configure diag_pin in the extruder's"
+                " TMC section." % (self._extruder_name,)
+            )
+        buttons = self._printer.load_object(config, "buttons")
+        buttons.register_button_push(diag_pin, self._on_diag_edge)
+        logging.info(
+            "clog_detect: armed on diag_pin '%s' from '%s'",
+            diag_pin,
+            tmc_name,
+        )
         if self._printer.lookup_object("clog_detect_commands", None) is None:
             self._printer.add_object(
                 "clog_detect_commands", ClogDetectCommands(self._printer)
             )
-        self._tared = False
-        self._last_trigger_stall_count = 0.0
         self._printer.register_event_handler("klippy:connect", self._on_connect)
-        self._printer.register_event_handler("klippy:ready", self._on_ready)
         self._printer.register_event_handler("load_cell:tare", self._on_tare)
 
     def _on_connect(self):
         self._load_cell = self._printer.lookup_object(self._load_cell_name)
         extruder = self._printer.lookup_object(self._extruder_name)
         if extruder.extruder_stepper is None:
+            # We should never hit this.
             raise self._printer.config_error(
                 "clog_detect: extruder '%s' has no stepper"
                 % (self._extruder_name,)
             )
         self._extruder = extruder
         self._toolhead = self._printer.lookup_object("toolhead")
-        stepper = extruder.extruder_stepper.stepper
-        stepper_name = stepper.get_name()
-        for name, obj in self._printer.lookup_objects():
-            parts = name.split()
-            if (
-                len(parts) >= 2
-                and parts[0].startswith("tmc")
-                and " ".join(parts[1:]) == stepper_name
-            ):
-                self._tmc = obj
-                break
-        if self._tmc is None:
-            raise self._printer.config_error(
-                "clog_detect: no TMC driver found for extruder '%s'"
-                % (stepper_name,)
-            )
-        if self._tmc.fields.lookup_register("lost_steps") is not None:
-            self._stall_mode = "lost_steps"
-        elif self._tmc.fields.lookup_register("sg4_result") is not None:
-            self._stall_mode = "sg_result"
-            self._steps_per_mm = 1.0 / stepper.get_step_dist()
-            self._sg_register = "SG4_RESULT"
-            self._sg_field = "sg4_result"
-            sg4_thrs = self._tmc.fields.get_field("sg4_thrs")
-            if sg4_thrs == 0:
-                raise self._printer.config_error(
-                    "clog_detect: driver_sg4_thrs must be non-zero for"
-                    " stall detection on extruder '%s'" % (stepper_name,)
-                )
-            self._sg_threshold = 2 * sg4_thrs
-        elif self._tmc.fields.lookup_register("sg_result") is not None:
-            self._stall_mode = "sg_result"
-            self._steps_per_mm = 1.0 / stepper.get_step_dist()
-            self._sg_register = "SG_RESULT"
-            self._sg_field = "sg_result"
-            sgthrs = self._tmc.fields.get_field("sgthrs")
-            if sgthrs == 0:
-                raise self._printer.config_error(
-                    "clog_detect: driver_sgthrs must be non-zero for"
-                    " stall detection on extruder '%s'" % (stepper_name,)
-                )
-            self._sg_threshold = 2 * sgthrs
-        else:
-            raise self._printer.config_error(
-                "clog_detect: the driver for extruder '%s' does not support"
-                " stall detection" % (stepper_name,)
-            )
-        self._mcu = stepper.get_mcu()
-        if self._stall_mode == "sg_result":
-            logging.info(
-                "clog_detect: stall threshold %s <= %d",
-                self._sg_field, self._sg_threshold,
-            )
-        logging.info(
-            "clog_detect: using %s mode for '%s'",
-            self._stall_mode,
-            stepper_name,
-        )
 
     def _on_tare(self, load_cell):
         if not self._tared:
             logging.info("clog_detect: tare received, detection armed")
             self._tared = True
 
-    def _on_ready(self):
-        reactor = self._printer.get_reactor()
-        reactor.register_timer(
-            self._poll, reactor.monotonic() + (1.0 / self._poll_rate)
-        )
-
-    def _poll(self, eventtime):
-        interval = 1.0 / self._poll_rate
-        if self._tmc is None or not self._tared or not self._enabled:
-            return eventtime + interval
+    def _on_diag_edge(self, eventtime):
+        if not self._tared or not self._enabled or self._clog_detected:
+            return
         if self._toolhead.get_extruder() is not self._extruder:
-            return eventtime + interval
-        status = self._load_cell.get_status(eventtime)
-        force_g = status.get("force_g")
-        if force_g is None or force_g > -self._force_threshold:
-            if self._force_active:
-                logging.info(
-                    "clog_detect: force below threshold (%.1fg)", force_g or 0.0
-                )
-                self._force_active = False
-            self._force_quiet_ticks += 1
-            quiet_limit = int(self._force_hysteresis * self._poll_rate)
-            if self._force_quiet_ticks >= quiet_limit:
-                self._stall_count = 0.0
-                self._force_quiet_ticks = 0
-            return eventtime + interval
-        if self._clog_detected:
-            return eventtime + interval
-        if not self._force_active:
-            logging.info(
-                "clog_detect: force threshold exceeded (%.1fg)", force_g
-            )
-            self._force_active = True
-        self._force_quiet_ticks = 0
-        if self._stall_mode == "lost_steps":
-            val = self._tmc.mcu_tmc.get_register("LOST_STEPS")
-            lost = self._tmc.fields.get_field("lost_steps", val)
-            if self._prev_lost_steps is not None:
-                delta = lost - self._prev_lost_steps
-                if delta < 0:
-                    delta += LOST_STEPS_MAX
-                if delta > 0:
-                    self._stall_count += delta
-                    logging.info(
-                        "clog_detect: lost_steps +%d (total %.1f)",
-                        delta,
-                        self._stall_count,
-                    )
-            self._prev_lost_steps = lost
-        else:
-            val = self._tmc.mcu_tmc.get_register(self._sg_register)
-            sg = self._tmc.fields.get_field(self._sg_field, val)
-            print_time = self._mcu.estimated_print_time(eventtime)
-            pos_now = self._extruder.find_past_position(print_time)
-            if sg <= self._sg_threshold and self._prev_pos is not None:
-                added = (pos_now - self._prev_pos) * self._steps_per_mm
-                self._stall_count = max(0.0, self._stall_count + added)
-                logging.info(
-                    "clog_detect: stall detected, +%.1f steps (total %.1f)",
-                    added,
-                    self._stall_count,
-                )
-            self._prev_pos = pos_now
-        if self._stall_count >= self._skipped_steps:
+            return
+        force_g = self._load_cell.get_status(eventtime).get("force_g")
+        if force_g is not None and force_g <= -self._force_threshold:
             self._trigger_clog(eventtime)
-        return eventtime + interval
 
     def _trigger_clog(self, eventtime):
         logging.info("clog_detect: clog detected at %.3f", eventtime)
         self._printer.send_event("clog_detect:detected", eventtime)
         self._clog_detected = True
-        self._last_trigger_stall_count = self._stall_count
-        self._stall_count = 0.0
         if self._clog_detected_gcode is not None:
             gcode = self._printer.lookup_object("gcode")
             reactor = self._printer.get_reactor()
@@ -243,7 +122,6 @@ class ClogDetect:
     def get_status(self, eventtime):
         return {
             "enabled": self._enabled,
-            "last_trigger_stall_count": self._last_trigger_stall_count,
             "clog_detected": self._clog_detected,
         }
 
@@ -263,7 +141,8 @@ class ClogDetectCommands:
         gcode.register_command(
             "CLOG_DETECTION",
             self._cmd_clog_detection,
-            desc="Control clog detection: NAME={tool_name} (optional), ENABLED=true/false, RESET",
+            desc="Control clog detection: NAME={name} (optional),"
+            " ENABLED=true/false, RESET=1",
         )
 
     def _resolve(self, gcmd):

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -58,6 +58,10 @@ class ClogDetect:
         self._prev_pos = None
         self._prev_lost_steps = None
         self._clog_detected = False
+        if self._printer.lookup_object("clog_detect_commands", None) is None:
+            self._printer.add_object(
+                "clog_detect_commands", ClogDetectCommands(self._printer)
+            )
         self._printer.register_event_handler("klippy:connect", self._on_connect)
         self._printer.register_event_handler("klippy:ready", self._on_ready)
 
@@ -158,11 +162,11 @@ class ClogDetect:
 
             def _run(et):
                 gcode.run_script(script)
-                self._clog_detected = False
 
             reactor.register_callback(_run)
-        else:
-            self._clog_detected = False
+
+    def reset(self):
+        self._clog_detected = False
 
     def get_status(self, eventtime):
         return {
@@ -173,3 +177,31 @@ class ClogDetect:
 
 def load_config_prefix(config):
     return ClogDetect(config)
+
+
+class ClogDetectCommands:
+    def __init__(self, printer):
+        self._printer = printer
+        gcode = printer.lookup_object("gcode")
+        gcode.register_command(
+            "CLOG_DETECT_RESET",
+            self._cmd_reset,
+            desc="Reset clog detection state",
+        )
+
+    def _cmd_reset(self, gcmd):
+        name = gcmd.get("NAME", None)
+        instances = dict(self._printer.lookup_objects("clog_detect"))
+        if name is None:
+            if len(instances) == 1:
+                list(instances.values())[0].reset()
+            else:
+                raise gcmd.error(
+                    "NAME required: %s"
+                    % ", ".join(n.split()[-1] for n in instances)
+                )
+        else:
+            instance = instances.get("clog_detect " + name)
+            if instance is None:
+                raise gcmd.error("Unknown clog_detect '%s'" % (name,))
+            instance.reset()

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -53,17 +53,27 @@ class ClogDetect:
         self._tmc = None
         self._stall_mode = None
         self._steps_per_mm = None
+        self._sgthrs = 0
         self._mcu = None
         self._stall_count = 0.0
         self._prev_pos = None
         self._prev_lost_steps = None
+        self._force_hysteresis = config.getfloat(
+            "force_hysteresis", default=1.0, minval=0.0
+        )
         self._clog_detected = False
+        self._force_quiet_ticks = 0
+        self._force_active = False
+        self._enabled = True
         if self._printer.lookup_object("clog_detect_commands", None) is None:
             self._printer.add_object(
                 "clog_detect_commands", ClogDetectCommands(self._printer)
             )
+        self._tared = False
+        self._last_trigger_stall_count = 0.0
         self._printer.register_event_handler("klippy:connect", self._on_connect)
         self._printer.register_event_handler("klippy:ready", self._on_ready)
+        self._printer.register_event_handler("load_cell:tare", self._on_tare)
 
     def _on_connect(self):
         self._load_cell = self._printer.lookup_object(self._load_cell_name)
@@ -96,17 +106,34 @@ class ClogDetect:
         elif self._tmc.fields.lookup_register("sg_result") is not None:
             self._stall_mode = "sg_result"
             self._steps_per_mm = 1.0 / stepper.get_step_dist()
+            self._sgthrs = self._tmc.fields.get_field("sgthrs")
+            if self._sgthrs == 0:
+                raise self._printer.config_error(
+                    "clog_detect: driver_sgthrs must be non-zero for"
+                    " stall detection on extruder '%s'" % (stepper_name,)
+                )
         else:
             raise self._printer.config_error(
                 "clog_detect: the driver for extruder '%s' does not support"
                 " stall detection" % (stepper_name,)
             )
         self._mcu = stepper.get_mcu()
+        if self._stall_mode == "sg_result":
+            logging.info(
+                "clog_detect: sgthrs=%d, stall threshold sg_result <= %d",
+                self._sgthrs,
+                2 * self._sgthrs,
+            )
         logging.info(
             "clog_detect: using %s mode for '%s'",
             self._stall_mode,
             stepper_name,
         )
+
+    def _on_tare(self, load_cell):
+        if not self._tared:
+            logging.info("clog_detect: tare received, detection armed")
+            self._tared = True
 
     def _on_ready(self):
         reactor = self._printer.get_reactor()
@@ -116,15 +143,32 @@ class ClogDetect:
 
     def _poll(self, eventtime):
         interval = 1.0 / self._poll_rate
-        if self._tmc is None:
+        if self._tmc is None or not self._tared or not self._enabled:
             return eventtime + interval
         if self._toolhead.get_extruder() is not self._extruder:
             return eventtime + interval
         status = self._load_cell.get_status(eventtime)
         force_g = status.get("force_g")
         if force_g is None or force_g > -self._force_threshold:
-            self._stall_count = 0.0
+            if self._force_active:
+                logging.info(
+                    "clog_detect: force below threshold (%.1fg)", force_g or 0.0
+                )
+                self._force_active = False
+            self._force_quiet_ticks += 1
+            quiet_limit = int(self._force_hysteresis * self._poll_rate)
+            if self._force_quiet_ticks >= quiet_limit:
+                self._stall_count = 0.0
+                self._force_quiet_ticks = 0
             return eventtime + interval
+        if self._clog_detected:
+            return eventtime + interval
+        if not self._force_active:
+            logging.info(
+                "clog_detect: force threshold exceeded (%.1fg)", force_g
+            )
+            self._force_active = True
+        self._force_quiet_ticks = 0
         if self._stall_mode == "lost_steps":
             val = self._tmc.mcu_tmc.get_register("LOST_STEPS")
             lost = self._tmc.fields.get_field("lost_steps", val)
@@ -132,18 +176,26 @@ class ClogDetect:
                 delta = lost - self._prev_lost_steps
                 if delta < 0:
                     delta += LOST_STEPS_MAX
-                self._stall_count += delta
+                if delta > 0:
+                    self._stall_count += delta
+                    logging.info(
+                        "clog_detect: lost_steps +%d (total %.1f)",
+                        delta,
+                        self._stall_count,
+                    )
             self._prev_lost_steps = lost
         else:
             val = self._tmc.mcu_tmc.get_register("SG_RESULT")
             sg = self._tmc.fields.get_field("sg_result", val)
             print_time = self._mcu.estimated_print_time(eventtime)
             pos_now = self._extruder.find_past_position(print_time)
-            if sg == 0 and self._prev_pos is not None:
-                self._stall_count = max(
-                    0.0,
-                    self._stall_count
-                    + (pos_now - self._prev_pos) * self._steps_per_mm,
+            if sg <= 2 * self._sgthrs and self._prev_pos is not None:
+                added = (pos_now - self._prev_pos) * self._steps_per_mm
+                self._stall_count = max(0.0, self._stall_count + added)
+                logging.info(
+                    "clog_detect: stall detected, +%.1f steps (total %.1f)",
+                    added,
+                    self._stall_count,
                 )
             self._prev_pos = pos_now
         if self._stall_count >= self._skipped_steps:
@@ -154,6 +206,7 @@ class ClogDetect:
         logging.info("clog_detect: clog detected at %.3f", eventtime)
         self._printer.send_event("clog_detect:detected", eventtime)
         self._clog_detected = True
+        self._last_trigger_stall_count = self._stall_count
         self._stall_count = 0.0
         if self._clog_detected_gcode is not None:
             gcode = self._printer.lookup_object("gcode")
@@ -168,9 +221,13 @@ class ClogDetect:
     def reset(self):
         self._clog_detected = False
 
+    def set_enabled(self, enabled):
+        self._enabled = enabled
+
     def get_status(self, eventtime):
         return {
-            "stall_count": self._stall_count,
+            "enabled": self._enabled,
+            "last_trigger_stall_count": self._last_trigger_stall_count,
             "clog_detected": self._clog_detected,
         }
 
@@ -188,24 +245,37 @@ class ClogDetectCommands:
         self._printer = printer
         gcode = printer.lookup_object("gcode")
         gcode.register_command(
-            "CLOG_DETECT_RESET",
-            self._cmd_reset,
-            desc="Reset clog detection state",
+            "CLOG_DETECTION",
+            self._cmd_clog_detection,
+            desc="Control clog detection: NAME={tool_name} (optional), ENABLED=true/false, RESET",
         )
 
-    def _cmd_reset(self, gcmd):
+    def _resolve(self, gcmd):
         name = gcmd.get("NAME", None)
         instances = dict(self._printer.lookup_objects("clog_detect"))
         if name is None:
             if len(instances) == 1:
-                list(instances.values())[0].reset()
-            else:
-                raise gcmd.error(
-                    "NAME required: %s"
-                    % ", ".join(n.split()[-1] for n in instances)
-                )
-        else:
-            instance = instances.get("clog_detect " + name)
-            if instance is None:
-                raise gcmd.error("Unknown clog_detect '%s'" % (name,))
-            instance.reset()
+                return list(instances.values())
+            raise gcmd.error(
+                "NAME required: %s"
+                % ", ".join(n.split()[-1] for n in instances)
+            )
+        instance = instances.get("clog_detect " + name)
+        if instance is None:
+            raise gcmd.error("Unknown clog_detect '%s'" % (name,))
+        return [instance]
+
+    def _cmd_clog_detection(self, gcmd):
+        targets = self._resolve(gcmd)
+        if gcmd.get_int("RESET", 0):
+            for t in targets:
+                t.reset()
+            gcmd.respond_info("Clog detection reset")
+        enabled_str = gcmd.get("ENABLED", None)
+        if enabled_str is not None:
+            enabled = enabled_str.lower() in ("1", "true", "yes")
+            for t in targets:
+                t.set_enabled(enabled)
+            gcmd.respond_info(
+                "Clog detection %s" % ("enabled" if enabled else "disabled")
+            )

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -175,6 +175,10 @@ class ClogDetect:
         }
 
 
+def load_config(config):
+    return ClogDetect(config)
+
+
 def load_config_prefix(config):
     return ClogDetect(config)
 

--- a/klippy/extras/clog_detect.py
+++ b/klippy/extras/clog_detect.py
@@ -1,0 +1,175 @@
+# Clog Detection
+#
+# Copyright (C) 2026 Ella Fox <ella@fox.gal>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+LOST_STEPS_MAX = 1 << 20
+
+# This aims to detect clogged nozzles by reading the state of two signals:
+# 1. When the extruder motor stalls (TMC stall/lost steps)
+# 2. The load cell reaches a sustained downward (negative) force
+#
+# Both of these signals must occur, in order to avoid false positives.
+#
+# This is only possible where the load cell is part of the filament path.
+# A good use case for this is where the load cell is also a probe,
+# such as when there is a load cell applied to a hotend's heatsink.
+#
+# The implementation is left open so that any load cell can be used.
+# It may also be possible to implement clog detection by using a load cell
+# in-line with the reverse-bowden tube.
+
+
+class ClogDetect:
+    def __init__(self, config):
+        self._printer = config.get_printer()
+        self._load_cell_name = config.get(
+            "load_cell", default="load_cell_probe"
+        )
+        self._extruder_name = config.get("extruder", default="extruder")
+
+        # Number of skipped steps required to trigger a clog detection event
+        # Default may not be sensible yet. Need to find a good place to start.
+        self._skipped_steps = config.getfloat("skipped_steps", default=20.0)
+
+        # Undetermined whether this is a sensible force to look for.
+        # The threshold for a sensible default probably sits somewhere in the >2kg range
+        # The extruder under normal operating conditions is unlikely to exert more than that
+        self._force_threshold = config.getfloat("force", default=4000.0)
+
+        # Frequency in which this runs the detection routine.
+        # 4Hz is the same as filament_motion_sensor's defaults
+        # 1Hz is the update rate to TMC stall guard
+        # Somewhere in this middle ground is the sweet spot no doubt.
+        self._poll_rate = config.getfloat("poll_rate", default=4.0)
+        self._clog_detected_gcode = config.get(
+            "clog_detected_gcode", default=None
+        )
+        self._load_cell = None
+        self._extruder = None
+        self._toolhead = None
+        self._tmc = None
+        self._stall_mode = None
+        self._steps_per_mm = None
+        self._mcu = None
+        self._stall_count = 0.0
+        self._prev_pos = None
+        self._prev_lost_steps = None
+        self._clog_detected = False
+        self._printer.register_event_handler("klippy:connect", self._on_connect)
+        self._printer.register_event_handler("klippy:ready", self._on_ready)
+
+    def _on_connect(self):
+        self._load_cell = self._printer.lookup_object(self._load_cell_name)
+        extruder = self._printer.lookup_object(self._extruder_name)
+        if extruder.extruder_stepper is None:
+            raise self._printer.config_error(
+                "clog_detect: extruder '%s' has no stepper"
+                % (self._extruder_name,)
+            )
+        self._extruder = extruder
+        self._toolhead = self._printer.lookup_object("toolhead")
+        stepper = extruder.extruder_stepper.stepper
+        stepper_name = stepper.get_name()
+        for name, obj in self._printer.lookup_objects():
+            parts = name.split()
+            if (
+                len(parts) >= 2
+                and parts[0].startswith("tmc")
+                and " ".join(parts[1:]) == stepper_name
+            ):
+                self._tmc = obj
+                break
+        if self._tmc is None:
+            raise self._printer.config_error(
+                "clog_detect: no TMC driver found for extruder '%s'"
+                % (stepper_name,)
+            )
+        if self._tmc.fields.lookup_register("lost_steps") is not None:
+            self._stall_mode = "lost_steps"
+        elif self._tmc.fields.lookup_register("sg_result") is not None:
+            self._stall_mode = "sg_result"
+            self._steps_per_mm = 1.0 / stepper.get_step_dist()
+        else:
+            raise self._printer.config_error(
+                "clog_detect: the driver for extruder '%s' does not support"
+                " stall detection" % (stepper_name,)
+            )
+        self._mcu = stepper.get_mcu()
+        logging.info(
+            "clog_detect: using %s mode for '%s'",
+            self._stall_mode,
+            stepper_name,
+        )
+
+    def _on_ready(self):
+        reactor = self._printer.get_reactor()
+        reactor.register_timer(
+            self._poll, reactor.monotonic() + (1.0 / self._poll_rate)
+        )
+
+    def _poll(self, eventtime):
+        interval = 1.0 / self._poll_rate
+        if self._tmc is None:
+            return eventtime + interval
+        if self._toolhead.get_extruder() is not self._extruder:
+            return eventtime + interval
+        status = self._load_cell.get_status(eventtime)
+        force_g = status.get("force_g")
+        if force_g is None or force_g > -self._force_threshold:
+            self._stall_count = 0.0
+            return eventtime + interval
+        if self._stall_mode == "lost_steps":
+            val = self._tmc.mcu_tmc.get_register("LOST_STEPS")
+            lost = self._tmc.fields.get_field("lost_steps", val)
+            if self._prev_lost_steps is not None:
+                delta = lost - self._prev_lost_steps
+                if delta < 0:
+                    delta += LOST_STEPS_MAX
+                self._stall_count += delta
+            self._prev_lost_steps = lost
+        else:
+            val = self._tmc.mcu_tmc.get_register("SG_RESULT")
+            sg = self._tmc.fields.get_field("sg_result", val)
+            print_time = self._mcu.estimated_print_time(eventtime)
+            pos_now = self._extruder.find_past_position(print_time)
+            if sg == 0 and self._prev_pos is not None:
+                self._stall_count = max(
+                    0.0,
+                    self._stall_count
+                    + (pos_now - self._prev_pos) * self._steps_per_mm,
+                )
+            self._prev_pos = pos_now
+        if self._stall_count >= self._skipped_steps:
+            self._trigger_clog(eventtime)
+        return eventtime + interval
+
+    def _trigger_clog(self, eventtime):
+        logging.info("clog_detect: clog detected at %.3f", eventtime)
+        self._printer.send_event("clog_detect:detected", eventtime)
+        self._clog_detected = True
+        self._stall_count = 0.0
+        if self._clog_detected_gcode is not None:
+            gcode = self._printer.lookup_object("gcode")
+            reactor = self._printer.get_reactor()
+            script = self._clog_detected_gcode
+
+            def _run(et):
+                gcode.run_script(script)
+                self._clog_detected = False
+
+            reactor.register_callback(_run)
+        else:
+            self._clog_detected = False
+
+    def get_status(self, eventtime):
+        return {
+            "stall_count": self._stall_count,
+            "clog_detected": self._clog_detected,
+        }
+
+
+def load_config_prefix(config):
+    return ClogDetect(config)


### PR DESCRIPTION
Adds support for nozzle clog detection, by watching the extruder TMC stepper for stall events, and combining this with load cell force readings. The important factor here is the load cell force. Without it, the TMC stepper alone may incur false positives.

This is a standalone module, that works for both single extruder, and multi-tool/multi-extruder setups.

In order for users to enable this, they need to configure TMC StallGuard for their extruder motor. Documentation has been updated to reflect this.

This still needs further testing from the real-world testing I have already done.  
Therefore, it is marked as a danger feature ⚠️ until we are happy with what we see.

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
