### PR TITLE
Per-Channel Tare Counts + Fixes & Improvements

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -373,9 +373,9 @@ A request may look like:
 `{"id": 123, "method":"load_cell/dump_force",
 "params": {"sensor": "load_cell", "response_template": {}}}`
 and might return:
-`{"id": 123,"result":{"header":["time", "force (g)", "counts", "tare_counts"]}}`
+`{"id": 123,"result":{"header":["time", "force (g)", "counts", "tare_counts", "channel-0 force (g)", "channel-0 counts"]}}`
 and might later produce asynchronous messages such as:
-`{"params":{"data":[[3292.432935, 40.65, 562534, -234467]]}}`
+`{"params":{"data":[[3292.432935, 40.65, 562534, -234467, 40.65, 562534]]}}`
 
 The "header" field in the initial query response is used to describe
 the fields found in later "data" responses.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -970,14 +970,20 @@ operation of the load cell. This command can be run on both calibrated and
 uncalibrated load cells.
 
 ### LOAD_CELL_CALIBRATE
-`LOAD_CELL_CALIBRATE [LOAD_CELL=<config_name>]`: Start the guided calibration
-utility. Calibration is a 3 step process:
+`LOAD_CELL_CALIBRATE [LOAD_CELL=<config_name>] [TARE=TRUE] [SAVE=TRUE]`: 
+Start the guided calibration utility. Calibration is a 3 step process:
 1. First you remove all load from the load cell and run the `TARE` command
 1. Next you apply a known load to the load cell and run the
 `CALIBRATE GRAMS=nnn` command
 1. Finally use the `ACCEPT` command to save the results
 
 You can cancel the calibration process at any time with `ABORT`.
+
+If the `TARE` option is included `reference_tare_counts` will be set at the
+current force. The `SAVE` option also prompts you to save the value and restart
+the printer. The default is to not save the value. Use this option to home the
+load cell in a print start routine at a time when the force on the load cell is
+'zero'. E.g. after [safe_z_home] or similar safety move.
 
 ### LOAD_CELL_TARE
 `LOAD_CELL_TARE [LOAD_CELL=<config_name>]`: This works just like the tare button

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -360,8 +360,11 @@ The following information is available for each `[load_cell name]`:
 - 'is_calibrated': True/False is the load cell calibrated
 - 'counts_per_gram': The number of raw sensor counts that equals 1 gram of force
 - 'reference_tare_counts': The reference number of raw sensor counts for 0 force
+- 'reference_tare_counts_per_channel': The reference number of raw sensor counts for 0 force as an array, one entry per channel
 - 'tare_counts': The current number of raw sensor counts for 0 force
+- 'tare_counts_per_channel': The current number of raw sensor counts for 0 force as an array, one entry per channel
 - 'force_g': The force in grams, averaged over the last polling period.
+- 'force_g_per_channel': The force in grams, averaged over the last polling period, one entry per channel
 - 'min_force_g': The minimum force in grams, over the last polling period.
 - 'max_force_g': The maximum force in grams, over the last polling period.
 

--- a/klippy/extras/load_cell/load_cell.py
+++ b/klippy/extras/load_cell/load_cell.py
@@ -3,12 +3,18 @@
 # Copyright (C) 2024 Gareth Farrington <gareth@waves.ky>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import collections
 import logging
+from dataclasses import dataclass
+from enum import Enum
 
+from klippy import Printer
 from klippy.configfile import ConfigWrapper
 from klippy.extras.bulk_sensor import BatchWebhooksClient
 from klippy.extras.load_cell.interfaces import BulkAdcSensor
+from klippy.gcode import GCodeCommand, GCodeDispatch
 
 
 # alternative to numpy's column selection:
@@ -18,6 +24,36 @@ def select_column(data, column_idx):
 
 def avg(data):
     return sum(data) / len(data)
+
+
+class SampleStructure(Enum):
+    # COLUMN = column index, colum header label
+    TIME = 0, "time"
+    FORCE_G = 1, "force (g)"
+    COUNTS = 2, "counts"
+    TARE_COUNTS = 3, "tare_counts"
+
+    def __new__(cls, index, label):
+        obj = object.__new__(cls)
+        obj._value_ = index
+        obj.label = label
+        return obj
+
+    @staticmethod
+    def header_labels(channel_count: int) -> list[str]:
+        labels = [col.label for col in SampleStructure]
+        for idx in range(channel_count):
+            labels.append(f"channel-{idx} {SampleStructure.FORCE_G.label}")
+            labels.append(f"channel-{idx} {SampleStructure.COUNTS.label}")
+        return labels
+
+    @staticmethod
+    def channel_force_col(idx):
+        return len(SampleStructure) + idx * 2
+
+    @staticmethod
+    def channel_counts_col(idx):
+        return len(SampleStructure) + idx * 2 + 1
 
 
 # Helper for event driven webhooks and subscription based API clients
@@ -52,11 +88,11 @@ class ApiClientHelper(object):
         wh.register_mux_endpoint(path, key, value, self._add_webhooks_client)
 
 
-# Class for handling commands related ot load cells
+# Class for handling gcode commands related to load cells
 class LoadCellCommandHelper:
-    def __init__(self, config, load_cell):
-        self.printer = config.get_printer()
-        self.load_cell = load_cell
+    def __init__(self, config: ConfigWrapper, load_cell: LoadCell):
+        self.printer: Printer = config.get_printer()
+        self.load_cell: LoadCell = load_cell
         name_parts = config.get_name().split()
         self.name = name_parts[-1]
         self.register_commands(self.name)
@@ -97,43 +133,30 @@ class LoadCellCommandHelper:
 
     cmd_LOAD_CELL_TARE_help = "Set the Zero point of the load cell"
 
