### PR TITLE
tempfile: Use gettempdir rather than hardcoded /tmp

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -8,6 +8,7 @@ import logging
 import math
 import multiprocessing
 import os
+import tempfile
 import time
 
 from . import bulk_sensor, bus
@@ -189,10 +190,15 @@ class AccelCommandHelper:
         self.bg_client = None
         bg_client.finish_measurements()
         # Write data to file
+        tmpdir = tempfile.gettempdir()
         if self.base_name == self.name:
-            filename = "/tmp/%s-%s.csv" % (self.base_name, name)
+            filename = os.path.join(
+                tmpdir, "%s-%s.csv" % (self.base_name, name)
+            )
         else:
-            filename = "/tmp/%s-%s-%s.csv" % (self.base_name, self.name, name)
+            filename = os.path.join(
+                tmpdir, "%s-%s-%s.csv" % (self.base_name, self.name, name)
+            )
         bg_client.write_to_file(filename)
         gcmd.respond_info(
             "Writing raw accelerometer data to %s file" % (filename,)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -5,6 +5,8 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 import math
+import os
+import tempfile
 
 from . import heaters
 
@@ -81,9 +83,10 @@ class PIDCalibrate:
         heater.set_control(old_control, False)
 
         if write_file:
-            fname = "/tmp/heattest.csv"
+            tmpdir = tempfile.gettempdir()
+            fname = os.path.join(tmpdir, "heattest.csv")
             if calibrate_secondary:
-                fname = "/tmp/heattest_secondary.csv"
+                fname = os.path.join(tmpdir, "heattest_secondary.csv")
             calibrate.write_file(fname)
 
         if calibrate.check_busy(0.0, 0.0, 0.0):

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -6,6 +6,7 @@
 import logging
 import math
 import os
+import tempfile
 import time
 from contextlib import contextmanager
 
@@ -649,7 +650,7 @@ class ResonanceTester:
         if point:
             name += "_%.3f_%.3f_%.3f" % (point[0], point[1], point[2])
         name += "_" + name_suffix
-        return os.path.join("/tmp", name + ".csv")
+        return os.path.join(tempfile.gettempdir(), name + ".csv")
 
     def save_calibration_data(
         self,


### PR DESCRIPTION
On some systems it's not desirable to write large files to ram disk due to limited ram.
Using pythons built-in `tempfile` module and `gettempdir` allows one to change the location of the temp directory using environmental variables, rather than having to patch the hardcoded `/tmp` directory in kalico source code.
This is consistent with how moonraker handles tempdirs.
The default behavior is not changed as it will use `/tmp` if `TMPDIR` is not defined as a environmental variable.

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
