### PR TITLE
Dual Loop PID fixes & improvements

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1167,13 +1167,16 @@ per_move_pressure_advance: False
 #
 #   If: control: dual_loop_pid
 #inner_sensor_name:
-#   The temperature_sensor name of a second sensor to use for temperature
-#   control with 'dual_loop_pid'. This sensor will limit the heater power
-#   to not allow the temperature to exceed the 'inner_max_temp' value.
+#   The temperature_sensor name of a second sensor used by
+#   'dual_loop_pid' for the inner PID loop.
 #
 #   If: control: dual_loop_pid
+#inner_target_temp:
+#   The target temperature for the inner PID loop. During calibration,
+#   the temperature will oscillate above and below this value. This
+#   behavior is expected and does not indicate a safety failure.
 #inner_max_temp:
-#   The maximum temperature target that the inner sensor will allow.
+#   Deprecated alias for inner_target_temp.
 #
 #   If control: dual_loop_pid
 #inner_pid_Kp:
@@ -1182,9 +1185,9 @@ per_move_pressure_advance: False
 #   'dual_loop_pid' control uses two PID loops to control the temperature.
 #   The inner(secondary) PID loop controls the temperature directly. The
 #   primary PID loop controls the power to the secondary PID loop. This
-#   allows the primary PID loop to be tuned for temperature control, while
-#   the secondary PID loop can be tuned for power control, not exceeding
-#   the temperature limit set on 'inner_max_temp'.
+#   allows the primary PID loop to be tuned for temperature control,
+#   while the secondary PID loop can be tuned for power control while
+#   tracking 'inner_target_temp'.
 #   The primary sensor is positioned close where the temperature
 #   measurament should be more accurate (e.g. on the bed surface). The
 #   secondary sensor is positioned where the temperature measurament

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -1158,12 +1158,14 @@ class ControlDualLoopPID:
         if secondary_temp is None:
             raise ValueError("Secondary temperature must be provided!")
 
+        primary_prev_temp_integ = self.primary_pid.prev_temp_integ
         primary_co, _ = self.primary_pid.calculate_output(
             read_time,
             primary_temp,
             target_temp,
         )
 
+        secondary_prev_temp_integ = self.secondary_pid.prev_temp_integ
         secondary_co, _ = self.secondary_pid.calculate_output(
             read_time,
             secondary_temp,
@@ -1172,6 +1174,14 @@ class ControlDualLoopPID:
 
         co = min(primary_co, secondary_co)
         bounded_co = max(0.0, min(self.heater_max_power, co))
+
+        # If the other loop reduced the final heater output, don't let this
+        # loop retain an integrator update based on power that was never
+        # actually applied to the heater.
+        if primary_co != bounded_co:
+            self.primary_pid.prev_temp_integ = primary_prev_temp_integ
+        if secondary_co != bounded_co:
+            self.secondary_pid.prev_temp_integ = secondary_prev_temp_integ
 
         self.heater.set_pwm(read_time, bounded_co)
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -35,6 +35,31 @@ PID_PROFILE_OPTIONS = {
     "pid_ki": (float, "%.3f"),
     "pid_kd": (float, "%.3f"),
 }
+DUAL_LOOP_PID_INNER_TARGET_OPTION = "inner_target_temp"
+DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION = "inner_max_temp"
+
+
+def lookup_dual_loop_pid_inner_target_temp(config):
+    inner_target_temp = config.getfloat(
+        DUAL_LOOP_PID_INNER_TARGET_OPTION, None
+    )
+    inner_max_temp = config.getfloat(
+        DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION, None
+    )
+    if inner_target_temp is not None and inner_max_temp is not None:
+        raise config.error(
+            "Options '%s' and '%s' may not both be specified"
+            % (
+                DUAL_LOOP_PID_INNER_TARGET_OPTION,
+                DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION,
+            )
+        )
+    if inner_target_temp is not None:
+        return inner_target_temp
+    if inner_max_temp is not None:
+        config.deprecate(DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION)
+        return inner_max_temp
+    return config.getfloat(DUAL_LOOP_PID_INNER_TARGET_OPTION)
 
 
 class Heater:
@@ -1119,7 +1144,9 @@ class ControlDualLoopPID:
             load_clean=load_clean,
         )
 
