### PR TITLE
HX71708 Sensor Support

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20260714: Users of HX711 and HX717 load cell sensors need to reflash their MCUs
+as the communication protocol for these sensors has changed to support the
+HX71708 which doesn't support changing the gain setting.
+
 20260201: The manual_stepper `STOP_ON_ENDSTOP` feature may now take
 less time to complete. Previously, the command would wait the entire
 time the move could possibly take even if the endstop triggered

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5975,6 +5975,20 @@ dout_pin:
 #   in software.
 ```
 
+#### HX71708
+The HX71708 is a single channel, fixed gain amplifier version of
+the HX717 with software selectable sample rates.
+```
+[load_cell]
+sensor_type: hx71708
+sclk_pin:
+#   The pin connected to the HX71708 clock line. This parameter must be provided.
+dout_pin:
+#   The pin connected to the HX71708 data output line. This parameter must be provided.
+#sample_rate: 320
+#   Valid values for sample_rate are: 10, 20, 80, 320. The default is 320.
+```
+
 #### ADS1220
 The ADS1220 is a 24 bit ADC supporting up to a 2Khz sample rate configurable in
 software.

--- a/klippy/extras/load_cell/hx71x.py
+++ b/klippy/extras/load_cell/hx71x.py
@@ -28,12 +28,13 @@ class HX71xBase(LoadCellSensor):
         default_sample_rate,
         gain_options,
         default_gain,
+        sps_bits,
     ):
         self.printer = printer = config.get_printer()
         self.name = config.get_name().split()[-1]
         self.last_error_count = 0
-        self.consecutive_fails = 0
         self.sensor_type = sensor_type
+        self.consecutive_fails = 0
         # Chip options
         dout_pin_name = config.get("dout_pin")
         sclk_pin_name = config.get("sclk_pin")
@@ -54,6 +55,17 @@ class HX71xBase(LoadCellSensor):
         self.sps = config.getchoice(
             "sample_rate", sample_rate_options, default=default_sample_rate
         )
+        # HX71708 configures the sample rate instead of the gain/channel.
+        # We forward the sps bits to hx71x_read_adc so that it can read the extra bits required
+        if sensor_type == "hx71708":
+            self.gain_or_sps = 1
+            self.sps_bits = config.getchoice(
+                "sample_rate", sps_bits, default=default_sample_rate
+            )
+        else:
+            self.gain_or_sps = 0
+            self.sps_bits = 0
+
         # gain/channel choices
         self.gain_channel = int(
             config.getchoice("gain", gain_options, default=default_gain)
@@ -74,8 +86,15 @@ class HX71xBase(LoadCellSensor):
         self.query_hx71x_cmd = None
         self.attach_probe_cmd = None
         mcu.add_config_cmd(
-            "config_hx71x oid=%d gain_channel=%d dout_pin=%s sclk_pin=%s"
-            % (self.oid, self.gain_channel, self.dout_pin, self.sclk_pin)
+            "config_hx71x oid=%d gain_or_sps=%d sps_bits=%d gain_channel=%d dout_pin=%s sclk_pin=%s"
+            % (
+                self.oid,
+                self.gain_or_sps,
+                self.sps_bits,
+                self.gain_channel,
+                self.dout_pin,
+                self.sclk_pin,
+            )
         )
         mcu.add_config_cmd(
             "query_hx71x oid=%d rest_ticks=0" % (self.oid,), on_restart=True
@@ -192,6 +211,7 @@ class HX711(HX71xBase):
             # HX711 gain/channel options
             {"A-128": 1, "B-32": 2, "A-64": 3},
             "A-128",
+            {},
         )
 
 
@@ -206,7 +226,23 @@ class HX717(HX71xBase):
             # HX717 gain/channel options
             {"A-128": 1, "B-64": 2, "A-64": 3, "B-8": 4},
             "A-128",
+            {},
         )
 
 
-HX71X_SENSOR_TYPES = {"hx711": HX711, "hx717": HX717}
+class HX71708(HX71xBase):
+    def __init__(self, config):
+        super(HX71708, self).__init__(
+            config,
+            "hx71708",
+            # HX717 sps options
+            {320: 320, 80: 80, 20: 20, 10: 10},
+            320,
+            # HX717 gain/channel options
+            {"A-128": 1},
+            "A-128",
+            {320: 4, 3: 80, 20: 2, 10: 1},
+        )
+
+
+HX71X_SENSOR_TYPES = {"hx711": HX711, "hx717": HX717, "hx71708": HX71708}

--- a/klippy/extras/load_cell/hx71x.py
+++ b/klippy/extras/load_cell/hx71x.py
@@ -24,17 +24,16 @@ class HX71xBase(LoadCellSensor):
         self,
         config,
         sensor_type,
-        sample_rate_options,
-        default_sample_rate,
-        gain_options,
-        default_gain,
-        sps_bits,
+        sps,
+        setting_pulses,
     ):
         self.printer = printer = config.get_printer()
         self.name = config.get_name().split()[-1]
         self.last_error_count = 0
         self.sensor_type = sensor_type
         self.consecutive_fails = 0
+        self.sps = sps
+        self.setting_pulses = setting_pulses
         # Chip options
         dout_pin_name = config.get("dout_pin")
         sclk_pin_name = config.get("sclk_pin")
@@ -51,25 +50,6 @@ class HX71xBase(LoadCellSensor):
             )
         self.dout_pin = dout_ppin["pin"]
         self.sclk_pin = sclk_ppin["pin"]
-        # Samples per second choices
-        self.sps = config.getchoice(
-            "sample_rate", sample_rate_options, default=default_sample_rate
-        )
-        # HX71708 configures the sample rate instead of the gain/channel.
-        # We forward the sps bits to hx71x_read_adc so that it can read the extra bits required
-        if sensor_type == "hx71708":
-            self.gain_or_sps = 1
-            self.sps_bits = config.getchoice(
-                "sample_rate", sps_bits, default=default_sample_rate
-            )
-        else:
-            self.gain_or_sps = 0
-            self.sps_bits = 0
-
-        # gain/channel choices
-        self.gain_channel = int(
-            config.getchoice("gain", gain_options, default=default_gain)
-        )
         ## Bulk Sensor Setup
         # Clock tracking
         chip_smooth = self.sps * UPDATE_INTERVAL * 2
@@ -86,23 +66,16 @@ class HX71xBase(LoadCellSensor):
         self.query_hx71x_cmd = None
         self.attach_probe_cmd = None
         mcu.add_config_cmd(
-            "config_hx71x oid=%d gain_or_sps=%d sps_bits=%d gain_channel=%d dout_pin=%s sclk_pin=%s"
-            % (
-                self.oid,
-                self.gain_or_sps,
-                self.sps_bits,
-                self.gain_channel,
-                self.dout_pin,
-                self.sclk_pin,
-            )
-        )
-        mcu.add_config_cmd(
             "query_hx71x oid=%d rest_ticks=0" % (self.oid,), on_restart=True
         )
 
         mcu.register_config_callback(self._build_config)
 
     def _build_config(self):
+        self.mcu.add_config_cmd(
+            "config_hx71x oid=%d setting_pulses=%d dout_pin=%s sclk_pin=%s"
+            % (self.oid, self.setting_pulses, self.dout_pin, self.sclk_pin)
+        )
         self.query_hx71x_cmd = self.mcu.lookup_command(
             "query_hx71x oid=%c rest_ticks=%u"
         )
@@ -201,48 +174,33 @@ class HX71xBase(LoadCellSensor):
 
 
 class HX711(HX71xBase):
+    SPS_OPTIONS = {80: 80, 10: 10}
+    GAIN_OPTIONS = {"A-128": 1, "B-32": 2, "A-64": 3}
+
     def __init__(self, config):
-        super(HX711, self).__init__(
-            config,
-            "hx711",
-            # HX711 sps options
-            {80: 80, 10: 10},
-            80,
-            # HX711 gain/channel options
-            {"A-128": 1, "B-32": 2, "A-64": 3},
-            "A-128",
-            {},
-        )
+        sps = config.getchoice("sample_rate", self.SPS_OPTIONS, default=80)
+        gain = int(config.getchoice("gain", self.GAIN_OPTIONS, default="A-128"))
+        super(HX711, self).__init__(config, "hx711", sps, gain)
 
 
 class HX717(HX71xBase):
+    SPS_OPTIONS = {320: 320, 80: 80, 20: 20, 10: 10}
+    GAIN_OPTIONS = {"A-128": 1, "B-64": 2, "A-64": 3, "B-8": 4}
+
     def __init__(self, config):
-        super(HX717, self).__init__(
-            config,
-            "hx717",
-            # HX717 sps options
-            {320: 320, 80: 80, 20: 20, 10: 10},
-            320,
-            # HX717 gain/channel options
-            {"A-128": 1, "B-64": 2, "A-64": 3, "B-8": 4},
-            "A-128",
-            {},
-        )
+        sps = config.getchoice("sample_rate", self.SPS_OPTIONS, default=320)
+        gain = int(config.getchoice("gain", self.GAIN_OPTIONS, default="A-128"))
+        super(HX717, self).__init__(config, "hx717", sps, gain)
 
 
 class HX71708(HX71xBase):
+    SPS_OPTIONS = {320: 320, 80: 80, 20: 20, 10: 10}
+    SPS_TO_BITS = {320: 4, 80: 3, 20: 2, 10: 1}
+
     def __init__(self, config):
-        super(HX71708, self).__init__(
-            config,
-            "hx71708",
-            # HX717 sps options
-            {320: 320, 80: 80, 20: 20, 10: 10},
-            320,
-            # HX717 gain/channel options
-            {"A-128": 1},
-            "A-128",
-            {320: 4, 3: 80, 20: 2, 10: 1},
-        )
+        sps = config.getchoice("sample_rate", self.SPS_OPTIONS, default=320)
+        setting_pulses = self.SPS_TO_BITS[sps]
+        super(HX71708, self).__init__(config, "hx71708", sps, setting_pulses)
 
 
 HX71X_SENSOR_TYPES = {"hx711": HX711, "hx717": HX717, "hx71708": HX71708}

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -304,7 +304,7 @@ config WANT_THERMOCOUPLE
     bool "Support thermocouple MAX sensors"
     depends on WANT_SPI
 config WANT_HX71X
-    bool "Support HX711 and HX717 ADC chips"
+    bool "Support HX711, HX717 & HX71708 ADC chips"
     depends on HAVE_GPIO
 config WANT_ADS1220
     bool "Support ADS 1220 ADC chip"

--- a/src/sensor_hx71x.c
+++ b/src/sensor_hx71x.c
@@ -18,6 +18,8 @@
 
 struct hx71x_adc {
     struct timer timer;
+    uint8_t gain_or_sps;
+    uint8_t sps_bits;
     uint8_t gain_channel;   // the gain+channel selection (1-4)
     uint8_t flags;
     uint32_t rest_ticks;
@@ -79,7 +81,7 @@ hx71x_delay(void)
 
 // Read 'num_bits' from the sensor
 static uint32_t
-hx71x_raw_read(struct gpio_in dout, struct gpio_out sclk, int num_bits)
+hx71x_raw_read(struct gpio_in dout, struct gpio_out sclk, uint_fast8_t num_bits)
 {
     uint32_t bits_read = 0;
     while (num_bits--) {
@@ -149,7 +151,15 @@ hx71x_read_adc(struct hx71x_adc *hx71x, uint8_t oid)
 {
     // Read from sensor
     uint_fast8_t gain_channel = hx71x->gain_channel;
-    uint32_t adc = hx71x_raw_read(hx71x->dout, hx71x->sclk, 24 + gain_channel);
+    uint_fast8_t gain_or_sps = hx71x->gain_or_sps;
+
+    uint_fast8_t extra_bits;
+    if (gain_or_sps == 1) {
+        extra_bits = hx71x->sps_bits;
+    } else {
+        extra_bits = hx71x->gain_channel;
+    }
+    uint32_t adc = hx71x_raw_read(hx71x->dout, hx71x->sclk, 24u + extra_bits);
 
     // Clear pending flag (and note if an overflow occurred)
     irq_disable();
@@ -158,12 +168,12 @@ hx71x_read_adc(struct hx71x_adc *hx71x, uint8_t oid)
     irq_enable();
 
     // Extract report from raw data
-    uint32_t counts = adc >> gain_channel;
+    uint32_t counts = adc >> extra_bits;
     if (counts & 0x800000)
         counts |= 0xFF000000;
 
     // Check for errors
-    uint_fast8_t extras_mask = (1 << gain_channel) - 1;
+    uint_fast8_t extras_mask = (1 << extra_bits) - 1;
     if ((adc & extras_mask) != extras_mask) {
         // Transfer did not complete correctly
         hx71x->last_error = SAMPLE_ERROR_DESYNC;
@@ -193,17 +203,24 @@ command_config_hx71x(uint32_t *args)
     struct hx71x_adc *hx71x = oid_alloc(args[0]
                 , command_config_hx71x, sizeof(*hx71x));
     hx71x->timer.func = hx71x_event;
-    uint8_t gain_channel = args[1];
-    if (gain_channel < 1 || gain_channel > 4) {
+    uint8_t gain_or_sps = args[1];
+    uint8_t sps_bits = args[2];
+    uint8_t gain_channel = args[3];
+    if (gain_or_sps == 0 && (gain_channel < 1 || gain_channel > 4)) {
         shutdown("HX71x gain/channel out of range 1-4");
     }
+    if (gain_or_sps == 1 && (sps_bits < 1 || sps_bits > 4)) {
+        shutdown("HX71x sample_rate out of range 1-4");
+    }
+    hx71x->gain_or_sps = gain_or_sps;
+    hx71x->sps_bits = sps_bits;
     hx71x->gain_channel = gain_channel;
-    hx71x->dout = gpio_in_setup(args[2], 1);
-    hx71x->sclk = gpio_out_setup(args[3], 0);
+    hx71x->dout = gpio_in_setup(args[4], 1);
+    hx71x->sclk = gpio_out_setup(args[5], 0);
     gpio_out_write(hx71x->sclk, 1); // put chip in power down state
 }
-DECL_COMMAND(command_config_hx71x, "config_hx71x oid=%c gain_channel=%c"
-             " dout_pin=%u sclk_pin=%u");
+DECL_COMMAND(command_config_hx71x, "config_hx71x oid=%c gain_or_sps=%c"
+             " sps_bits=%c gain_channel=%c dout_pin=%u sclk_pin=%u");
 
 void
 hx71x_attach_load_cell_probe(uint32_t *args) {

--- a/src/sensor_hx71x.c
+++ b/src/sensor_hx71x.c
@@ -18,9 +18,7 @@
 
 struct hx71x_adc {
     struct timer timer;
-    uint8_t gain_or_sps;
-    uint8_t sps_bits;
-    uint8_t gain_channel;   // the gain+channel selection (1-4)
+    uint8_t setting_pulses;     // additional clock pulses after 24-bit read (1-4)
     uint8_t flags;
     uint32_t rest_ticks;
     uint32_t last_error;
@@ -150,16 +148,8 @@ static void
 hx71x_read_adc(struct hx71x_adc *hx71x, uint8_t oid)
 {
     // Read from sensor
-    uint_fast8_t gain_channel = hx71x->gain_channel;
-    uint_fast8_t gain_or_sps = hx71x->gain_or_sps;
-
-    uint_fast8_t extra_bits;
-    if (gain_or_sps == 1) {
-        extra_bits = hx71x->sps_bits;
-    } else {
-        extra_bits = hx71x->gain_channel;
-    }
-    uint32_t adc = hx71x_raw_read(hx71x->dout, hx71x->sclk, 24u + extra_bits);
+    uint_fast8_t setting_pulses = hx71x->setting_pulses;
+    uint32_t adc = hx71x_raw_read(hx71x->dout, hx71x->sclk, 24u + setting_pulses);
 
     // Clear pending flag (and note if an overflow occurred)
     irq_disable();
@@ -168,12 +158,12 @@ hx71x_read_adc(struct hx71x_adc *hx71x, uint8_t oid)
     irq_enable();
 
     // Extract report from raw data
-    uint32_t counts = adc >> extra_bits;
+    uint32_t counts = adc >> setting_pulses;
     if (counts & 0x800000)
         counts |= 0xFF000000;
 
     // Check for errors
-    uint_fast8_t extras_mask = (1 << extra_bits) - 1;
+    uint_fast8_t extras_mask = (1 << setting_pulses) - 1;
     if ((adc & extras_mask) != extras_mask) {
         // Transfer did not complete correctly
         hx71x->last_error = SAMPLE_ERROR_DESYNC;
@@ -203,24 +193,17 @@ command_config_hx71x(uint32_t *args)
     struct hx71x_adc *hx71x = oid_alloc(args[0]
                 , command_config_hx71x, sizeof(*hx71x));
     hx71x->timer.func = hx71x_event;
-    uint8_t gain_or_sps = args[1];
-    uint8_t sps_bits = args[2];
-    uint8_t gain_channel = args[3];
-    if (gain_or_sps == 0 && (gain_channel < 1 || gain_channel > 4)) {
-        shutdown("HX71x gain/channel out of range 1-4");
+    uint8_t setting_pulses = args[1];
+    if (setting_pulses < 1 || setting_pulses > 4) {
+        shutdown("HX71x setting_pulses out of range 1-4");
     }
-    if (gain_or_sps == 1 && (sps_bits < 1 || sps_bits > 4)) {
-        shutdown("HX71x sample_rate out of range 1-4");
-    }
-    hx71x->gain_or_sps = gain_or_sps;
-    hx71x->sps_bits = sps_bits;
-    hx71x->gain_channel = gain_channel;
-    hx71x->dout = gpio_in_setup(args[4], 1);
-    hx71x->sclk = gpio_out_setup(args[5], 0);
+    hx71x->setting_pulses = setting_pulses;
+    hx71x->dout = gpio_in_setup(args[2], 1);
+    hx71x->sclk = gpio_out_setup(args[3], 0);
     gpio_out_write(hx71x->sclk, 1); // put chip in power down state
 }
-DECL_COMMAND(command_config_hx71x, "config_hx71x oid=%c gain_or_sps=%c"
-             " sps_bits=%c gain_channel=%c dout_pin=%u sclk_pin=%u");
+DECL_COMMAND(command_config_hx71x, "config_hx71x oid=%c setting_pulses=%c"
+             " dout_pin=%u sclk_pin=%u");
 
 void
 hx71x_attach_load_cell_probe(uint32_t *args) {

--- a/test/klippy/load_cell.cfg
+++ b/test/klippy/load_cell.cfg
@@ -17,3 +17,7 @@ dout_pin: PA3
 sensor_type: hx717
 sclk_pin: PA4
 dout_pin: PA5
+[load_cell my_hx71708]
+sensor_type: hx717
+sclk_pin: PA6
+dout_pin: PA7


### PR DESCRIPTION
This is the code to integrate the HX71708 variant of the HX71x sensor family. This has been initially developed and tested out by @EllaFoxo.

There is a refactor of the of the MCU command so that you are commanding a sequence of bits that will be sent at the end of each sampling loop.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