-    def cmd_LOAD_CELL_TARE(self, gcmd):
-        tare_counts = self.load_cell.avg_counts()
-        self.load_cell.tare(tare_counts)
-        tare_percent = self.load_cell.counts_to_percent(tare_counts)
-        tare_force = self.load_cell.tare_force
-        if tare_force is not None:
-            gcmd.respond_info(
-                "Load cell tare value: 0 = %.1fg (%.2f%% / %i)"
-                % (tare_force, tare_percent, tare_counts)
-            )
-        else:
-            gcmd.respond_info(
-                "Load cell tare value: 0 = %.2f%% (%i)"
-                % (tare_percent, tare_counts)
-            )
+    def cmd_LOAD_CELL_TARE(self, gcmd: GCodeCommand):
+        reporter = ForceReporter(gcmd, self.load_cell)
+        self.load_cell.tare(reporter.channel_counts)
+        reporter.report(
+            ZeroReference.REFERENCE_TARE, "Load cell tare value: 0 = "
+        )
+        LoadCellGuidedCalibrationHelper.calibration_warning(
+            gcmd, self.load_cell, reporter.counts
+        )
 
     cmd_CALIBRATE_LOAD_CELL_help = "Start interactive calibration tool"
 
-    def cmd_LOAD_CELL_CALIBRATE(self, gcmd):
+    def cmd_LOAD_CELL_CALIBRATE(self, gcmd: GCodeCommand):
         LoadCellGuidedCalibrationHelper(self.printer, self.load_cell)
 
     cmd_LOAD_CELL_READ_help = "Take a reading from the load cell"
 
-    def cmd_LOAD_CELL_READ(self, gcmd):
-        counts = self.load_cell.avg_counts()
-        percent = self.load_cell.counts_to_percent(counts)
-        force = self.load_cell.counts_to_grams(counts)
-        if percent >= 100 or percent <= -100:
-            gcmd.respond_info("Err (%.2f%%)" % (percent,))
-        if force is None:
-            gcmd.respond_info("---.-g (%.2f%%)" % (percent,))
-        else:
-            gcmd.respond_info("%.1fg (%.2f%%)" % (force, percent))
+    def cmd_LOAD_CELL_READ(self, gcmd: GCodeCommand):
+        reporter = ForceReporter(gcmd, self.load_cell)
+        reporter.report(ZeroReference.TARE)
 
     cmd_LOAD_CELL_DIAGNOSTIC_help = "Check the health of the load cell"
 
-    def cmd_LOAD_CELL_DIAGNOSTIC(self, gcmd):
+    def cmd_LOAD_CELL_DIAGNOSTIC(self, gcmd: GCodeCommand):
         gcmd.respond_info("Collecting load cell data for 10 seconds...")
         collector = self.load_cell.get_collector()
         reactor = self.printer.get_reactor()
@@ -149,7 +172,7 @@ class LoadCellCommandHelper:
             gcmd.respond_info("Sensor reported no errors")
         if not samples:
             raise gcmd.error("No samples returned from sensor!")
-        counts = select_column(samples, 2)
+        counts = select_column(samples, SampleStructure.COUNTS.value)
         range_min, range_max = self.load_cell.saturation_range()
         good_count = 0
         saturation_count = 0
@@ -183,12 +206,13 @@ class LoadCellCommandHelper:
 
 # Class to guide the user through calibrating a load cell
 class LoadCellGuidedCalibrationHelper:
-    def __init__(self, printer, load_cell):
-        self.printer = printer
-        self.gcode = printer.lookup_object("gcode")
-        self.load_cell = load_cell
-        self._tare_counts = self._counts_per_gram = None
-        self.tare_percent = 0.0
+    def __init__(self, printer: Printer, load_cell: LoadCell):
+        self.printer: Printer = printer
+        self.gcode: GCodeDispatch = printer.lookup_object("gcode")
+        self.load_cell: LoadCell = load_cell
+        self._tare_counts: tuple[int, ...] | None = None
+        self._counts_per_gram: float | None = None
+        self.tare_percent: float = 0.0
         self.register_commands()
         self.gcode.respond_info(
             "Starting load cell calibration. \n"
@@ -196,6 +220,19 @@ class LoadCellGuidedCalibrationHelper:
             "2.) Apply a known load, run CALIBRATE GRAMS=nnn. \n"
             "Complete calibration with the ACCEPT command.\n"
             "Use the ABORT command to quit."
+        )
+
+    # warn if the tare point is far enough from zero to reduce sensor range
+    @staticmethod
+    def calibration_warning(
+        gcmd: GCodeCommand, load_cell: LoadCell, counts: int
+    ):
+        if load_cell.counts_to_percent(counts) <= 2.0:
+            return
+        gcmd.respond_info(
+            "WARNING: tare value is more than 2% away from 0!\n"
+            "The load cell's range will be impacted.\n"
+            "Check for external force on the load cell."
         )
 
     def verify_no_active_calibration(
@@ -220,18 +257,19 @@ class LoadCellGuidedCalibrationHelper:
         )
 
     # convert the delta of counts to a counts/gram metric
-    def counts_per_gram(self, grams, cal_counts):
-        return float(abs(int(self._tare_counts - cal_counts))) / grams
+    def counts_per_gram(self, grams: float, cal_counts: tuple[int, ...]):
+        tare_sum = sum(self._tare_counts)
+        cal_sum = sum(cal_counts)
+        return float(abs(tare_sum - cal_sum)) / grams
 
     # calculate max force that the load cell can register
     # given tare bias, at saturation in kilograms
-    def capacity_kg(self, counts_per_gram):
+    def capacity_kg(self, counts_per_gram: float):
         range_min, range_max = self.load_cell.saturation_range()
-        return (
-            int((range_max - abs(self._tare_counts)) / counts_per_gram) / 1000.0
-        )
+        tare_sum = sum(self._tare_counts)
+        return int((range_max - abs(tare_sum)) / counts_per_gram) / 1000.0
 
-    def finalize(self, save_results=False):
+    def finalize(self, save_results: bool = False):
         for name in ["ABORT", "ACCEPT", "TARE", "CALIBRATE"]:
             self.gcode.register_command(name, None)
         if not save_results:
@@ -242,13 +280,14 @@ class LoadCellGuidedCalibrationHelper:
                 "Calibration process is incomplete, aborting"
             )
         self.load_cell.set_calibration(self._counts_per_gram, self._tare_counts)