-        self.secondary_max_temp = self.heater.config.getfloat("inner_max_temp")
+        self.inner_target_temp = lookup_dual_loop_pid_inner_target_temp(
+            self.heater.config
+        )
 
     def temperature_update(
         self,
@@ -1140,7 +1167,7 @@ class ControlDualLoopPID:
         secondary_co, _ = self.secondary_pid.calculate_output(
             read_time,
             secondary_temp,
-            self.secondary_max_temp,
+            self.inner_target_temp,
         )
 
         co = min(primary_co, secondary_co)

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -662,6 +662,33 @@ class Heater:
                 "pid_ki": ki,
                 "pid_kd": kd,
             }
+            if control == "dual_loop_pid":
+                # The inner loop has its own gains, default to the values from
+                # the current profile when not overridden on the command line.
+                inner_kp = self._check_value_gcmd(
+                    "INNER_KP",
+                    current_profile.get("inner_pid_kp"),
+                    gcmd,
+                    float,
+                    False,
+                )
+                inner_ki = self._check_value_gcmd(
+                    "INNER_KI",
+                    current_profile.get("inner_pid_ki"),
+                    gcmd,
+                    float,
+                    False,
+                )
+                inner_kd = self._check_value_gcmd(
+                    "INNER_KD",
+                    current_profile.get("inner_pid_kd"),
+                    gcmd,
+                    float,
+                    False,
+                )
+                temp_profile["inner_pid_kp"] = inner_kp
+                temp_profile["inner_pid_ki"] = inner_ki
+                temp_profile["inner_pid_kd"] = inner_kd
             temp_control = self.outer_instance.lookup_control(
                 temp_profile, load_clean
             )
@@ -674,10 +701,13 @@ class Heater:
             )
             if smooth_time is not None:
                 msg += "Smooth Time: %.3f\n" % smooth_time
-            msg += (
-                "pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
-                "have been set as current profile." % (kp, ki, kd)
-            )
+            msg += "pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n" % (kp, ki, kd)
+            if control == "dual_loop_pid":
+                msg += (
+                    "inner_pid_Kp=%.3f inner_pid_Ki=%.3f "
+                    "inner_pid_Kd=%.3f\n" % (inner_kp, inner_ki, inner_kd)
+                )
+            msg += "have been set as current profile."
             self.outer_instance.gcode.respond_info(msg)
             self.save_profile(profile_name=profile_name, verbose=True)
 
@@ -695,16 +725,27 @@ class Heater:
                 else temp_profile["smooth_time"]
             )
             name = temp_profile["name"]
-            self.outer_instance.gcode.respond_info(
+            msg = (
                 "PID Parameters:\n"
                 "Target: %.2f,\n"
                 "Tolerance: %.4f\n"
                 "Control: %s\n"
                 "Smooth Time: %.3f\n"
                 "pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
-                "name: %s"
-                % (target, tolerance, control, smooth_time, kp, ki, kd, name)
+                % (target, tolerance, control, smooth_time, kp, ki, kd)
             )
+            if control == "dual_loop_pid":
+                msg += (
+                    "inner_pid_Kp=%.3f inner_pid_Ki=%.3f "
+                    "inner_pid_Kd=%.3f\n"
+                    % (
+                        temp_profile["inner_pid_kp"],
+                        temp_profile["inner_pid_ki"],
+                        temp_profile["inner_pid_kd"],
+                    )
+                )
+            msg += "name: %s" % name
+            self.outer_instance.gcode.respond_info(msg)
 
         def save_profile(self, profile_name=None, gcmd=None, verbose=True):
             temp_profile = self.outer_instance.get_control().get_profile()
@@ -815,6 +856,16 @@ class Heater:
                         profile["pid_kd"],
                     )
                 )
+                if profile["control"] == "dual_loop_pid":
+                    msg += (
+                        "Inner PID Parameters: inner_pid_Kp=%.3f "
+                        "inner_pid_Ki=%.3f inner_pid_Kd=%.3f\n"
+                        % (
+                            profile["inner_pid_kp"],
+                            profile["inner_pid_ki"],
+                            profile["inner_pid_kd"],
+                        )
+                    )
                 self.outer_instance.gcode.respond_info(msg)
 
         def remove_profile(self, profile_name, gcmd, verbose):

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -40,9 +40,7 @@ DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION = "inner_max_temp"
 
 
 def lookup_dual_loop_pid_inner_target_temp(config):
