### PR TITLE
tmc5262: Add stepper driver support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5038,6 +5038,166 @@ sense_resistor:
 #   sensorless homing.
 ```
 
+### [tmc5262]
+
+Configure a TMC5262 stepper motor driver via SPI bus. To use this
+feature, define a config section with a "tmc5262" prefix followed by
+the name of the corresponding stepper config section (for example,
+"[tmc5262 stepper_x]").
+
+The TMC5262 is a 65V/4.25A RMS smart stepper driver with integrated
+MOSFETs and Integrated Current Sense (ICS) - no external sense resistor
+is required. It uses a reference resistor (RREF) between the REF pin
+and GND to set the current ranges (typ. 12kΩ ±1%). Communication is
+SPI only - this driver does not support UART.
+
+```
+[tmc5262 stepper_x]
+cs_pin:
+#   The pin corresponding to the TMC5262 chip select line. This pin
+#   will be set to low at the start of SPI messages and raised to high
+#   after the message completes. This parameter must be provided.
+#spi_speed:
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   See the "common SPI settings" section for a description of the
+#   above parameters.
+#chain_position:
+#chain_length:
+#   These parameters configure an SPI daisy chain. The two parameters
+#   define the stepper position in the chain and the total chain length.
+#   Position 1 corresponds to the stepper that connects to the MOSI signal.
+#   The default is to not use an SPI daisy chain.
+#interpolate: True
+#   If true, enable step interpolation (the driver will internally
+#   step at a rate of 256 micro-steps). The default is True.
+run_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   during stepper movement. This parameter must be provided.
+#hold_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is not moving. Setting a hold_current is not
+#   recommended (see TMC_Drivers.md for details). The default is to
+#   not reduce the current.
+#home_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   during homing procedures. The default is to not reduce the current.
+#current_change_dwell_time:
+#   The amount of time (in seconds) to wait after changing homing current.
+#   The default is 0.5 seconds.
+#rref: 12000
+#   The resistance (in ohms) of the external reference resistor between
+#   the REF pin and GND. The TMC5262 datasheet specifies 12kΩ ±1%.
+#   Valid range is 10000-14000. The default is 12000.
+#current_range:
+#current_range_scale:
+#   These set the DRV_CONF.CURRENT_RANGE (0-3, peak 1A/2A/3A/4A) and
+#   DRV_CONF.CURRENT_RANGE_SCALE (0-3, scale 25%/50%/75%/100%) bits.
+#   By default both are auto-selected to match the requested run_current.
+#   Per the datasheet, current_range_scale below 3 is only valid when
+#   current_range is 0 - this is enforced.
+#stealthchop_threshold: 0
+#   The velocity (in mm/s) below which the driver runs in StealthChop+
+#   mode. The default of 0 disables StealthChop+.
+#coolstep_threshold:
+#   The velocity (in mm/s) above which the CoolStep+ feature is enabled.
+#   If set, sensorless homing speed must be above this threshold. The
+#   default is to not enable CoolStep+.
+#high_velocity_threshold:
+#   The velocity (in mm/s) at which the driver internal "high velocity"
+#   threshold (THIGH) is set. Typically used to disable CoolStep+ at
+#   high speeds. The default is unset.
+#driver_MSLUT0: 2863314260
+#driver_MSLUT1: 1251300522
+#driver_MSLUT2: 608774441
+#driver_MSLUT3: 269500962
+#driver_MSLUT4: 4227858431
+#driver_MSLUT5: 3048961917
+#driver_MSLUT6: 1227445590
+#driver_MSLUT7: 4211234
+#driver_W0: 2
+#driver_W1: 1
+#driver_W2: 1
+#driver_W3: 1
+#driver_X1: 128
+#driver_X2: 255
+#driver_X3: 255
+#driver_START_SIN: 0
+#driver_START_SIN90: 247
+#driver_OFFSET_SIN90: 0
+#   These fields control the Microstep Table registers directly. See the
+#   tmc2240 entry above for tuning notes - the wave-table format is the
+#   same on TMC5262.
+#driver_STEP_DIR: True
+#   Selects the external step/dir interface (GCONF.step_dir). Must be
+#   true to use the chip with Klipper's stepper driver - the default is
+#   True.
+#driver_MULTISTEP_FILT: True
+#driver_IHOLDDELAY: 7
+#driver_IRUNDELAY: 4
+#driver_TPOWERDOWN: 10
+#driver_TBL: 2
+#driver_TOFF: 3
+#driver_HEND: 2
+#driver_HSTRT: 5
+#driver_FD3: 0
+#driver_TPFD: 4
+#driver_CHM: 0
+#driver_PWM_FREQ: 0
+#driver_FREEWHEEL: 0
+#driver_SD_ON_MEAS_LO: 14
+#driver_SD_ON_MEAS_HI: 15
+#   These set PWMCONF thresholds that control when the Integrated Current
+#   Sense (ICS) samples each motor coil within the chopper cycle. The
+#   defaults (14/15) come from datasheet Table 8 (p.75) for PWM_FREQ=0
+#   (19.5 kHz). If you change driver_PWM_FREQ, also adjust these per
+#   Table 8 - leaving them at 0 silently disables ICS sampling and breaks
+#   StealthChop+ / StallGuard+ regulation.
+#driver_SLOPE_CONTROL: 3
+#   Controls the slew rate of the gate driver output (DRV_CONF.SLOPE_CONTROL).
+#   0=100V/μs, 1=200V/μs, 2=400V/μs, 3=800V/μs (chip default and Kalico
+#   default). Lower values reduce EMI at the cost of higher driver heat.
+#driver_SGT: 0
+#driver_SEMIN: 0
+#driver_SEUP: 0
+#driver_SEMAX: 0
+#driver_SEDN: 0
+#driver_SEIMIN: 0
+#driver_SFILT: 0
+#driver_CUR_P: 64
+#driver_CUR_I: 10
+#driver_ANGLE_P: 50
+#driver_ANGLE_I: 20
+#driver_CUR_PI_LIMIT: 4095
+#driver_ANGLE_PI_LIMIT: 256
+#driver_ANGLE_LOWER_I_LIMIT: 256
+#   StealthChop+ PI regulator tuning. The TMC5262 replaces TMC2240's
+#   StealthChop2 (with driver_PWM_GRAD / OFS / REG / LIM) by two PI
+#   regulators - one for current amplitude (CUR_P / CUR_I) and one for
+#   electrical angle (ANGLE_P / ANGLE_I), each with a clip limit. The
+#   defaults here match the chip's reset values, which the datasheet
+#   recommends as starting points ("Keep this default value, unless...").
+#   See datasheet pp 33-40 for the tuning guide.
+#   Set the given register during the configuration of the TMC5262
+#   chip. This may be used to set custom motor parameters. The defaults
+#   for each parameter are next to the parameter name in the above list.
+#diag0_pin:
+#diag1_pin:
+#   The micro-controller pin attached to one of the DO0 / DO1 pins of
+#   the TMC5262. Only a single diag pin should be specified. The pin is
+#   "active low" by default (chip default DO0/DO1 polarity) and is thus
+#   normally prefaced with "^!". Setting this creates a
+#   "tmc5262_stepper_x:virtual_endstop" virtual pin which may be used
+#   as the stepper's endstop_pin to enable sensorless homing. Be sure
+#   to also set driver_SGT to an appropriate sensitivity value. Unlike
+#   TMC2130/5160/2240, the TMC5262 routes the stall signal through
+#   DO_CONF.do0_stall / do1_stall (datasheet pg 140), so the driver
+#   reconfigures DO_CONF at homing start and restores it at homing end.
+#   The default is to not enable sensorless homing.
+```
+
 ## Run-time stepper motor current configuration
 
 ### [ad5206]

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -158,6 +158,12 @@ class TMCErrorCheck:
         # Setup for temperature query
         self.adc_temp = None
         self.adc_temp_reg = self.fields.lookup_register("adc_temp")
+        # Optional driver-specific ADC->°C converter. The default formula
+        # (`(v - 2038) / 7.7`) below matches the TMC2240's 13-bit
+        # ADC_TEMP. Drivers with a different ADC width or scaling can
+        # set a `temp_from_adc(adc_value) -> celsius` callable on their
+        # mcu_tmc instance to override.
+        self.temp_from_adc = getattr(mcu_tmc, "temp_from_adc", None)
         if self.adc_temp_reg is not None:
             pheaters = self.printer.load_object(config, "heaters")
             pheaters.register_monitor(config)
@@ -255,7 +261,10 @@ class TMCErrorCheck:
             return {"drv_status": None, "temperature": None}
         temp = None
         if self.adc_temp is not None:
-            temp = round((self.adc_temp - 2038) / 7.7, 2)
+            if self.temp_from_adc is not None:
+                temp = round(self.temp_from_adc(self.adc_temp), 2)
+            else:
+                temp = round((self.adc_temp - 2038) / 7.7, 2)
         last_value, reg_name = self.drv_status_reg_info[:2]
         if last_value != self.last_drv_status:
             self.last_drv_status = last_value

--- a/klippy/extras/tmc5262.py
+++ b/klippy/extras/tmc5262.py
@@ -1,0 +1,653 @@
+# TMC5262 configuration
+#
+# Copyright (C) 2026  Kalico Contributors
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import math
+
+from . import tmc, tmc2130
+
+# Internal 16MHz oscillator divided down to 1MHz fCLK (CLOCK_DIVIDER=15)
+TMC_FREQUENCY = 16000000.0
+
+
+# ADC conversion formulas (datasheet pg 134, 9-bit ADC)
+def _adc_to_celsius(adc_value):
+    return 1.042 * adc_value - 264.6
+
+
+def _adc_to_volts(adc_value):
+    return adc_value * 0.1409
+
+
+######################################################################
+# Register addresses (TMC5262 datasheet pp 121..136)
+######################################################################
+
+Registers = {
+    # General configuration
+    "GCONF": 0x00,
+    "GSTAT": 0x01,
+    "DO_CONF": 0x02,
+    "DO_SCOPE_CONF": 0x03,
+    "IOIN": 0x04,
+    "X_COMPARE": 0x05,
+    "X_COMPARE_REPEAT": 0x06,
+    "DRV_CONF": 0x0A,
+    "PLL": 0x0B,
+    # Velocity dependent configuration
+    "IHOLD_IRUN": 0x10,
+    "TPOWERDOWN": 0x11,
+    "TSTEP": 0x12,
+    "TPWMTHRS": 0x13,
+    "TCOOLTHRS": 0x14,
+    "THIGH": 0x15,
+    "TSGP_LOW_VEL_THRS": 0x16,
+    "T_RCOIL_MEAS": 0x17,
+    "TUDCSTEP": 0x18,
+    "UDC_CONF": 0x19,
+    "STEPS_LOST": 0x1A,
+    # StealthChop+ PI regulator tuning + readbacks (datasheet pp 33-40)
+    "CURRENT_PI_REG": 0x40,
+    "ANGLE_PI_REG": 0x41,
+    "CUR_ANGLE_LIMIT": 0x42,
+    "ANGLE_LOWER_LIMIT": 0x43,
+    "CUR_ANGLE_MEAS": 0x44,
+    "PI_RESULTS": 0x45,
+    # ADC
+    "ADC_VSUPPLY_TEMP": 0x58,
+    "ADC_I": 0x59,
+    "OTW_OV_VTH": 0x5A,
+    # Motor driver / wave table
+    "MSLUT0": 0x60,
+    "MSLUT1": 0x61,
+    "MSLUT2": 0x62,
+    "MSLUT3": 0x63,
+    "MSLUT4": 0x64,
+    "MSLUT5": 0x65,
+    "MSLUT6": 0x66,
+    "MSLUT7": 0x67,
+    "MSLUTSEL": 0x68,
+    "MSLUTSTART": 0x69,
+    "MSCNT": 0x6A,
+    "MSCURACT": 0x6B,
+    "CHOPCONF": 0x6C,
+    "COOLCONF": 0x6D,
+    "DRV_STATUS": 0x6F,
+    "PWMCONF": 0x70,
+}
+
+ReadRegisters = [
+    "GCONF",
+    "GSTAT",
+    "IOIN",
+    "DRV_CONF",
+    "PLL",
+    "IHOLD_IRUN",
+    "TPOWERDOWN",
+    "TSTEP",
+    "TPWMTHRS",
+    "TCOOLTHRS",
+    "THIGH",
+    "ADC_VSUPPLY_TEMP",
+    "ADC_I",
+    "CURRENT_PI_REG",
+    "ANGLE_PI_REG",
+    "CUR_ANGLE_LIMIT",
+    "ANGLE_LOWER_LIMIT",
+    "CUR_ANGLE_MEAS",
+    "PI_RESULTS",
+    "OTW_OV_VTH",
+    "MSCNT",
+    "MSCURACT",
+    "CHOPCONF",
+    "COOLCONF",
+    "DRV_STATUS",
+    "PWMCONF",
+]
+
+
+######################################################################
+# Register field maps
+######################################################################
+
+Fields = {}
+
+# GCONF (0x00) - p.137
+# Bit 1 is "en_stealthchop" in the datasheet; aliased to "en_pwm_mode"
+# for tmc.TMCStealthchopHelper compatibility.
+Fields["GCONF"] = {
+    "fast_standstill": 0x01 << 0,
+    "en_pwm_mode": 0x01 << 1,
+    "multistep_filt": 0x01 << 2,
+    "shaft": 0x01 << 3,
+    "small_hysteresis": 0x01 << 4,
+    "stop_enable": 0x01 << 5,
+    "direct_mode": 0x01 << 6,
+    "length_steppulse": 0x0F << 8,
+    "ov_nn": 0x01 << 12,
+    "step_dir": 0x01 << 31,
+}
+
+# GSTAT (0x01) - p.139, write-1-to-clear
+Fields["GSTAT"] = {
+    "reset": 0x01 << 0,
+    "drv_err": 0x01 << 1,
+    "uv_cp": 0x01 << 2,
+    "register_reset": 0x01 << 3,
+    "vm_uvlo": 0x01 << 4,
+    "vccio_uv": 0x01 << 5,
+}
+
+# DO_CONF (0x02) - p.140 - DIAG output mux
+Fields["DO_CONF"] = {
+    "do0_error": 0x01 << 0,
+    "do0_otpw": 0x01 << 1,
+    "do0_stall": 0x01 << 2,
+    "do0_index": 0x01 << 3,
+    "do0_step": 0x01 << 4,
+    "do0_dir": 0x01 << 5,
+    "do0_xcomp": 0x01 << 6,
+    "do0_ov": 0x01 << 7,
+    "do0_udcstep": 0x01 << 8,
+    "do0_ev_stop_ref": 0x01 << 9,
+    "do0_ev_stop_sg": 0x01 << 10,
+    "do0_ev_pos_reached": 0x01 << 11,
+    "do0_ev_n_deviation": 0x01 << 12,
+    "do1_error": 0x01 << 13,
+    "do1_otpw": 0x01 << 14,
+    "do1_stall": 0x01 << 15,
+    "do1_index": 0x01 << 16,
+    "do1_step": 0x01 << 17,
+    "do1_dir": 0x01 << 18,
+    "do1_xcomp": 0x01 << 19,
+    "do1_ov": 0x01 << 20,
+    "do1_udcstep": 0x01 << 21,
+    "do1_ev_stop_ref": 0x01 << 22,
+    "do1_ev_stop_sg": 0x01 << 23,
+    "do1_ev_pos_reached": 0x01 << 24,
+    "do1_ev_n_deviation": 0x01 << 25,
+    "do0_npp_pp": 0x01 << 28,
+    "do0_invpp": 0x01 << 29,
+    "do1_npp_pp": 0x01 << 30,
+    "do1_invpp": 0x01 << 31,
+}
+
+# IOIN (0x04) - p.144 - read-only inputs / silicon revision
+Fields["IOIN"] = {
+    "refl": 0x01 << 0,
+    "refr": 0x01 << 1,
+    "encb": 0x01 << 2,
+    "enca": 0x01 << 3,
+    "drv_enn": 0x01 << 4,
+    "encn": 0x01 << 5,
+    "ext_res_det": 0x01 << 13,
+    "ext_clk": 0x01 << 14,
+    "silicon_rv": 0x07 << 16,
+}
+
+# DRV_CONF (0x0A) - p.148 - integrated current sense (ICS) range select
+Fields["DRV_CONF"] = {
+    "current_range": 0x03 << 0,
+    "current_range_scale": 0x03 << 2,
+    "slope_control": 0x03 << 4,
+}
+
+# PLL (0x0B) - p.149 - mandatory clock setup. ext_not_int=0, clk_sys_sel=1,
+# clk_fsm_ena=1, CLOCK_DIVIDER=15 -> internal 16MHz osc, 1MHz fCLK.
+Fields["PLL"] = {
+    "commit": 0x01 << 0,
+    "ext_not_int": 0x01 << 1,
+    "clk_sys_sel": 0x01 << 2,
+    "clk_fsm_ena": 0x01 << 3,
+    "clock_divider": 0x1F << 5,
+    "clk_1m0_tmo": 0x01 << 11,
+    "clk_loss": 0x01 << 13,
+    "clk_is_stuck": 0x01 << 14,
+}
+
+# IHOLD_IRUN (0x10) - p.151 - 8-bit IRUN/IHOLD (TMC5262 widened from 5)
+Fields["IHOLD_IRUN"] = {
+    "ihold": 0xFF << 0,
+    "irun": 0xFF << 8,
+    "iholddelay": 0xFF << 16,
+    "irundelay": 0x0F << 24,
+}
+
+Fields["TPOWERDOWN"] = {"tpowerdown": 0xFF << 0}
+Fields["TSTEP"] = {"tstep": 0xFFFFF << 0}
+Fields["TPWMTHRS"] = {"tpwmthrs": 0xFFFFF << 0}
+Fields["TCOOLTHRS"] = {"tcoolthrs": 0xFFFFF << 0}
+Fields["THIGH"] = {"thigh": 0xFFFFF << 0}
+Fields["TSGP_LOW_VEL_THRS"] = {"tsgp_low_vel_thrs": 0xFFFFF << 0}
+Fields["T_RCOIL_MEAS"] = {"t_rcoil_meas": 0xFFFFF << 0}
+
+# ADC registers - p.134 (9-bit Vsupply/temperature, 12-bit coil currents)
+#   T(°C) = 1.042 * v - 264.6
+#   V_supply(V) = v * 0.1409
+Fields["ADC_VSUPPLY_TEMP"] = {
+    "adc_vsupply": 0x1FF << 0,
+    "adc_temp": 0x1FF << 16,
+}
+Fields["ADC_I"] = {
+    "adc_i_a": 0xFFF << 0,
+    "adc_i_b": 0xFFF << 16,
+}
+# StealthChop+ PI regulator config and state (datasheet pp 193-198).
+# Defaults match the chip's reset values.
+Fields["CURRENT_PI_REG"] = {
+    "cur_p": 0xFFF << 0,
+    "cur_i": 0x3FF << 16,
+}
+Fields["ANGLE_PI_REG"] = {
+    "angle_p": 0xFFF << 0,
+    "angle_i": 0x3FF << 16,
+}
+Fields["CUR_ANGLE_LIMIT"] = {
+    "angle_pi_limit": 0x3FF << 0,
+    "angle_pi_int_pos_clip": 0x01 << 12,
+    "angle_pi_int_neg_clip": 0x01 << 13,
+    "angle_pi_pos_clip": 0x01 << 14,
+    "angle_pi_neg_clip": 0x01 << 15,
+    "cur_pi_limit": 0xFFF << 16,
+    "cur_pi_int_pos_clip": 0x01 << 28,
+    "cur_pi_int_neg_clip": 0x01 << 29,
+    "cur_pi_pos_clip": 0x01 << 30,
+    "cur_pi_neg_clip": 0x01 << 31,
+}
+Fields["ANGLE_LOWER_LIMIT"] = {
+    "angle_lower_i_limit": 0x3FF << 0,
+    "angle_error": 0x3FF << 16,
+}
+# CUR_ANGLE_MEAS (0x44) - p.197 - StealthChop+ readbacks. Both read 0
+# in SpreadCycle mode.
+Fields["CUR_ANGLE_MEAS"] = {
+    "ampl_meas": 0xFFF << 0,
+    "angle_meas": 0x3FF << 16,
+}
+Fields["PI_RESULTS"] = {
+    "pwm_calc": 0x1FFF << 0,
+    "angle_corr_calc": 0x3FF << 16,
+}
+Fields["OTW_OV_VTH"] = {
+    "overvoltage_vth": 0x1FF << 0,
+    "overtempprewarning_vth": 0x1FF << 16,
+}
+
+# Wave table - format identical to TMC2240/TMC5160
+Fields["MSLUT0"] = {"mslut0": 0xFFFFFFFF}
+Fields["MSLUT1"] = {"mslut1": 0xFFFFFFFF}
+Fields["MSLUT2"] = {"mslut2": 0xFFFFFFFF}
+Fields["MSLUT3"] = {"mslut3": 0xFFFFFFFF}
+Fields["MSLUT4"] = {"mslut4": 0xFFFFFFFF}
+Fields["MSLUT5"] = {"mslut5": 0xFFFFFFFF}
+Fields["MSLUT6"] = {"mslut6": 0xFFFFFFFF}
+Fields["MSLUT7"] = {"mslut7": 0xFFFFFFFF}
+Fields["MSLUTSEL"] = {
+    "x3": 0xFF << 24,
+    "x2": 0xFF << 16,
+    "x1": 0xFF << 8,
+    "w3": 0x03 << 6,
+    "w2": 0x03 << 4,
+    "w1": 0x03 << 2,
+    "w0": 0x03 << 0,
+}
+Fields["MSLUTSTART"] = {
+    "start_sin": 0xFF << 0,
+    "start_sin90": 0xFF << 16,
+    "offset_sin90": 0xFF << 24,
+}
+
+Fields["MSCNT"] = {"mscnt": 0x3FF << 0}
+
+# MSCURACT - coil order is *swapped* relative to TMC2240/TMC5160:
+# TMC5262 puts CUR_B at [8:0] and CUR_A at [24:16].
+Fields["MSCURACT"] = {"cur_b": 0x1FF << 0, "cur_a": 0x1FF << 16}
+
+# CHOPCONF (0x6C) - p.136 - layout differs from TMC2240:
+#   * tbl is contiguous bits [16:15]
+#   * hend is contiguous bits [10:7]
+#   * vhighfs / vhighchm / diss2g / diss2vs are gone
+Fields["CHOPCONF"] = {
+    "toff": 0x0F << 0,
+    "hstrt": 0x07 << 4,
+    "hend": 0x0F << 7,
+    "fd3": 0x01 << 11,
+    "disfdcc": 0x01 << 12,
+    "chm": 0x01 << 14,
+    "tbl": 0x03 << 15,
+    "tpfd": 0x0F << 20,
+    "mres": 0x0F << 24,
+    "intpol": 0x01 << 28,
+    "dedge": 0x01 << 29,
+}
+
+# COOLCONF (0x6D) - p.136 - sedn widened to 3 bits, +thigh_sg_off
+Fields["COOLCONF"] = {
+    "semin": 0x0F << 0,
+    "seup": 0x03 << 5,
+    "semax": 0x0F << 8,
+    "sedn": 0x07 << 12,
+    "seimin": 0x01 << 15,
+    "sgt": 0x7F << 16,
+    "thigh_sg_off": 0x01 << 23,
+    "sfilt": 0x01 << 24,
+}
+
+# DRV_STATUS (0x6F) - p.136 - 10-bit sg_result, 8-bit cs_actual,
+# +ov / +seq_stopped, no fsactive
+Fields["DRV_STATUS"] = {
+    "sg_result": 0x3FF << 0,
+    "seq_stopped": 0x01 << 10,
+    "ov": 0x01 << 11,
+    "s2vsa": 0x01 << 12,
+    "s2vsb": 0x01 << 13,
+    "stealth": 0x01 << 14,
+    "cs_actual": 0xFF << 16,
+    "stallguard": 0x01 << 24,
+    "ot": 0x01 << 25,
+    "otpw": 0x01 << 26,
+    "s2ga": 0x01 << 27,
+    "s2gb": 0x01 << 28,
+    "ola": 0x01 << 29,
+    "olb": 0x01 << 30,
+    "stst": 0x01 << 31,
+}
+
+# PWMCONF (0x70) - p.136 - simplified vs TMC2240
+Fields["PWMCONF"] = {
+    "pwm_freq": 0x0F << 0,
+    "freewheel": 0x03 << 4,
+    "ol_thrsh": 0x03 << 6,
+    "sd_on_meas_lo": 0x0F << 12,
+    "sd_on_meas_hi": 0x0F << 16,
+}
+
+
+SignedFields = [
+    "cur_a",
+    "cur_b",
+    "sgt",
+    "offset_sin90",
+    "adc_i_a",
+    "adc_i_b",
+    "angle_error",
+    "angle_corr_calc",
+]
+
+
+FieldFormatters = dict(tmc2130.FieldFormatters)
+FieldFormatters.update(
+    {
+        "ov": lambda v: "1(Overvoltage!)" if v else "",
+        "s2vsa": lambda v: "1(ShortToSupply_A!)" if v else "",
+        "s2vsb": lambda v: "1(ShortToSupply_B!)" if v else "",
+        "vm_uvlo": lambda v: "1(VMUndervoltage!)" if v else "",
+        "vccio_uv": lambda v: "1(VCCIOUndervoltage!)" if v else "",
+        "register_reset": lambda v: "1(RegisterReset!)" if v else "",
+        "ext_clk": lambda v: "1(ExternalClock)" if v else "0(Internal16MHz)",
+        "ext_res_det": lambda v: "1" if v else "0(MissingRREF!)",
+        "drv_enn": lambda v: "1(Disabled)" if v else "0(Enabled)",
+        "silicon_rv": lambda v: "%d" % v,
+        "clk_loss": lambda v: "1(ClockLoss!)" if v else "",
+        "clk_is_stuck": lambda v: "1(ClockStuck!)" if v else "",
+        "clk_1m0_tmo": lambda v: "1(ClockTimeout!)" if v else "",
+        "adc_temp": (lambda v: "0x%03x(%.1fC)" % (v, _adc_to_celsius(v))),
+        "adc_vsupply": (lambda v: "0x%03x(%.3fV)" % (v, _adc_to_volts(v))),
+        # ADC_I_*/AMPL_MEAS read 0 in SpreadCycle (datasheet p.75)
+        "adc_i_a": (lambda v: "%d(SpreadCycle?)" % v if v == 0 else "%d" % v),
+        "adc_i_b": (lambda v: "%d(SpreadCycle?)" % v if v == 0 else "%d" % v),
+        "ampl_meas": (lambda v: "%d(SpreadCycle?)" % v if v == 0 else "%d" % v),
+        "angle_meas": (lambda v: "%d(%.1fdeg)" % (v, v * 360.0 / 1024.0)),
+        "overvoltage_vth": (lambda v: "0x%03x(%.3fV)" % (v, _adc_to_volts(v))),
+        "overtempprewarning_vth": (
+            lambda v: "0x%03x(%.1fC)" % (v, _adc_to_celsius(v))
+        ),
+    }
+)
+
+
+######################################################################
+# TMC5262 current helper (Integrated Current Sense, no GLOBALSCALER)
+######################################################################
+# Datasheet Table 21 (p.74):
+#   I_FS_peak = 18 * (CR+1) * (CRS+1) / (4 * RREF_kohm)         [A peak]
+#   I_FS_RMS  = I_FS_peak / sqrt(2)                              [A RMS]
+#   I_RMS(IRUN) = I_FS_RMS * IRUN / 250
+# CRS != 3 is only meaningful when CR == 0 per datasheet.
+
+DEFAULT_RREF = 12000.0
+KIFS_BASE = 18.0  # peak full-scale * Rref_kohm at CR=0, CRS=0
+
+
+class TMC5262CurrentHelper(tmc.BaseTMCCurrentHelper):
+    def __init__(self, config, mcu_tmc):
+        self.Rref = config.getfloat(
+            "rref", DEFAULT_RREF, minval=10000.0, maxval=14000.0
+        )
+        max_current = self._ifs_rms_for(3, 3)
+        super().__init__(config, mcu_tmc, max_current, has_sense_resistor=False)
+
+        cr, crs = self._calc_ranges(self.req_run_current)
+        self.current_range = config.getint(
+            "current_range", cr, minval=0, maxval=3
+        )
+        self.current_range_scale = config.getint(
+            "current_range_scale", crs, minval=0, maxval=3
+        )
+        if self.current_range != 0 and self.current_range_scale != 3:
+            raise config.error(
+                "tmc5262 %s: current_range_scale<3 is only valid with "
+                "current_range=0 per datasheet" % (self.name,)
+            )
+        self.fields.set_field("current_range", self.current_range)
+        self.fields.set_field("current_range_scale", self.current_range_scale)
+
+        irun, ihold = self._calc_current(
+            self.req_run_current, self.req_hold_current
+        )
+        self.fields.set_field("irun", irun)
+        self.fields.set_field("ihold", ihold)
+
+    def _ifs_rms_for(self, cr, crs):
+        i_peak = KIFS_BASE * (cr + 1) * (crs + 1) / (4.0 * self.Rref / 1000.0)
+        return i_peak / math.sqrt(2.0)
+
+    def _ifs_rms(self):
+        cr = self.fields.get_field("current_range")
+        crs = self.fields.get_field("current_range_scale")
+        return self._ifs_rms_for(cr, crs)
+
+    def _calc_ranges(self, current):
+        # Smallest CR that fits at CRS=3; fall back to CRS<3 only at CR=0.
+        for cr in range(4):
+            if current <= self._ifs_rms_for(cr, 3):
+                if cr == 0:
+                    for crs in range(4):
+                        if current <= self._ifs_rms_for(0, crs):
+                            return 0, crs
+                return cr, 3
+        return 3, 3
+
+    def _calc_current(self, run_current, hold_current):
+        ifs = self._ifs_rms()
+        # IRUN 251..255 are clipped to 250 internally.
+        irun = max(1, min(250, int(round(run_current / ifs * 250.0))))
+        if run_current > 0.0:
+            ihold = int(round(hold_current / run_current * irun))
+        else:
+            ihold = 0
+        ihold = max(0, min(irun, ihold))
+        return irun, ihold
+
+    def _calc_current_from_field(self, field_name):
+        return self._ifs_rms() * self.fields.get_field(field_name) / 250.0
+
+    def get_current(self):
+        return (
+            self._calc_current_from_field("irun"),
+            self._calc_current_from_field("ihold"),
+            self.req_hold_current,
+            self._ifs_rms(),
+            self.req_home_current,
+        )
+
+    def apply_current(self, print_time):
+        irun, ihold = self._calc_current(
+            self.actual_current, self.req_hold_current
+        )
+        self.fields.set_field("ihold", ihold)
+        val = self.fields.set_field("irun", irun)
+        self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
+
+
+######################################################################
+# TMC5262 main object
+######################################################################
+
+
+class TMC5262:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
+        self.mcu_tmc = tmc2130.MCU_TMC_SPI(
+            config, Registers, self.fields, TMC_FREQUENCY
+        )
+        # tmc.TMCErrorCheck reads this via getattr to use the chip-specific
+        # 9-bit ADC formula instead of the default TMC2240 one.
+        self.mcu_tmc.temp_from_adc = _adc_to_celsius
+        # PLL must come up before any other register write the chip is
+        # meant to react to - register before TMCCommandHelper.
+        self.printer.register_event_handler(
+            "klippy:connect", self._handle_pll_init
+        )
+        # Sensorless homing: TMC5262 routes stall through DO_CONF.do0_stall
+        # / do1_stall (datasheet pg 140), unlike GCONF.diag*_stall on older
+        # chips. Prime do0_invpp / do1_invpp = 1 (chip-default active-low)
+        # so the homing handler's stall-bit writes don't clear them.
+        self.fields.set_field("do0_invpp", 1)
+        self.fields.set_field("do1_invpp", 1)
+        virtual_pin_helper = tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        if config.get("diag0_pin", None) is not None:
+            virtual_pin_helper.diag_pin = config.get("diag0_pin")
+            virtual_pin_helper.diag_pin_field = "do0_stall"
+        elif config.get("diag1_pin", None) is not None:
+            virtual_pin_helper.diag_pin = config.get("diag1_pin")
+            virtual_pin_helper.diag_pin_field = "do1_stall"
+        # Register commands
+        current_helper = TMC5262CurrentHelper(config, self.mcu_tmc)
+        cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
+        cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_status = cmdhelper.get_status
+        # Microstep wave table
+        tmc.TMCWaveTableHelper(config, self.mcu_tmc)
+        self.fields.set_config_field(config, "offset_sin90", 0)
+        # StealthChop / CoolStep velocity thresholds
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc)
+        tmc.TMCVcoolthrsHelper(config, self.mcu_tmc)
+        tmc.TMCVhighHelper(config, self.mcu_tmc)
+        # Allow other registers to be set from the config
+        set_config_field = self.fields.set_config_field
+        # PLL steady-state. _handle_pll_init runs the boot sequence; this
+        # makes cmd_INIT_TMC re-issue the same value and DUMP_TMC report it.
+        self.fields.set_field("clock_divider", 15)
+        self.fields.set_field("clk_sys_sel", 1)
+        self.fields.set_field("clk_fsm_ena", 1)
+        # GCONF: step_dir is required for use as an external step/dir
+        # driver. Bits not set here are written as 0 by INIT_TMC, including
+        # small_hysteresis (chip default is 1, ends up 0 - matches TMC2240).
+        set_config_field(config, "step_dir", True)
+        set_config_field(config, "multistep_filt", True)
+        # CHOPCONF
+        set_config_field(config, "toff", 3)
+        set_config_field(config, "hstrt", 5)
+        set_config_field(config, "hend", 2)
+        set_config_field(config, "fd3", 0)
+        set_config_field(config, "disfdcc", 0)
+        set_config_field(config, "chm", 0)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "tpfd", 4)
+        # COOLCONF
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
+        set_config_field(config, "sgt", 0)
+        set_config_field(config, "sfilt", 0)
+        # IHOLDIRUN
+        set_config_field(config, "iholddelay", 7)
+        set_config_field(config, "irundelay", 4)
+        # PWMCONF. SD_ON_MEAS_LO/HI control when the ICS samples coil
+        # currents within the chopper cycle - datasheet Table 8 (p.75)
+        # specifies values per PWM_FREQ. Defaults below match PWM_FREQ=0
+        # (19.5 kHz); change them if PWM_FREQ changes or ICS goes silent.
+        set_config_field(config, "pwm_freq", 0)
+        set_config_field(config, "freewheel", 0)
+        set_config_field(config, "sd_on_meas_lo", 14)
+        set_config_field(config, "sd_on_meas_hi", 15)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 10)
+        # DRV_CONF
+        set_config_field(config, "slope_control", 3)
+        # StealthChop+ PI regulators - chip reset values, exposed for tuning.
+        set_config_field(config, "cur_p", 64)
+        set_config_field(config, "cur_i", 10)
+        set_config_field(config, "angle_p", 50)
+        set_config_field(config, "angle_i", 20)
+        set_config_field(config, "cur_pi_limit", 0xFFF)
+        set_config_field(config, "angle_pi_limit", 256)
+        set_config_field(config, "angle_lower_i_limit", 256)
+
+    def _build_pll_value(self, commit, clk_fsm_ena, clear_flags=False):
+        # Built from raw bits so __init__'s steady-state cache stays intact.
+        val = (
+            (1 if commit else 0) << 0
+            | (0 << 1)  # ext_not_int = 0 (internal oscillator)
+            | (1 << 2)  # clk_sys_sel = 1 (use PLL)
+            | ((1 if clk_fsm_ena else 0) << 3)
+            | (15 << 5)  # CLOCK_DIVIDER = 15 -> 16MHz/16 = 1MHz fCLK
+        )
+        if clear_flags:
+            # write-1-to-clear clk_1m0_tmo / clk_loss / clk_is_stuck
+            val |= (1 << 11) | (1 << 13) | (1 << 14)
+        return val
+
+    def _handle_pll_init(self):
+        if self.mcu_tmc.mcu.non_critical_disconnected:
+            return
+        try:
+            # Stage 1: program PLL with commit=1, FSM still off. Datasheet
+            # p.149: chip enters reset state (except register space).
+            self.mcu_tmc.set_register(
+                "PLL", self._build_pll_value(commit=1, clk_fsm_ena=0)
+            )
+            # Wait for commit to self-clear (PLL locked). Cap at 20ms.
+            reactor = self.printer.get_reactor()
+            deadline = reactor.monotonic() + 0.020
+            while reactor.monotonic() < deadline:
+                reactor.pause(reactor.monotonic() + 0.001)
+                pll = self.mcu_tmc.get_register("PLL")
+                if not (pll & 0x01):
+                    break
+            # Stage 2: release reset, enable FSM, W1C clock-fault flags.
+            # Written twice with a settle - the flags re-assert during the
+            # PLL lock transient and a single write fails to clear them.
+            stage2 = self._build_pll_value(
+                commit=0, clk_fsm_ena=1, clear_flags=True
+            )
+            self.mcu_tmc.set_register("PLL", stage2)
+            reactor.pause(reactor.monotonic() + 0.005)
+            self.mcu_tmc.set_register("PLL", stage2)
+            # Stage 1 puts the chip in reset, which sets GSTAT.reset /
+            # register_reset / uv_cp. Clear so TMCErrorCheck doesn't trip.
+            self.mcu_tmc.set_register("GSTAT", 0x3F)
+        except self.printer.command_error as e:
+            logging.info("TMC5262 %s PLL init failed: %s", self.name, str(e))
+
+
+def load_config_prefix(config):
+    return TMC5262(config)

--- a/test/klippy/tmc5262.cfg
+++ b/test/klippy/tmc5262.cfg
@@ -1,0 +1,62 @@
+# Test config for the TMC5262 driver
+
+[stepper_x]
+step_pin: PC0
+dir_pin: PL0
+enable_pin: !PA7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB6
+position_endstop: 0
+position_max: 250
+
+[tmc5262 stepper_x]
+cs_pin: PG0
+run_current: 1.2
+hold_current: 0.5
+rref: 12000
+
+[stepper_x1]
+step_pin: PC3
+dir_pin: PL6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB7
+
+[tmc5262 stepper_x1]
+cs_pin: PG1
+run_current: 0.4
+rref: 12000
+current_range: 0
+current_range_scale: 1
+driver_TOFF: 4
+driver_HSTRT: 4
+driver_HEND: 1
+
+[stepper_y]
+step_pin: PC1
+dir_pin: PL1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB4
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PB5
+position_endstop: 0.5
+position_max: 200
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/tmc5262.test
+++ b/test/klippy/tmc5262.test
@@ -1,0 +1,31 @@
+# Tests for the TMC5262 driver
+CONFIG tmc5262.cfg
+DICTIONARY atmega2560.dict
+
+; Home and move to seed register state
+G28
+G90
+G1 F6000
+G1 X1
+G1 Y1
+G1 Z1
+
+; DUMP_TMC must work on both steppers (covers register dump path)
+DUMP_TMC STEPPER=stepper_x
+DUMP_TMC STEPPER=stepper_x1
+
+; Test re-init (writes every register again, including PLL)
+INIT_TMC STEPPER=stepper_x
+INIT_TMC STEPPER=stepper_x1
+
+; Current changes - exercise the IFS/IRUN math at multiple range buckets
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=1.0
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=2.0
+SET_TMC_CURRENT STEPPER=stepper_x1 CURRENT=0.3
+
+; Field writes - exercise CHOPCONF, COOLCONF and DRV_CONF paths
+SET_TMC_FIELD STEPPER=stepper_x FIELD=intpol VALUE=0
+SET_TMC_FIELD STEPPER=stepper_x FIELD=tbl VALUE=1
+SET_TMC_FIELD STEPPER=stepper_x FIELD=slope_control VALUE=2
+SET_TMC_FIELD STEPPER=stepper_x FIELD=sgt VALUE=5
+SET_TMC_FIELD STEPPER=stepper_x1 FIELD=current_range VALUE=1

--- a/test/test_tmc5262.py
+++ b/test/test_tmc5262.py
@@ -1,0 +1,156 @@
+"""Unit tests for the TMC5262 driver module.
+
+Static checks on the register/field map:
+  * Every Fields register has a known address
+  * Every ReadRegister is in Registers
+  * Field masks are contiguous and non-overlapping
+  * Round-trip through FieldHelper at maximum value
+  * Critical bit positions Kalico depends on (sensorless homing,
+    StealthChop+, ADC, etc.)
+
+Integration coverage (DUMP_TMC, INIT_TMC, SET_TMC_CURRENT) lives in
+test/klippy/tmc5262.test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from klippy.extras import tmc5262
+from klippy.extras.tmc import FieldHelper
+
+
+def _make_fields() -> FieldHelper:
+    return FieldHelper(tmc5262.Fields, tmc5262.SignedFields)
+
+
+def _ffs(mask: int) -> int:
+    return (mask & -mask).bit_length() - 1
+
+
+# ---------------------------------------------------------------------------
+# Static layout sanity
+# ---------------------------------------------------------------------------
+
+
+def test_every_field_register_has_an_address():
+    missing = [r for r in tmc5262.Fields if r not in tmc5262.Registers]
+    assert not missing, f"Fields without a register address: {missing}"
+
+
+def test_every_read_register_is_known():
+    missing = [r for r in tmc5262.ReadRegisters if r not in tmc5262.Registers]
+    assert not missing, f"ReadRegisters not in Registers: {missing}"
+
+
+@pytest.mark.parametrize("reg", sorted(tmc5262.Fields))
+def test_field_masks_are_contiguous_and_non_overlapping(reg):
+    seen = 0
+    for fname, mask in tmc5262.Fields[reg].items():
+        assert mask, f"{reg}.{fname} has empty mask"
+        shifted = mask >> _ffs(mask)
+        assert (shifted & (shifted + 1)) == 0, (
+            f"{reg}.{fname} mask 0x{mask:08x} is not contiguous"
+        )
+        assert (seen & mask) == 0, f"{reg}.{fname} overlaps another field"
+        seen |= mask
+
+
+def test_field_roundtrip_at_max_value():
+    fields = _make_fields()
+    for reg, fmap in tmc5262.Fields.items():
+        for fname, mask in fmap.items():
+            width = bin(mask).count("1")
+            maxv = (1 << width) - 1
+            fields.set_field(fname, maxv)
+            got = fields.get_field(fname)
+            if fname in fields.signed_fields:
+                assert got in (
+                    -1,
+                    maxv,
+                ), f"{reg}.{fname} signed roundtrip got {got}"
+            else:
+                assert got == maxv, f"{reg}.{fname} roundtrip got {got}"
+
+
+# ---------------------------------------------------------------------------
+# Critical bits the rest of Kalico depends on
+# ---------------------------------------------------------------------------
+
+
+def test_step_dir_bit_is_at_31():
+    # step/dir mode is essential for use as an external driver. Bit 31 of
+    # GCONF is what flips the chip out of motion-controller mode.
+    assert tmc5262.Fields["GCONF"]["step_dir"] == 1 << 31
+
+
+def test_en_pwm_mode_aliases_en_stealthchop_bit():
+    # tmc.TMCStealthchopHelper looks up "en_pwm_mode"; we must keep that
+    # name pointing at GCONF bit 1 (en_stealthchop in the datasheet).
+    assert tmc5262.Fields["GCONF"]["en_pwm_mode"] == 1 << 1
+
+
+def test_irun_field_is_eight_bits_at_offset_8():
+    # IHOLD_IRUN was widened from 5 to 8 bits on TMC5262.
+    assert tmc5262.Fields["IHOLD_IRUN"]["irun"] == 0xFF << 8
+
+
+def test_drv_status_uses_10bit_sg_result_and_8bit_cs_actual():
+    assert tmc5262.Fields["DRV_STATUS"]["sg_result"] == 0x3FF
+    assert tmc5262.Fields["DRV_STATUS"]["cs_actual"] == 0xFF << 16
+
+
+def test_pwmconf_sd_on_meas_bit_positions():
+    # Datasheet pg 168: SD_ON_MEAS_LO at PWMCONF[15:12], SD_ON_MEAS_HI at
+    # [19:16]. Wrong positions silently disable ICS sampling.
+    assert tmc5262.Fields["PWMCONF"]["sd_on_meas_lo"] == 0x0F << 12
+    assert tmc5262.Fields["PWMCONF"]["sd_on_meas_hi"] == 0x0F << 16
+
+
+def test_cur_angle_meas_bit_positions():
+    # Datasheet pg 197: AMPL_MEAS at [11:0], ANGLE_MEAS at [25:16].
+    assert tmc5262.Fields["CUR_ANGLE_MEAS"]["ampl_meas"] == 0xFFF
+    assert tmc5262.Fields["CUR_ANGLE_MEAS"]["angle_meas"] == 0x3FF << 16
+
+
+def test_adc_i_fields_are_signed():
+    # ADC_I_A/B are signed 12-bit per datasheet pg 75.
+    assert "adc_i_a" in tmc5262.SignedFields
+    assert "adc_i_b" in tmc5262.SignedFields
+
+
+def test_do_conf_stall_fields_present():
+    # Sensorless homing on TMC5262 routes stall through DO_CONF.do0_stall
+    # / do1_stall instead of GCONF.diag*_stall on older chips.
+    assert "do0_stall" in tmc5262.Fields["DO_CONF"]
+    assert "do1_stall" in tmc5262.Fields["DO_CONF"]
+    assert tmc5262.Fields["DO_CONF"]["do0_stall"] == 0x01 << 2
+    assert tmc5262.Fields["DO_CONF"]["do1_stall"] == 0x01 << 15
+
+
+def test_do_conf_polarity_fields_present():
+    # do0_invpp / do1_invpp control DO0 / DO1 output polarity.
+    assert tmc5262.Fields["DO_CONF"]["do0_invpp"] == 0x01 << 29
+    assert tmc5262.Fields["DO_CONF"]["do1_invpp"] == 0x01 << 31
+
+
+def test_temp_from_adc_matches_datasheet_formula():
+    # Datasheet pg 134: T(°C) = 1.042 * v - 264.6 (9-bit ADC code).
+    # tmc.TMCErrorCheck consumes this via getattr(mcu_tmc, "temp_from_adc").
+    assert tmc5262._adc_to_celsius(278) == pytest.approx(25.07, abs=0.01)
+    assert tmc5262._adc_to_celsius(360) == pytest.approx(110.52, abs=0.01)
+
+
+def test_pi_regulator_fields_present():
+    # TMC5262 replaces TMC2240's StealthChop2 PWM_GRAD/OFS/REG/LIM with
+    # PI regulators (datasheet pp 33-40). These need to be exposed.
+    assert tmc5262.Fields["CURRENT_PI_REG"]["cur_p"] == 0xFFF
+    assert tmc5262.Fields["CURRENT_PI_REG"]["cur_i"] == 0x3FF << 16
+    assert tmc5262.Fields["ANGLE_PI_REG"]["angle_p"] == 0xFFF
+    assert tmc5262.Fields["ANGLE_PI_REG"]["angle_i"] == 0x3FF << 16
+    assert tmc5262.Fields["CUR_ANGLE_LIMIT"]["cur_pi_limit"] == 0xFFF << 16
+    assert tmc5262.Fields["CUR_ANGLE_LIMIT"]["angle_pi_limit"] == 0x3FF
+    assert tmc5262.Fields["PI_RESULTS"]["pwm_calc"] == 0x1FFF
+    assert tmc5262.Fields["PI_RESULTS"]["angle_corr_calc"] == 0x3FF << 16
+    assert "angle_error" in tmc5262.SignedFields
+    assert "angle_corr_calc" in tmc5262.SignedFields


### PR DESCRIPTION
## Summary

Adds Kalico support for the ADI/Trinamic **TMC5262** stepper driver (65V / 4.25A RMS, integrated MOSFETs, integrated current sense, SPI-only).

This branch is two commits:

### `tmc5262: Add stepper driver support`
New `[tmc5262]` driver module, with the notable differences from TMC2240/TMC5160 handled:
- Mandatory PLL init via a `klippy:connect` handler
- No `GLOBALSCALER` — current is set via `CURRENT_RANGE` + `CURRENT_RANGE_SCALE` + `IRUN`, auto-ranged to fit `run_current`
- `GCONF.step_dir` set for external step/dir mode
- Stall signal via `DO_CONF.do0_stall` / `do1_stall` (not `GCONF.diag*_stall`)
- Temperature monitoring via the new `temp_from_adc` hook

Includes the driver module, unit tests, a klippy integration test pair (`test/klippy/tmc5262.{cfg,test}`), and a new `[tmc5262]` section in `docs/Config_Reference.md`.

### `tmc: Allow drivers to provide a chip-specific ADC->°C conversion`
`TMCErrorCheck.get_status()` previously hardcoded the TMC2240 ADC formula `(adc_value - 2038) / 7.7` for any driver exposing an `adc_temp` field. This adds an optional `temp_from_adc(adc_value) -> celsius` callable that a driver can attach to its `mcu_tmc`; if absent the default formula is used unchanged. **No behavior change for any existing driver.**

## Test plan
- [x] Validated on hardware — **NorthPrint3D TMC5262 stepstick on a BTT Octopus Pro V1.1**
- [x] Running in production — 2x TMC5262 replacing TMC2240 on the X/Y axes
- [x] `pytest test/test_tmc5262.py` — 53 passed
- [x] klippy integration test pair (`test/klippy/tmc5262.{cfg,test}`)



🤖 Generated with [Claude Code](https://claude.com/claude-code)