+        ref_tare_str = ", ".join("%i" % c for c in self._tare_counts)
         self.gcode.respond_info(
             "Load cell calibration settings:\n\n"
             "counts_per_gram: %.6f\n"
-            "reference_tare_counts: %i\n\n"
+            "reference_tare_counts: %s\n\n"
             "The SAVE_CONFIG command will update the printer config file"
             " with the above and restart the printer."
-            % (self._counts_per_gram, self._tare_counts)
+            % (self._counts_per_gram, ref_tare_str)
         )
         self.load_cell.tare(self._tare_counts)
 
@@ -264,20 +303,17 @@ class LoadCellGuidedCalibrationHelper:
 
     cmd_TARE_help = "Tare the load cell"
 
-    def cmd_TARE(self, gcmd):
-        self._tare_counts = self.load_cell.avg_counts()
+    def cmd_TARE(self, gcmd: GCodeCommand):
         self._counts_per_gram = None  # require re-calibration on tare
-        self.tare_percent = self.load_cell.counts_to_percent(self._tare_counts)
-        gcmd.respond_info(
-            "Load cell tare value: %.2f%% (%i)"
-            % (self.tare_percent, self._tare_counts)
+        reporter = ForceReporter(gcmd, self.load_cell)
+        self._tare_counts = reporter.channel_counts
+        reporter.report(
+            ZeroReference.ZERO,
+            "Load cell tare value: 0 = ",
+            show_force=False,
         )
-        if self.tare_percent > 2.0:
-            gcmd.respond_info(
-                "WARNING: tare value is more than 2% away from 0!\n"
-                "The load cell's range will be impacted.\n"
-                "Check for external force on the load cell."
-            )
+        self.tare_percent = self.load_cell.counts_to_percent(reporter.counts)
+        self.calibration_warning(gcmd, self.load_cell, reporter.counts)
         gcmd.respond_info(
             "Now apply a known force to the load cell and enter \
                          the force value with:\n CALIBRATE GRAMS=nnn"
@@ -285,22 +321,23 @@ class LoadCellGuidedCalibrationHelper:
 
     cmd_CALIBRATE_help = "Enter the load cell value in grams"
 
-    def cmd_CALIBRATE(self, gcmd):
+    def cmd_CALIBRATE(self, gcmd: GCodeCommand):
         if self._tare_counts is None:
             gcmd.respond_info("You must use TARE first.")
             return
         grams = gcmd.get_float("GRAMS", minval=50.0, maxval=25000.0)
         cal_counts = self.load_cell.avg_counts()
-        cal_percent = self.load_cell.counts_to_percent(cal_counts)
+        cal_sum = sum(cal_counts)
+        cal_percent = self.load_cell.counts_to_percent(cal_sum)
         c_per_g = self.counts_per_gram(grams, cal_counts)
         cap_kg = self.capacity_kg(c_per_g)
         gcmd.respond_info(
             "Calibration value: %.2f%% (%i), Counts/gram: %.5f, \
             Total capacity: +/- %0.2fKg"
-            % (cal_percent, cal_counts, c_per_g, cap_kg)
+            % (cal_percent, cal_sum, c_per_g, cap_kg)
         )
         range_min, range_max = self.load_cell.saturation_range()
-        if cal_counts >= range_max or cal_counts <= range_min:
+        if cal_sum >= range_max or cal_sum <= range_min:
             raise self.printer.command_error(
                 "ERROR: Sensor is saturated with too much load!\n"
                 "Use less force to calibrate the load cell."
@@ -438,19 +475,114 @@ class LoadCellSampleCollector:
 MIN_COUNTS_PER_GRAM = 1.0
 
 
+@dataclass
+class ForceFormatter:
+    counts: int
+    percent: float
+    force: float | None
+
+    def format(self, show_force=True, show_counts=True) -> str:
+        parts: list[str] = []
+        if show_force:
+            if self.force is None:
+                parts.append("---.-g")
+            else:
+                parts.append(f"{self.force:.1f}g")
+            parts.append("/")
+        parts.append(f"{self.percent:.2f}%")
+        if show_counts:
+            parts.append(f"({self.counts})")
+        return " ".join(parts)
+
+
+# enum of zero references for force calculations
+class ZeroReference(Enum):
+    ZERO = 1  # the raw value 0 from the sensor
+    REFERENCE_TARE = 2  # the reference_tare_counts value
+    TARE = 3  # the tare_counts value
+
+
+class ForceReporter:
+    channel_counts: tuple[int, ...]
+    counts: int
+    load_cell: LoadCell
+    gcmd: GCodeCommand
+
+    def __init__(self, gcmd: GCodeCommand, load_cell: LoadCell):
+        self.channel_counts = load_cell.avg_counts()
+        self.counts = sum(self.channel_counts)
+        self.gcmd = gcmd
+        self.load_cell = load_cell
+
+    # build the summed measurement against the zero reference
+    def _summed(self, reference: ZeroReference) -> ForceFormatter:
+        lc = self.load_cell
+        return ForceFormatter(
+            counts=self.counts,
+            percent=lc.counts_to_percent(self.counts),
+            force=lc.counts_to_grams(self.counts, reference),
+        )
+
+    # build the per-channel breakdown against the zero reference
+    def _channels(self, reference: ZeroReference) -> list[ForceFormatter]:
+        lc = self.load_cell
+        return [
+            ForceFormatter(
+                counts=ch_counts,
+                percent=lc.channel_counts_to_percent(ch_counts),
+                force=lc.counts_to_grams(ch_counts, reference, channel=idx),
+            )
+            for idx, ch_counts in enumerate(self.channel_counts)
+        ]
+
+    # report the summed measurement against the zero reference,
+    # optionally with a per-channel breakdown
+    def report(
+        self,
+        reference: ZeroReference,
+        prefix: str = "",
+        show_force: bool = True,
+        show_channels: bool = True,
+    ):
+        summed = self._summed(reference)
+        self.gcmd.respond_info(prefix + summed.format(show_force=show_force))
+        # single channel sensors don't show a per-channel breakdown
+        if not show_channels or len(self.channel_counts) == 1:
+            return
+        for idx, channel in enumerate(self._channels(reference)):
+            line = channel.format(show_force=show_force)
+            self.gcmd.respond_info(f"    Channel {idx}: {line}")
+
+
 class LoadCell:
     def __init__(self, config: ConfigWrapper, sensor: BulkAdcSensor):
         self.printer = printer = config.get_printer()
         self.config_name = config.get_name()
         self.name = config.get_name().split()[-1]
         self.sensor = sensor
+        self.channel_count = self.sensor.get_channel_count()
         buffer_size = sensor.get_samples_per_second() // 2
         self._force_buffer = collections.deque(maxlen=buffer_size)
-        self.reference_tare_counts = config.getint(
-            "reference_tare_counts", default=None
+        self._channel_force_buffers: list[collections.deque] = [
+            collections.deque(maxlen=buffer_size)
+            for _ in range(self.channel_count)
+        ]
+        ref_tare = config.getintlist("reference_tare_counts", default=None)
+        if ref_tare is not None:
+            if len(ref_tare) != self.channel_count:
+                raise config.error(
+                    "reference_tare_counts has %d values, expected %d"
+                    % (len(ref_tare), self.channel_count)
+                )
+        self.reference_tare_counts_per_channel: tuple[int, ...] | None = (
+            ref_tare
         )
+        self.reference_tare_counts: int | None = (
+            sum(ref_tare) if ref_tare is not None else None
+        )
+        self.tare_counts_per_channel = self.reference_tare_counts_per_channel
         self.tare_counts = self.reference_tare_counts
-        self.tare_force = (
+        self.tare_force: float | None = (
             0.0 if self.reference_tare_counts is not None else None
         )
         self.counts_per_gram = config.getfloat(
@@ -464,13 +596,7 @@ class LoadCell:
         LoadCellCommandHelper(config, self)
         # Client support:
         self.clients = ApiClientHelper(printer)
-        self.channel_count = self.sensor.get_channel_count()
-        header_labels = ["time", "force (g)", "counts", "tare_counts"]
-        if self.channel_count > 1:
-            for idx in range(self.channel_count):
-                header_labels.append(f"channel-{idx} force (g)")
-                header_labels.append(f"channel-{idx} counts")
-        header = {"header": header_labels}
+        header = {"header": SampleStructure.header_labels(self.channel_count)}
         self.clients.add_mux_endpoint(
             "load_cell/dump_force", "load_cell", self.name, header
         )
@@ -509,10 +635,13 @@ class LoadCell:
                 sum_counts,
                 self.tare_counts,
             ]
-            if self.channel_count > 1:
-                for counts in channel_counts:
-                    sample.append(self.counts_to_grams(counts))
-                    sample.append(counts)
+            for idx, counts in enumerate(channel_counts):
+                sample.append(
+                    self.counts_to_grams(
+                        counts, ZeroReference.TARE, channel=idx
+                    )
+                )
+                sample.append(counts)
             samples.append(sample)
         msg = {"data": samples, "errors": errors, "overflows": overflows}
         self.clients.send(msg)
@@ -522,42 +651,77 @@ class LoadCell:
     def add_client(self, callback):
         self.clients.add_client(callback)
 
-    def tare(self, tare_counts):
-        self.tare_counts = int(tare_counts)
+    def tare(self, tare_counts_per_channel: tuple[int, ...]):
+        self.tare_counts_per_channel = tare_counts_per_channel
+        self.tare_counts = sum(tare_counts_per_channel)
         if self.is_calibrated():
-            tare_delta = float(tare_counts - self.reference_tare_counts)
+            tare_delta = float(self.tare_counts - self.reference_tare_counts)
             self.tare_force = round(
                 self.invert * (tare_delta / self.counts_per_gram), 1
             )
         self.printer.send_event("load_cell:tare", self)
 
-    def set_calibration(self, counts_per_gram, tare_counts):
+    def set_reference_tare_counts(
+        self,
+        tare_counts_per_channel: tuple[int, ...] | None,
+        save: bool = False,
+    ):
+        if tare_counts_per_channel is None:
+            raise self.printer.command_error("Missing tare counts")
+        self.reference_tare_counts_per_channel = tare_counts_per_channel
+        self.reference_tare_counts = sum(tare_counts_per_channel)
+        self.tare(self.reference_tare_counts_per_channel)
+        if save:
+            configfile = self.printer.lookup_object("configfile")
+            configfile.set(
+                self.config_name,
+                "reference_tare_counts",
+                ", ".join(
+                    "%i" % c for c in self.reference_tare_counts_per_channel
+                ),
+            )
+
+    def set_calibration(
+        self,
+        counts_per_gram: float,
+        reference_tare_counts_per_channel: tuple[int, ...] | None,
+        save=True,
+    ):
         if (
             counts_per_gram is None
             or abs(counts_per_gram) < MIN_COUNTS_PER_GRAM
         ):
             raise self.printer.command_error("Invalid counts per gram value")
-        if tare_counts is None:
-            raise self.printer.command_error("Missing tare counts")
         self.counts_per_gram = counts_per_gram
-        self.reference_tare_counts = int(tare_counts)
-        configfile = self.printer.lookup_object("configfile")
-        configfile.set(
-            self.config_name,
-            "counts_per_gram",
-            "%.5f" % (self.counts_per_gram,),
+        self.set_reference_tare_counts(
+            reference_tare_counts_per_channel, save=save
         )
-        configfile.set(
-            self.config_name,
-            "reference_tare_counts",
-            "%i" % (self.reference_tare_counts,),
-        )
+        if save:
+            configfile = self.printer.lookup_object("configfile")
+            configfile.set(
+                self.config_name,
+                "counts_per_gram",
+                "%.5f" % (self.counts_per_gram,),
+            )
         self.printer.send_event("load_cell:calibrate", self)
 
-    def counts_to_grams(self, sample):
-        if not self.is_calibrated() or not self.is_tared():
+    def counts_to_grams(
+        self,
+        counts: int,
+        reference: ZeroReference = ZeroReference.TARE,
+        channel: int | None = None,
+    ) -> float | None:
+        if not self.is_calibrated():
             return None
-        sample_delta = float(sample - self.tare_counts)
+        ref_tare: tuple[int, ...] = (0,) * self.channel_count
+        if reference == ZeroReference.REFERENCE_TARE:
+            ref_tare = self.reference_tare_counts_per_channel
+        elif reference == ZeroReference.TARE:
+            ref_tare = self.tare_counts_per_channel
+        ref_counts: int = (
+            sum(ref_tare) if channel is None else ref_tare[channel]
+        )
+        sample_delta: float = float(counts - ref_counts)
         return self.invert * (sample_delta / self.counts_per_gram)
 
     # The maximum range of a single ADC channel, based on its bit width
@@ -569,14 +733,18 @@ class LoadCell:
         range_min, range_max = self.channel_saturation_range()
         return range_min * self.channel_count, range_max * self.channel_count
 
-    # convert raw counts to a +/- percentage of the sensors range
+    # convert raw counts to a +/- percentage of the sensors total range
     def counts_to_percent(self, counts):
-        range_min, range_max = self.saturation_range()
+        _, range_max = self.saturation_range()
+        return (float(counts) / float(range_max)) * 100.0
+
+    def channel_counts_to_percent(self, counts):
+        range_min, range_max = self.channel_saturation_range()
         return (float(counts) / float(range_max)) * 100.0
 
     # read 1 second of load cell data and average it
-    # performs safety checks for saturation
-    def avg_counts(self, num_samples=None):
+    # performs safety checks for errors and saturation
+    def avg_counts(self, num_samples: int | None = None) -> tuple[int, ...]:
         if num_samples is None:
             num_samples = self.sensor.get_samples_per_second()
         samples, errors = self.get_collector().collect_min(num_samples)
@@ -587,26 +755,26 @@ class LoadCell:
             )
         # check individual channels for saturated readings
         range_min, range_max = self.channel_saturation_range()
+        first_channel_col = SampleStructure.channel_counts_col(0)
         for sample in samples:
-            if self.channel_count > 1:
-                channel_counts = sample[5::2]
-            else:
-                channel_counts = [sample[2]]
+            channel_counts = sample[first_channel_col::2]
             for counts in channel_counts:
                 if counts >= range_max or counts <= range_min:
                     raise self.printer.command_error(
                         "Some samples are saturated (+/-100%)"
                     )
-        return avg(select_column(samples, 2))
+        return self._avg_counts_from_samples(samples)
 
     # Provide ongoing force tracking/averaging for status updates
     def _track_force(self, msg):
         if not (self.is_calibrated() and self.is_tared()):
             return True
         samples = msg["data"]
-        # selectColumn unusable here because Python 2 lacks deque.extend
         for sample in samples:
-            self._force_buffer.append(sample[1])
+            self._force_buffer.append(sample[SampleStructure.FORCE_G.value])
+            for idx in range(self.channel_count):
+                col = SampleStructure.channel_force_col(idx)
+                self._channel_force_buffers[idx].append(sample[col])
         return True
 
     def _force_g(self):
@@ -615,8 +783,14 @@ class LoadCell:
             and self.is_tared()
             and len(self._force_buffer) > 0
         ):
+            channel_force: list[float] = []
+            for buf in self._channel_force_buffers:
+                if len(buf) == 0:
+                    return None
+                channel_force.append(round(avg(buf), 1))
             return {
                 "force_g": round(avg(self._force_buffer), 1),
+                "force_g_per_channel": channel_force,
                 "min_force_g": round(min(self._force_buffer), 1),
                 "max_force_g": round(max(self._force_buffer), 1),
             }
@@ -643,6 +817,14 @@ class LoadCell:
     def get_counts_per_gram(self):
         return self.counts_per_gram
 
+    # convert samples into average per channel
+    def _avg_counts_from_samples(self, samples: list) -> tuple[int, ...]:
+        per_channel: list[int] = []
+        for idx in range(self.channel_count):
+            col = SampleStructure.channel_counts_col(idx)
+            per_channel.append(int(avg(select_column(samples, col))))
+        return tuple(per_channel)
+
     def get_collector(self):
         return LoadCellSampleCollector(self.printer, self)
 
@@ -653,7 +835,11 @@ class LoadCell:
                 "is_calibrated": self.is_calibrated(),
                 "counts_per_gram": self.counts_per_gram,
                 "reference_tare_counts": self.reference_tare_counts,
+                "reference_tare_counts_per_channel": (
+                    self.reference_tare_counts_per_channel
+                ),
                 "tare_counts": self.tare_counts,
+                "tare_counts_per_channel": self.tare_counts_per_channel,
                 "tare_force": self.tare_force,
             }
         )

--- a/klippy/extras/load_cell/load_cell.py
+++ b/klippy/extras/load_cell/load_cell.py
@@ -15,6 +15,7 @@ from klippy.configfile import ConfigWrapper
 from klippy.extras.bulk_sensor import BatchWebhooksClient
 from klippy.extras.load_cell.interfaces import BulkAdcSensor
 from klippy.gcode import GCodeCommand, GCodeDispatch
+from klippy.toolhead import ToolHead
 
 
 # alternative to numpy's column selection:
@@ -747,7 +748,16 @@ class LoadCell:
     def avg_counts(self, num_samples: int | None = None) -> tuple[int, ...]:
         if num_samples is None:
             num_samples = self.sensor.get_samples_per_second()
-        samples, errors = self.get_collector().collect_min(num_samples)
+        toolhead: ToolHead = self.printer.lookup_object("toolhead")
+        # callers expect a load from the context of the call, all moves must
+        # finish before samples are valid
+        collector: LoadCellSampleCollector = self.get_collector()
+        collector.start_collecting(min_time=toolhead.get_last_move_time())
+        samples, errors = collector.collect_min(num_samples)
+        self.validate_samples(samples, errors)
+        return self._avg_counts_from_samples(samples)
+
+    def validate_samples(self, samples, errors):
         if errors:
             raise self.printer.command_error(
                 "Sensor reported %i errors while sampling"
@@ -763,7 +773,6 @@ class LoadCell:
                     raise self.printer.command_error(
                         "Some samples are saturated (+/-100%)"
                     )
-        return self._avg_counts_from_samples(samples)
 
     # Provide ongoing force tracking/averaging for status updates
     def _track_force(self, msg):
@@ -825,7 +834,7 @@ class LoadCell:
             per_channel.append(int(avg(select_column(samples, col))))
         return tuple(per_channel)
 
-    def get_collector(self):
+    def get_collector(self) -> LoadCellSampleCollector:
         return LoadCellSampleCollector(self.printer, self)
 
     def get_status(self, eventtime):

--- a/klippy/extras/load_cell/load_cell.py
+++ b/klippy/extras/load_cell/load_cell.py
@@ -27,6 +27,10 @@ def avg(data):
     return sum(data) / len(data)
 
 
+def has_flag(gcmd: GCodeCommand, name):
+    return gcmd.get(name, default="False").strip().lower() in {"1", "true"}
+
+
 class SampleStructure(Enum):
     # COLUMN = column index, colum header label
     TIME = 0, "time"
@@ -147,7 +151,46 @@ class LoadCellCommandHelper:
     cmd_CALIBRATE_LOAD_CELL_help = "Start interactive calibration tool"
 
     def cmd_LOAD_CELL_CALIBRATE(self, gcmd: GCodeCommand):
-        LoadCellGuidedCalibrationHelper(self.printer, self.load_cell)
+        # just tare or run the whole guided calibration experience?
+        if has_flag(gcmd, "TARE"):
+            self._calibration_tare(gcmd)
+        else:
+            LoadCellGuidedCalibrationHelper(self.printer, self.load_cell)
+
+    # set reference tare counts on a calibrated load cell
+    def _calibration_tare(self, gcmd: GCodeCommand):
+        # it is invalid to set the reference tare counts on an uncalibrated
+        # load cell. Prompt user to run full calibration
+        if not self.load_cell.is_calibrated():
+            raise gcmd.error(
+                "Load cell has not been calibrated. Run LOAD_CELL_CALIBRATE first."
+            )
+        reporter: ForceReporter = ForceReporter(gcmd, self.load_cell)
+        reporter.report(ZeroReference.ZERO, "New reference tare value: 0 = ")
+        self._report_calibration_change(gcmd, reporter)
+        LoadCellGuidedCalibrationHelper.calibration_warning(
+            gcmd, self.load_cell, reporter.counts
+        )
+        save = gcmd.get("SAVE", default="False").strip().lower() in {
+            "1",
+            "true",
+        }
+        self.load_cell.set_reference_tare_counts(
+            reporter.channel_counts, save=save
+        )
+
+    def _report_calibration_change(
+        self, gcmd: GCodeCommand, reporter: ForceReporter
+    ):
+        change = reporter.counts - self.load_cell.reference_tare_counts
+        formatter = ForceFormatter(
+            counts=change,
+            percent=self.load_cell.counts_to_percent(change),
+            force=self.load_cell.counts_to_grams(change, ZeroReference.ZERO),
+        )
+        gcmd.respond_info(
+            "Calibration changed by: " + formatter.format(show_counts=False)
+        )
 
     cmd_LOAD_CELL_READ_help = "Take a reading from the load cell"
 

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -3,8 +3,10 @@
 # Copyright (C) 2025  Gareth Farrington <gareth@waves.ky>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import math
-from typing import Tuple
+from typing import Optional, Tuple
 
 from klippy import mcu
 from klippy.configfile import ConfigWrapper
@@ -88,6 +90,35 @@ class ParamHelper:
         for value in values:
             self._validate_float(description, error, value, above, below)
 
+    @staticmethod
+    def _get_gcmd_boolean(gcmd: GCodeCommand):
+        def get_boolean(name, default: Optional[bool] = False):
+            raw_value: str = gcmd.get(name, parser=str, default=default)
+            if raw_value is None and default is None:
+                return None
+            if raw_value is not None:
+                raw_value = str(raw_value)
+            if (
+                raw_value is None
+                or raw_value.upper() == "FALSE"
+                or raw_value == "0"
+            ):
+                return False
+            elif raw_value.upper() == "TRUE" or raw_value == "1":
+                return True
+            else:
+                raise gcmd.error(
+                    f"Value `{raw_value}` is not a valid boolean for {name}"
+                )
+
+        return get_boolean
+
+    def _get_boolean(
+        self, config: ConfigWrapper, gcmd: GCodeCommand
+    ) -> Optional[bool]:
+        get = self._get_gcmd_boolean(gcmd) if gcmd else config.getboolean
+        return get(self._get_name(gcmd), default=self.value)
+
     def _get_int(self, config, gcmd, minval, maxval):
         get = gcmd.get_int if gcmd else config.getint
         return get(
@@ -146,12 +177,18 @@ class ParamHelper:
     ):
         if config is None and gcmd is None:
             return self.value
-        if self._type_name == "int":
+        if self._type_name == "boolean":
+            return self._get_boolean(config, gcmd)
+        elif self._type_name == "int":
             return self._get_int(config, gcmd, minval, maxval)
         elif self._type_name == "float":
             return self._get_float(config, gcmd, minval, maxval, above, below)
         else:
             return self._get_float_list(config, gcmd, above, below)
+
+
+def booleanParamHelper(config, name, default=False):
+    return ParamHelper(config, name, "boolean", default)
 
 
 def intParamHelper(config, name, default=None, minval=None, maxval=None):
@@ -353,8 +390,8 @@ class LoadCellProbeConfigHelper:
             config, "drift_safety_limit", minval=0, default=1000
         )
         # pullback move
-        self._disable_pullback_move = config.getboolean(
-            "disable_pullback_move", False
+        self._disable_pullback_move = booleanParamHelper(
+            config, "disable_pullback_move", False
         )
         self._pullback_distance_param = floatParamHelper(
             config, "pullback_distance", minval=0.01, maxval=2.0, default=0.2
@@ -388,8 +425,8 @@ class LoadCellProbeConfigHelper:
     def get_pullback_distance(self, gcmd=None) -> float:
         return self._pullback_distance_param.get(gcmd)
 
-    def is_pullback_move_disabled(self) -> bool:
-        return self._disable_pullback_move
+    def is_pullback_move_disabled(self, gcmd=None) -> bool:
+        return self._disable_pullback_move.get(gcmd)
 
     def get_rest_time(self) -> float:
         return self._rest_time
@@ -780,7 +817,7 @@ class TappingMove:
             self, pos, speed, gcmd
         )
         # when pullback is disabled, skip the pullback move and tap analysis
-        if self._config_helper.is_pullback_move_disabled():
+        if self._config_helper.is_pullback_move_disabled(gcmd):
             collector.stop_collecting()
             self._is_last_result_valid = True
             return epos, self._is_last_result_valid

--- a/klippy/extras/load_cell/load_cell_probe.py
+++ b/klippy/extras/load_cell/load_cell_probe.py
@@ -6,8 +6,6 @@
 import math
 from typing import Tuple
 
-import numpy as np
-
 from klippy import mcu
 from klippy.configfile import ConfigWrapper
 from klippy.extras.homing import PrinterHoming
@@ -19,6 +17,7 @@ from .interfaces import LoadCellSensor
 from .load_cell import (
     LoadCell,
     LoadCellSampleCollector,
+    ZeroReference,
 )
 from .tap_analysis import TapAnalysisHelper, TapClassifierModule
 
@@ -329,17 +328,6 @@ class ContinuousTareFilterHelper:
         return self._sos_filter
 
 
-# check results from the collector for errors and raise an exception is found
-def check_sensor_errors(results, printer):
-    samples, errors = results
-    if errors:
-        raise printer.command_error(
-            "Load cell sensor reported errors while"
-            " probing: %i errors, %i overflows" % (errors[0], errors[1])
-        )
-    return samples
-
-
 class LoadCellProbeConfigHelper:
     def __init__(
         self,
@@ -424,18 +412,21 @@ class LoadCellProbeConfigHelper:
         return safety_min, safety_max
 
     # check if tare_counts is within the force_safety_limit
-    def assert_force_safety_limit(self, tare_counts, gcmd=None):
-        limit = self.get_safety_limit_grams(gcmd)
+    def assert_force_safety_limit(self, gcmd=None):
+        limit: int = self.get_safety_limit_grams(gcmd)
         # zero limit disables this check
         if limit == 0:
             return
         safety_min, safety_max = self.get_reference_safety_range(gcmd)
+        tare_counts: int = self._load_cell.tare_counts
         if tare_counts <= safety_min or tare_counts >= safety_max:
-            cmd_err = self._printer.command_error
-            force = round(self._load_cell.counts_to_grams(tare_counts), 1)
-            raise cmd_err(
-                "Load Cell Probe Error: force of {}g exceeds "
-                "force_safety_limit ({}g) before probing!".format(force, limit)
+            force: float = self._load_cell.counts_to_grams(
+                tare_counts, ZeroReference.REFERENCE_TARE
+            )
+            raise self._printer.command_error(
+                f"Load Cell Probe Error: current absolute force of "
+                f"{force:.1f}g exceeds force_safety_limit (+/-{limit:.1f}g) "
+                f"before probing!"
             )
 
     def get_probe_drift_range(self, tare_counts, gcmd=None) -> Tuple[int, int]:
@@ -543,18 +534,16 @@ class McuLoadCellProbe:
     def get_dispatch(self):
         return self._dispatch
 
-    def set_endstop_range(self, tare_counts: int, gcmd=None):
+    def set_endstop_range(self, gcmd: GCodeCommand = None):
         # update the load cell so it reflects the new tare value
-        self._load_cell.tare(tare_counts)
-        # update internal tare value
         safety_min, safety_max = self._config_helper.get_probe_drift_range(
-            tare_counts, gcmd
+            self._load_cell.tare_counts, gcmd
         )
         args = [
             self._oid,
             safety_min,
             safety_max,
-            tare_counts,
+            self._load_cell.tare_counts,
             self._config_helper.get_trigger_force_grams(gcmd),
             self._config_helper.get_grams_per_count(),
         ]
@@ -634,18 +623,13 @@ class LoadCellPrimitives:
     # pauses for the last move to complete and then
     # sets the endstop tare value and range
     def tare(self, gcmd=None):
-        collector = self._start_collector()
         num_samples = self._config_helper.get_tare_samples(gcmd)
-        # use collect_min collected samples are not wasted
-        results = collector.collect_min(num_samples)
-        tare_samples = check_sensor_errors(results, self._printer)
-        tare_counts = int(
-            np.average(np.array(tare_samples)[:, 2].astype(float))
-        )
-        self._config_helper.assert_force_safety_limit(tare_counts, gcmd)
+        tare_counts_per_channel = self._load_cell.avg_counts(num_samples)
+        self._load_cell.tare(tare_counts_per_channel)
+        self._config_helper.assert_force_safety_limit(gcmd)
         # update sos_filter with any gcode parameter changes
         self._continuous_tare_filter_helper.update_from_command(gcmd)
-        self._mcu_load_cell_probe.set_endstop_range(tare_counts, gcmd)
+        self._mcu_load_cell_probe.set_endstop_range(gcmd)
 
     def home_start(self, print_time):
         # do not permit homing if the load cell is not calibrated
@@ -704,6 +688,9 @@ class LoadCellPrimitives:
         print_time = toolhead.get_last_move_time()
         self.home_start(print_time)
         return self.home_wait(print_time + timeout)
+
+    def validate_samples(self, samples, errors):
+        self._load_cell.validate_samples(samples, errors)
 
     def get_status(self, eventtime):
         status = self._load_cell.get_status(eventtime)
@@ -800,13 +787,13 @@ class TappingMove:
         # do the pullback move
         pullback_end_time = self.pullback_move(gcmd)
         # collect samples from the tap
-        results = collector.collect_until(pullback_end_time)
+        samples, errors = collector.collect_until(pullback_end_time)
+        self._load_cell_primitives.validate_samples(samples, errors)
         # calculate how long we waited to get the data
         t_end = self._printer.get_reactor().monotonic()
         t_end = self.get_mcu().estimated_print_time(t_end)
         collection_time = t_end - pullback_end_time
         # check for data errors
-        samples = check_sensor_errors(results, self._printer)
         trigger_force = self._config_helper.get_trigger_force_grams(gcmd)
         # Analyze the tap data
         tap_analysis = self._tap_analysis_helper.analyze(


### PR DESCRIPTION
This little branch has turned into kind of an omnibus. Lets get into it:

## Better Multichannel Sensor Support

The first commit is all about making multi-channel sensors a first-class experience. Now the tare and reference tare values are stored as arrays of values, one for each channel. Force and counts of each individual channel is also emitted to the printer object and the websocket. This allows for deeper inspection of individual channels to look for saturation errors.

When using a multichannel sensor, all of the gcode commands now display data from the individual channels as well as the summation of the force from all channels. This will help users debug issues in multichannel setups. E.g. showing what happens when weight is applied to extreme corners of a multichannel under bed setup.

There was a lot of duplicated code for displaying force and for handling column identification in the sensor data. So I refactored it to use a more object oriented and declarative approach.

There was a bug in `load_cell_probe.py` that was displaying force incorrectly when the safety limit was violated. This was root caused to using the wrong tare value to calculate force. The new `ZeroReference` enum explicit explains what reference will be used when calculating and displaying force. Everywhere that calculates or displays force now explicitly passes its zero reference.

`ForceReporter` now centralizes the job of printing force to the console. A 4 channel sensor might report force from LOAD_CELL_READ like this:

```
LOAD_CELL_READ
200g / 0.25% (12349456)
    Channel 0: 50g / 5.1% (26201)
    Channel 1: 20g / 2.03% (76323)
    Channel 2: 100g / 1.9% (275903)
    Channel 3: 30g / 5.8% (821542)
```

The `SampleStructure` Enum now describes the columns present in a load cell sample and makes finding the column index for a specific channel easy. No more magic 🪄 numbers in the code.

This is all backwards compatible with the existing interface. Everything new is being added onto the end and everything that already existed is still there. If we dont like the new structure and want to pack the channels one after another, I'm OK with making that change. Just let me know your preference in the review.

#### Future work
The tare value sent to the on MCU endstop is still just a single value. But we could send the tare value of each individual channel. This might help in detecting probes at the corners or edges of a bed where cantilever effects could potentially cause force cancelling between pairs of channels. Summing the absolute delta from each channel would cause these cases to be amplified. Supporting 4 channels is probably enough for our printers, so the command could have a limited size.

We just need to gather feedback for testers before prioritizing this work.

----

## LOAD_CELL_CALIBRATE TARE=TRUE

The next commit is an update to how `LOAD_CELL_CALIBRATE` works. You can now run `LOAD_CELL_CALIBRATE TARE=TRUE` and the `reference_tare_counts` will be updated. This is the equivalent of "homing" the load cell.

Users can call `LOAD_CELL_CALIBRATE TARE=TRUE` at a point in their `PRINT_START` when they know that the load cell does not have any force applied to it. e.g. after a Z lift, after nozzle heating etc.

E.g here the load cell starts up at a load of 1kg:
```
$ LOAD_CELL_READ
// 1085.1g / 0.10% (8335)
$ LOAD_CELL_CALIBRATE TARE=TRUE
// New reference tare value: 0 = 30.5g / 0.10% (8124)
// Calibration changed by: 1084.3g / 3.44%
```

This solves for some persistent issues we have seen in testing:

### How it's supposed to work

`reference_tare_counts` is the calibrated 0 of the load cell. `force_safety_limit` is a limit relative (+/-) to that 0 point. This is checked before probing starts. Probing at forces outside the safety limit raises an error. This is in place because we don't have any other safeguards to prevent crashes. This is the same idea as "probe triggered before movement" in other probes.

### Real world ways the safety limit can be violated

1) Moving the toolhead in X/Y before probing causes it to collide with the bed. This exerts a high force on the toolhead and probing should not continue. A common scenario would be a tilted gantry or bed, running the QUAD_GANTRY_LEVEL command and not building in enough retract height.
2) Running the PROBE command repeatedly. The PROBE command does not retract the toolhead. This means it can leave the toolhead in contact with the bed and under load. Repeatedly probing will continue to increase this load. The dynamic tare value is reset before each probe attempt. If there was no external idea of a 0 reference value it could continue to apply force until something breaks.
3) Load Cell Damage - some prior collision causes the reference point of the load cell to shift. This should ideally lead to a physical examination of the toolhead and a re-calibration or replacement.

### What we found in testing

We see lots of false violations of the safety limit which users find frustrating:

1) Temperature of the toolhead changes the reference value. Load cells get calibrated at ambient temperature. When heated they report a very different tare value.
2) Extruder pressure - the reference zero changes depending on extruder pressure. With heat at the end of the print this tents to drop to 0. But it depends and certain ooze prevention routines (cold retraction) can put negative pressure on the load cell.
3) Toohead position changes - the bowden tube and attached cable chain pull on the toolhead changing the zero value.
4) Apparent drift over time - this is hard to pin down. It could be due to seasonal temperature variations causing ambient temperature to shift the zero point.

With all of these issues its hard to find an ideal reference value.

### How this is solved elsewhere

Prusa's firmware uses stall detection to stop a probe when the toolhead crashes. That requires stall detecting stepper drivers and steppers that work well with stall detection. So that's not a universal fix for all printers.

### Tradeoffs

`LOAD_CELL_CALIBRATE TARE=TRUE` sets the zero reference point. This has the potential to allow bad things to happen:

* If this is run while the toolhead is already crashed
* If this is run on a load cell that has suffered damage

In those cases you'll defeat the safety system and potentially suffer further machine damage. So by running this you are asserting that neither of those things can be true.

#### Future work
I know that if you give users a way to "fix" a problem they will just run it all the time and ignore the underlying issue. Adding a second safety sensor, like stall detection, would be a good solution for most users.

----

## disable_pullback_move on gcode commands

The last commit is a small change to allow the pullback move to be selectively disabled for individual probes or other commands. e.g. you want to probe a nozzle wiper pad and leave the nozzle in contact with the pad.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