-    inner_target_temp = config.getfloat(
-        DUAL_LOOP_PID_INNER_TARGET_OPTION, None
-    )
+    inner_target_temp = config.getfloat(DUAL_LOOP_PID_INNER_TARGET_OPTION, None)
     inner_max_temp = config.getfloat(
         DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION, None
     )
@@ -716,12 +714,21 @@ class Heater:
             self.outer_instance.configfile.set(
                 section_name, "pid_version", PID_PROFILE_VERSION
             )
+            is_dual_loop = temp_profile["control"] == "dual_loop_pid"
             for key, (type, placeholder) in PID_PROFILE_OPTIONS.items():
                 value = temp_profile[key]
                 if value is not None:
                     self.outer_instance.configfile.set(
                         section_name, key, placeholder % value
                     )
+                # Mirror the inner/secondary loop keys read in _init_profile
+                if is_dual_loop and key in ("pid_kp", "pid_ki", "pid_kd"):
+                    inner_key = "inner_" + key
+                    inner_value = temp_profile.get(inner_key)
+                    if inner_value is not None:
+                        self.outer_instance.configfile.set(
+                            section_name, inner_key, placeholder % inner_value
+                        )
             temp_profile["name"] = profile_name
             self.profiles[profile_name] = temp_profile
             if verbose:

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -31,10 +31,10 @@ class PIDCalibrate:
     ):
         if isinstance(heater.control, heaters.ControlDualLoopPID):
             if calibrate_secondary:
-                delta = heater.control.secondary_max_temp - target
+                delta = heater.control.inner_target_temp - target
                 if delta <= 15.0:
                     gcmd.respond_raw(
-                        "!! Target calibration temperature of %d°C is <= 15°C below `secondary_max_temp`."
+                        "!! Target calibration temperature of %d°C is <= 15°C below `inner_target_temp`."
                         % target
                     )
                     gcmd.respond_raw(
@@ -43,11 +43,11 @@ class PIDCalibrate:
 
                 gcmd.respond_info(
                     "Calibrating secondary pid loop (target=%.1f)"
-                    % (heater.control.secondary_max_temp)
+                    % (heater.control.inner_target_temp)
                 )
                 calibrate = ControlAutoTune(
                     heater,
-                    heater.control.secondary_max_temp,
+                    heater.control.inner_target_temp,
                     tolerance,
                     calibrate_secondary=calibrate_secondary,
                 )
@@ -332,7 +332,7 @@ class ControlAutoTune:
             is_dual_loop = isinstance(self.control, heaters.ControlDualLoopPID)
             if is_dual_loop and not self.calibrate_secondary:
                 pid = self.control.secondary_pid
-                secondary_target_temp = self.control.secondary_max_temp
+                secondary_target_temp = self.control.inner_target_temp
                 _, bounded_co = pid.calculate_output(
                     read_time, secondary_temp, secondary_target_temp
                 )

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -66,7 +66,7 @@ class PIDCalibrate:
                 max_temp = max(0.0, calibrate.temp_low - 5.0)
                 gcmd.respond_info(
                     "Waiting for heater %s to cool down to %.1f for calibration."
-                    % (heater.get_name(), target)
+                    % (heater.get_name(), max_temp)
                 )
                 pheaters.set_temperature(heater, max_temp, True)
         else:

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -42,8 +42,10 @@ class PIDCalibrate:
                     )
 
                 gcmd.respond_info(
-                    "Calibrating secondary pid loop (target=%.1f)"
-                    % (heater.control.inner_target_temp)
+                    "Calibrating secondary pid loop around %.1fC. "
+                    "The inner sensor temperature will oscillate above "
+                    "and below this target during calibration; this is "
+                    "expected." % (heater.control.inner_target_temp)
                 )
                 calibrate = ControlAutoTune(
                     heater,

--- a/test/test_pid_profile.py
+++ b/test/test_pid_profile.py
@@ -4,6 +4,44 @@ import typing
 from klippy_testing import PrinterShim
 
 import klippy.extras.heaters as heaters
+import klippy.gcode
+
+PID_PARAM_BASE = heaters.PID_PARAM_BASE
+
+
+def _dual_loop_profile():
+    """A fresh dual_loop_pid profile dict (tests mutate it)."""
+    return {
+        "pid_target": 70.0,
+        "pid_tolerance": 0.02,
+        "control": "dual_loop_pid",
+        "smooth_time": None,
+        "pid_kp": 42.894,
+        "pid_ki": 0.376,
+        "pid_kd": 1224.094,
+        "inner_pid_kp": 60.499,
+        "inner_pid_ki": 2.425,
+        "inner_pid_kd": 377.360,
+        "name": "default",
+    }
+
+
+def _make_pmgr(heater):
+    pmgr = heaters.Heater.ProfileManager.__new__(heaters.Heater.ProfileManager)
+    pmgr.outer_instance = heater
+    pmgr.profiles = {}
+    return pmgr
+
+
+def _gcmd(heater, params):
+    return klippy.gcode.GCodeCommand(
+        heater.gcode, "PID_PROFILE", "PID_PROFILE", params, False
+    )
+
+
+######################################################################
+# save_profile() autosave persistence
+######################################################################
 
 
 class _FakeControl:
@@ -27,13 +65,6 @@ class _FakeHeater:
         return self._control
 
 
-def _make_pmgr(heater):
-    pmgr = heaters.Heater.ProfileManager.__new__(heaters.Heater.ProfileManager)
-    pmgr.outer_instance = heater
-    pmgr.profiles = {}
-    return pmgr
-
-
 def test_save_profile_persists_inner_pid_values(
     config_root: typing.Annotated[pathlib.Path, "test_configs/autosave"],
 ):
@@ -44,21 +75,10 @@ def test_save_profile_persists_inner_pid_values(
         # configfile.set() writes into.
         printer.load_config()
 
-        profile = {
-            "pid_target": 70.0,
-            "pid_tolerance": 0.02,
-            "control": "dual_loop_pid",
-            "smooth_time": None,
-            "pid_kp": 42.894,
-            "pid_ki": 0.376,
-            "pid_kd": 1224.094,
-            "inner_pid_kp": 60.499,
-            "inner_pid_ki": 2.425,
-            "inner_pid_kd": 377.360,
-            "name": "default",
-        }
         heater = _FakeHeater(
-            pconfig, printer.lookup_object("gcode"), _FakeControl(profile)
+            pconfig,
+            printer.lookup_object("gcode"),
+            _FakeControl(_dual_loop_profile()),
         )
         pmgr = _make_pmgr(heater)
 
@@ -71,3 +91,176 @@ def test_save_profile_persists_inner_pid_values(
         assert pending["inner_pid_kp"] == "60.499"
         assert pending["inner_pid_ki"] == "2.425"
         assert pending["inner_pid_kd"] == "377.360"
+
+
+######################################################################
+# set_values() / get_values() / load_profile() over a real control
+######################################################################
+
+
+class _FakeReactor:
+    def monotonic(self):
+        return 0.0
+
+
+class _FakeConfig:
+    def getfloat(self, key, default=None, **kw):
+        return {"inner_target_temp": 135.0}.get(key, default)
+
+    def error(self, msg):
+        return Exception(msg)
+
+
+class _FakeGCode:
+    error = Exception
+
+    def __init__(self):
+        self.messages = []
+
+    def respond_info(self, msg):
+        self.messages.append(msg)
+
+    def respond_raw(self, msg):
+        self.messages.append(msg)
+
+
+class _FakeConfigFile:
+    def __init__(self):
+        self.data = {}
+
+    def set(self, section, key, val):
+        self.data.setdefault(section, {})[key] = val
+
+
+class _FakeDualLoopHeater:
+    """Heater stand-in that exercises the real dual-loop control path."""
+
+    short_name = "heater_bed"
+
+    def __init__(self):
+        self.reactor = _FakeReactor()
+        self.config = _FakeConfig()
+        self.gcode = _FakeGCode()
+        self.configfile = _FakeConfigFile()
+        self.smooth_time = 1.0
+        self.target_temp = 0.0
+        self.control = None
+
+    def get_max_power(self):
+        return 1.0
+
+    def get_smooth_time(self):
+        return 1.0
+
+    def get_temp(self, eventtime):
+        return (25.0, self.target_temp)
+
+    def set_inv_smooth_time(self, value):
+        pass
+
+    def get_control(self):
+        return self.control
+
+    def set_control(self, control, keep_target=True):
+        old = self.control
+        self.control = control
+        if not keep_target:
+            self.target_temp = 0.0
+        return old
+
+    # Use the real lookup_control so ControlDualLoopPID is constructed.
+    lookup_control = heaters.Heater.lookup_control
+
+
+def _make_dual_loop_setup():
+    profile = _dual_loop_profile()
+    heater = _FakeDualLoopHeater()
+    heater.control = heaters.ControlDualLoopPID(profile, heater)
+    pmgr = _make_pmgr(heater)
+    pmgr.profiles = {"default": profile}
+    return heater, pmgr
+
+
+def test_set_values_dual_loop_preserves_inner_loop():
+    """SET_VALUES on a dual_loop_pid heater must not crash and must keep
+    the inner-loop gains when they are not supplied on the command line."""
+    heater, pmgr = _make_dual_loop_setup()
+
+    gcmd = _gcmd(
+        heater,
+        {
+            "SET_VALUES": "default",
+            "TARGET": "70",
+            "KP": "50",
+            "KI": "0.5",
+            "KD": "1300",
+        },
+    )
+
+    pmgr.set_values("default", gcmd, True)
+
+    control = heater.get_control()
+    assert isinstance(control, heaters.ControlDualLoopPID)
+    # Outer loop gains updated from the command...
+    assert control.primary_pid.Kp == 50.0 / PID_PARAM_BASE
+    # ...inner loop gains preserved from the previous profile.
+    assert control.secondary_pid.Kp == 60.499 / PID_PARAM_BASE
+    assert pmgr.profiles["default"]["inner_pid_kp"] == 60.499
+    assert pmgr.profiles["default"]["inner_pid_ki"] == 2.425
+    assert pmgr.profiles["default"]["inner_pid_kd"] == 377.360
+
+
+def test_set_values_dual_loop_accepts_inner_params():
+    """SET_VALUES accepts INNER_KP/INNER_KI/INNER_KD for the inner loop."""
+    heater, pmgr = _make_dual_loop_setup()
+
+    gcmd = _gcmd(
+        heater,
+        {
+            "SET_VALUES": "default",
+            "TARGET": "70",
+            "KP": "50",
+            "KI": "0.5",
+            "KD": "1300",
+            "INNER_KP": "70",
+            "INNER_KI": "3",
+            "INNER_KD": "400",
+        },
+    )
+
+    pmgr.set_values("default", gcmd, True)
+
+    control = heater.get_control()
+    assert control.secondary_pid.Kp == 70.0 / PID_PARAM_BASE
+    assert control.secondary_pid.Ki == 3.0 / PID_PARAM_BASE
+    assert control.secondary_pid.Kd == 400.0 / PID_PARAM_BASE
+    assert pmgr.profiles["default"]["inner_pid_kp"] == 70.0
+
+
+def test_get_values_dual_loop_reports_inner():
+    """GET_VALUES reports the inner-loop gains for a dual_loop_pid heater."""
+    heater, pmgr = _make_dual_loop_setup()
+
+    gcmd = _gcmd(heater, {"GET_VALUES": "default"})
+    pmgr.get_values("default", gcmd, True)
+
+    output = "\n".join(heater.gcode.messages)
+    assert "inner_pid_Kp=60.499" in output
+    assert "inner_pid_Ki=2.425" in output
+    assert "inner_pid_Kd=377.360" in output
+
+
+def test_load_high_verbose_dual_loop_reports_inner():
+    """LOAD ... VERBOSE=high reports the inner-loop gains."""
+    heater, pmgr = _make_dual_loop_setup()
+
+    gcmd = _gcmd(
+        heater,
+        {"LOAD": "default", "VERBOSE": "high", "LOAD_CLEAN": "1"},
+    )
+    pmgr.load_profile("default", gcmd, True)
+
+    output = "\n".join(heater.gcode.messages)
+    assert "inner_pid_Kp=60.499" in output
+    assert "inner_pid_Ki=2.425" in output
+    assert "inner_pid_Kd=377.360" in output

--- a/test/test_pid_profile.py
+++ b/test/test_pid_profile.py
@@ -1,0 +1,73 @@
+import pathlib
+import typing
+
+from klippy_testing import PrinterShim
+
+import klippy.extras.heaters as heaters
+
+
+class _FakeControl:
+    def __init__(self, profile):
+        self._profile = profile
+
+    def get_profile(self):
+        return self._profile
+
+
+class _FakeHeater:
+    """Minimal stand-in for a Heater exposing what save_profile() touches."""
+
+    def __init__(self, configfile, gcode, control):
+        self.short_name = "heater_bed"
+        self.configfile = configfile
+        self.gcode = gcode
+        self._control = control
+
+    def get_control(self):
+        return self._control
+
+
+def _make_pmgr(heater):
+    pmgr = heaters.Heater.ProfileManager.__new__(heaters.Heater.ProfileManager)
+    pmgr.outer_instance = heater
+    pmgr.profiles = {}
+    return pmgr
+
+
+def test_save_profile_persists_inner_pid_values(
+    config_root: typing.Annotated[pathlib.Path, "test_configs/autosave"],
+):
+    start_args = {"config_file": str(config_root / "printer.cfg")}
+    with PrinterShim(start_args) as printer:
+        pconfig = printer.lookup_object("configfile")
+        # read_main_config() initializes the autosave fileconfig that
+        # configfile.set() writes into.
+        printer.load_config()
+
+        profile = {
+            "pid_target": 70.0,
+            "pid_tolerance": 0.02,
+            "control": "dual_loop_pid",
+            "smooth_time": None,
+            "pid_kp": 42.894,
+            "pid_ki": 0.376,
+            "pid_kd": 1224.094,
+            "inner_pid_kp": 60.499,
+            "inner_pid_ki": 2.425,
+            "inner_pid_kd": 377.360,
+            "name": "default",
+        }
+        heater = _FakeHeater(
+            pconfig, printer.lookup_object("gcode"), _FakeControl(profile)
+        )
+        pmgr = _make_pmgr(heater)
+
+        pmgr.save_profile(profile_name="default", verbose=False)
+
+        pending = pconfig.status_save_pending["heater_bed"]
+        # The recalibrated outer-loop values are saved...
+        assert pending["pid_kp"] == "42.894"
+        # ...and the inner-loop values must be saved too.
+        assert pending["inner_pid_kp"] == "60.499"
+        assert pending["inner_pid_ki"] == "2.425"
+        assert pending["inner_pid_kd"] == "377.360"


### PR DESCRIPTION
**fix: Rename dual loop inner target option**
Renames the inner-loop target config key from `inner_max_temp` to `inner_target_temp`, since the value is a setpoint the inner sensor tracks, not a ceiling. The old name stays as a deprecated alias so existing configs keep loading while nudging users to the clearer name.

**fix: Warn about inner loop oscillation**
Rewrites the secondary-loop autotune message to say the inner sensor temperature will swing above and below the target during calibration, so users don't mistake normal tuning behavior for a fault. The target temperature is now included in the message so the log line stands on its own.

**fix: Report the actual cooldown target**
The primary-loop calibration log printed the requested tuning target during the cooldown phase instead of the temperature it was actually cooling to. Now it reports the real cooldown temperature, matching what's passed to `set_temperature()` so the logs aren't misleading.

**fix: Prevent dual loop PID windup**
In dual-loop control the final PWM is the lower of the two loops' outputs, so the loop that "lost" would otherwise keep integrating error for power that was never applied. This restores each loop's integrator whenever the applied PWM falls below that loop's requested output, preventing windup; the change is scoped to `ControlDualLoopPID` so the shared `ControlPID` is untouched.

**fix: Save dual loop inner PID values on SAVE_CONFIG**
`PID_CALIBRATE` computes both outer and inner gains, but `SAVE_CONFIG` only wrote the outer `pid_kp/ki/kd` back, so the inner gains silently reverted to the stale config values after a restart. `save_profile` only iterated `PID_PROFILE_OPTIONS` (which has no inner entries) even though the load path reads them; the fix mirrors that load logic on save so inner gains persist too.

**fix: make PID_PROFILE commands dual-loop aware**
`PID_PROFILE SET_VALUES` crashed with a `KeyError` on dual-loop heaters because the rebuilt profile dropped the inner gains needed to construct the inner controller, and `GET_VALUES`/`LOAD VERBOSE=high` hid those gains entirely. Now `SET_VALUES` preserves the active inner gains and accepts `INNER_KP/INNER_KI/INNER_KD` overrides, the value reports include the inner loop, and missing inner values raise a clear error instead of a raw `KeyError`.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
