### PR TITLE
Extend and Improve Interruption

### DIFF
--- a/klippy/exceptions.py
+++ b/klippy/exceptions.py
@@ -1,0 +1,13 @@
+# Exceptions that are broadly used in the klippy codebase
+#
+# Copyright (C) 2026  Gareth Farrington <gareth@waves.ky>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+
+class CommandError(Exception):
+    pass
+
+
+class WaitInterruption(CommandError):
+    pass

--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -30,6 +30,7 @@ class PauseResume:
             "CANCEL_PRINT",
             self.cmd_CANCEL_PRINT,
             desc=self.cmd_CANCEL_PRINT_help,
+            trigger_interrupt=True,
         )
         webhooks = self.printer.lookup_object("webhooks")
         webhooks.register_endpoint(

--- a/klippy/extras/trad_rack.py
+++ b/klippy/extras/trad_rack.py
@@ -2317,6 +2317,7 @@ class TradRackToolHead(toolhead.ToolHead, object):
     def __init__(self, config, buffer_pull_speed, is_extruder_synced):
         self.printer = config.get_printer()
         self.danger_options = self.printer.lookup_object("danger_options")
+        self.gcode = self.printer.lookup_object("gcode")
         self.reactor = self.printer.get_reactor()
         self.all_mcus = [
             m for n, m in self.printer.lookup_objects(module="mcu")

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -314,7 +314,6 @@ class VirtualSD:
                 self.reactor.pause(self.reactor.monotonic() + 0.100)
                 continue
             # Dispatch command
-            self.cmd_from_sd = True
             line = lines.pop()
             if sys.version_info.major >= 3:
                 next_file_position = self.file_position + len(line.encode()) + 1
@@ -322,10 +321,12 @@ class VirtualSD:
                 next_file_position = self.file_position + len(line) + 1
             self.next_file_position = next_file_position
             try:
+                self.cmd_from_sd = True
                 self.gcode.run_script(line)
             except self.gcode.error as e:
                 error_message = str(e)
                 try:
+                    self.cmd_from_sd = False
                     self.gcode.run_script(self.on_error_gcode.render())
                 except:
                     logging.exception("virtual_sdcard on_error")
@@ -333,7 +334,8 @@ class VirtualSD:
             except:
                 logging.exception("virtual_sdcard dispatch")
                 break
-            self.cmd_from_sd = False
+            finally:
+                self.cmd_from_sd = False
             self.file_position = self.next_file_position
             # Do we need to skip around?
             if self.next_file_position != next_file_position:
@@ -343,6 +345,8 @@ class VirtualSD:
                     logging.exception("virtual_sdcard seek")
                     self.work_timer = None
                     return self.reactor.NEVER
+                finally:
+                    self.cmd_from_sd = False
                 lines = []
                 partial_input = ""
         logging.info("Exiting SD card print (position %d)", self.file_position)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -9,18 +9,20 @@ import os
 import re
 import shlex
 
+import klippy.exceptions as klippy_ex
+
 from . import mathutil
 
-
-class CommandError(Exception):
-    pass
+# legacy export, use exceptions.CommandError
+CommandError = klippy_ex.CommandError
 
 
 Coord = collections.namedtuple("Coord", ("x", "y", "z", "e"))
 
 
 class GCodeCommand:
-    error = CommandError
+    # legacy export, use exceptions.CommandError
+    error = klippy_ex.CommandError
 
     def __init__(self, gcode, command, commandline, params, need_ack):
         self._command = command
@@ -84,33 +86,33 @@ class GCodeCommand:
         value = self._params.get(name)
         if value is None:
             if default is self.sentinel:
-                raise self.error(
+                raise klippy_ex.CommandError(
                     "Error on '%s': missing %s" % (self._commandline, name)
                 )
             return default
         try:
             value = parser(value)
         except:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Error on '%s': unable to parse %s" % (self._commandline, value)
             )
         if minval is not None and value < minval:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Error on '%s': %s must have minimum of %s"
                 % (self._commandline, name, minval)
             )
         if maxval is not None and value > maxval:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Error on '%s': %s must have maximum of %s"
                 % (self._commandline, name, maxval)
             )
         if above is not None and value <= above:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Error on '%s': %s must be above %s"
                 % (self._commandline, name, above)
             )
         if below is not None and value >= below:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Error on '%s': %s must be below %s"
                 % (self._commandline, name, below)
             )
@@ -316,7 +318,7 @@ class GCodeDispatch:
             handler = self.gcode_handlers.get(cmd, self.cmd_default)
             try:
                 handler(gcmd)
-            except self.error as e:
+            except klippy_ex.CommandError as e:
                 self._respond_error(str(e))
                 self.printer.send_event("gcode:command_error")
                 if not need_ack:
@@ -384,7 +386,7 @@ class GCodeDispatch:
             eparams = [earg.split("=", 1) for earg in s]
             eparams = {k.upper(): v for k, v in eparams}
         except ValueError as e:
-            raise self.error(
+            raise klippy_ex.CommandError(
                 "Malformed command '%s'" % (gcmd.get_commandline(),)
             )
         # Update gcmd with new parameters

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -74,6 +74,9 @@ class GCodeCommand:
             param_start += 1
         return origline[param_start:param_end]
 
+    def get_need_ack(self):
+        return self._need_ack
+
     def ack(self, msg=None):
         if not self._need_ack:
             return False
@@ -464,72 +467,103 @@ class GCodeDispatch:
     # Parse input into commands
     args_r = re.compile("([A-Z_]+|[A-Z*])")
 
-    def _process_commands(self, commands, need_ack=True):
+    def _parse_command_line(self, line: str):
+        # Ignore comments and leading/trailing spaces
+        line = stripped_line = line.strip()
+        cpos = line.find(";")
+        if cpos >= 0:
+            line = line[:cpos]
+        # Break line into parts and determine command
+        parts = self.args_r.split(line.upper())
+        if "".join(parts[:2]) == "N":
+            # Skip line number at start of command
+            cmd = "".join(parts[3:5]).strip()
+        else:
+            cmd = "".join(parts[:3]).strip()
+        # Build gcode "params" dictionary
+        params = {
+            parts[i]: parts[i + 1].strip() for i in range(1, len(parts), 2)
+        }
+        return cmd, params, stripped_line
+
+    def _process_command(self, gcmd: GCodeCommand):
+        handler = self.gcode_handlers.get(gcmd.get_command(), self.cmd_default)
+        self._gcmd_stacks.push(gcmd)
+        try:
+            # raise interrupted exception if interrupted
+            gcmd.check_interrupted()
+            handler(gcmd)
+        except klippy_ex.CommandError as e:
+            self._respond_error(str(e))
+            self.printer.send_event("gcode:command_error")
+            if not gcmd.get_need_ack():
+                raise
+        except:
+            msg = 'Internal error on command:"%s"' % (gcmd.get_command(),)
+            logging.exception(msg)
+            self.printer.invoke_shutdown(msg)
+            self._respond_error(msg)
+            if not gcmd.get_need_ack():
+                raise
+        finally:
+            self._gcmd_stacks.pop(gcmd)
+        gcmd.ack()
+
+    def _process_commands_loop(self, commands, need_ack=True):
         for line in commands:
-            # Ignore comments and leading/trailing spaces
-            line = origline = line.strip()
-            cpos = line.find(";")
-            if cpos >= 0:
-                line = line[:cpos]
-            # Break line into parts and determine command
-            parts = self.args_r.split(line.upper())
-            if "".join(parts[:2]) == "N":
-                # Skip line number at start of command
-                cmd = "".join(parts[3:5]).strip()
-            else:
-                cmd = "".join(parts[:3]).strip()
-            # Build gcode "params" dictionary
-            params = {
-                parts[i]: parts[i + 1].strip() for i in range(1, len(parts), 2)
-            }
-            if cmd in self.trigger_interrupt_commands:
-                self._trigger_interrupt()
-            gcmd = GCodeCommand(
-                self,
-                cmd,
-                origline,
-                params,
-                need_ack,
-                self._gcmd_stacks.create_interrupt_token(),
-            )
-            # Invoke handler for command
+            cmd, params, line = self._parse_command_line(line)
+            # RETURN from gcode macro
             if self._script_context > 0 and cmd == "RETURN":
                 return
-            handler = self.gcode_handlers.get(cmd, self.cmd_default)
-            self._gcmd_stacks.push(gcmd)
-            try:
-                # raise interrupted exception if interrupted
-                gcmd.check_interrupted()
-                handler(gcmd)
-            except klippy_ex.CommandError as e:
-                self._respond_error(str(e))
-                self.printer.send_event("gcode:command_error")
-                if not need_ack:
-                    raise
-            except:
-                msg = 'Internal error on command:"%s"' % (cmd,)
-                logging.exception(msg)
-                self.printer.invoke_shutdown(msg)
-                self._respond_error(msg)
-                if not need_ack:
-                    raise
-            finally:
-                self._gcmd_stacks.pop(gcmd)
-            gcmd.ack()
+            if cmd in self.trigger_interrupt_commands:
+                # release the mutex so this thread will suspend on mutex.lock()
+                # to allow all interrupted threads to finish first when
+                # it waits to re-acquire the lock
+                if self.mutex.owns_lock():
+                    self.mutex.unlock()
+                # causes all waiters of the mutex to get an exception
+                self._trigger_interrupt()
+            gcmd: GCodeCommand = GCodeCommand(
+                self,
+                cmd,
+                line,
+                params,
+                need_ack,
+                # acquires the token after the interrupt, this command
+                # belongs to the next generation of commands
+                self._gcmd_stacks.create_interrupt_token(),
+            )
+            # take lock once per loop
+            if not self.mutex.owns_lock():
+                self.mutex.lock()
+            self._process_command(gcmd)
+
+    def _process_commands(self, commands, need_ack=True):
+        if self.mutex.owns_lock():
+            raise RuntimeError(
+                "The current greenlet already owns the lock! Did "
+                "you mean to call run_script_from_command()?"
+            )
+        try:
+            self._process_commands_loop(commands, need_ack)
+        finally:
+            if self.mutex.owns_lock():
+                self.mutex.unlock()
 
     def run_script_from_command(self, script):
+        if not self.mutex.owns_lock():
+            raise RuntimeError(
+                "The current greenlet does not own the lock! "
+                "Did you mean to call run_script()?"
+            )
         self._script_context += 1
         try:
-            self._process_commands(script.split("\n"), need_ack=False)
+            self._process_commands_loop(script.split("\n"), need_ack=False)
         finally:
             self._script_context -= 1
 
     def run_script(self, script):
-        if "INTERRUPT" in script:
-            self._process_commands(script.split("\n"), need_ack=False)
-        else:
-            with self.mutex:
-                self._process_commands(script.split("\n"), need_ack=False)
+        self._process_commands(script.split("\n"), need_ack=False)
 
     def get_mutex(self):
         return self.mutex
@@ -715,7 +749,6 @@ class GCodeIO:
         printer.register_event_handler("klippy:ready", self._handle_ready)
         printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
         self.gcode = printer.lookup_object("gcode")
-        self.gcode_mutex = self.gcode.get_mutex()
         self.fd = printer.get_start_args().get("gcode_fd")
         self.reactor = printer.get_reactor()
         self.is_printer_ready = False
@@ -796,8 +829,7 @@ class GCodeIO:
         self.is_processing_data = True
         while pending_commands:
             self.pending_commands = []
-            with self.gcode_mutex:
-                self.gcode._process_commands(pending_commands)
+            self.gcode._process_commands(pending_commands)
             pending_commands = self.pending_commands
         self.is_processing_data = False
         if self.fd_handle is None:

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -309,26 +309,34 @@ class GCodeDispatch:
         self.ready_gcode_handlers = {}
         self.mux_commands = {}
         self.gcode_help = {}
+        # Name-bound policy: intentionally survives unregister/rename_existing.
+        self.trigger_interrupt_commands = set()
         self.status_commands = {}
         self._gcmd_stacks = GCodeCommandStacks(printer)
         self._script_context = 0
         # Register commands needed before config file is loaded
-        handlers = [
-            "M110",
-            "M112",
-            "M115",
-            "RESTART",
-            "FIRMWARE_RESTART",
-            "ECHO",
-            "STATUS",
-            "HELP",
-            "HEATER_INTERRUPT",
-            "LOG_ROLLOVER",
-        ]
-        for cmd in handlers:
+        handlers: dict[str, bool] = {
+            "M110": False,
+            "M112": False,
+            "M115": False,
+            "RESTART": False,
+            "FIRMWARE_RESTART": False,
+            "ECHO": False,
+            "STATUS": False,
+            "HELP": False,
+            "LOG_ROLLOVER": False,
+            "HEATER_INTERRUPT": True,
+        }
+        for cmd, interrupt in handlers.items():
             func = getattr(self, "cmd_" + cmd)
             desc = getattr(self, "cmd_" + cmd + "_help", None)
-            self.register_command(cmd, func, True, desc)
+            self.register_command(
+                cmd,
+                func,
+                when_not_ready=True,
+                desc=desc,
+                trigger_interrupt=interrupt,
+            )
 
     # get the token for the active GCodeCommand context
     def get_interrupt_token(self) -> InterruptToken:
@@ -351,7 +359,14 @@ class GCodeDispatch:
         except:
             return False
 
-    def register_command(self, cmd, func, when_not_ready=False, desc=None):
+    def register_command(
+        self,
+        cmd,
+        func,
+        when_not_ready=False,
+        desc=None,
+        trigger_interrupt=False,
+    ):
         if func is None:
             old_cmd = self.ready_gcode_handlers.get(cmd)
             if cmd in self.ready_gcode_handlers:
@@ -381,6 +396,8 @@ class GCodeDispatch:
             def func(params):
                 return origfunc(self._get_extended_params(params))
 
+        if trigger_interrupt:
+            self.trigger_interrupt_commands.add(cmd)
         self.ready_gcode_handlers[cmd] = func
         if when_not_ready:
             self.base_gcode_handlers[cmd] = func
@@ -465,6 +482,8 @@ class GCodeDispatch:
             params = {
                 parts[i]: parts[i + 1].strip() for i in range(1, len(parts), 2)
             }
+            if cmd in self.trigger_interrupt_commands:
+                self._trigger_interrupt()
             gcmd = GCodeCommand(
                 self,
                 cmd,
@@ -683,7 +702,7 @@ class GCodeDispatch:
         gcmd.respond_info("\n".join(cmdhelp), log=False)
 
     def cmd_HEATER_INTERRUPT(self, gcmd):
-        self._trigger_interrupt()
+        pass
 
     def cmd_LOG_ROLLOVER(self, gcmd):
         self.printer.bglogger.doRollover()

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -3,15 +3,22 @@
 # Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import collections
 import logging
 import os
 import re
 import shlex
+from typing import Optional
+from weakref import WeakKeyDictionary
+
+import greenlet
 
 import klippy.exceptions as klippy_ex
 
 from . import mathutil
+from .reactor import ReactorCompletion, SelectReactor
 
 # legacy export, use exceptions.CommandError
 CommandError = klippy_ex.CommandError
@@ -24,11 +31,21 @@ class GCodeCommand:
     # legacy export, use exceptions.CommandError
     error = klippy_ex.CommandError
 
-    def __init__(self, gcode, command, commandline, params, need_ack):
+    def __init__(
+        self,
+        gcode: GCodeDispatch,
+        command,
+        commandline,
+        params,
+        need_ack,
+        interrupt_token: Optional[InterruptToken],
+    ):
+        self._printer = gcode.printer
         self._command = command
         self._commandline = commandline
         self._params = params
         self._need_ack = need_ack
+        self._interrupt_token: InterruptToken = interrupt_token
         # Method wrappers
         self.respond_info = gcode.respond_info
         self.respond_raw = gcode.respond_raw
@@ -140,6 +157,136 @@ class GCodeCommand:
             below=below,
         )
 
+    def was_interrupted(self):
+        self._interrupt_token.test()
+
+    # if the command was interrupted, throws WaitInterruption
+    def check_interrupted(self):
+        self._interrupt_token.check_interrupted()
+
+    def get_interrupt_token(self) -> InterruptToken:
+        return self._interrupt_token
+
+    def wait_while(self, condition_cb, interval=1.0):
+        """
+        receives a callback
+        waits until callback returns False
+            (or is interrupted, or printer shuts down)
+        """
+        eventtime = self._printer.get_reactor().monotonic()
+        while condition_cb(eventtime):
+            self._interrupt_token.wait_until(eventtime + interval)
+            eventtime = self._printer.get_reactor().monotonic()
+
+    def delay(self, delay_time):
+        """
+        waits for delay_time seconds
+            (unless interrupted, or printer shuts down)
+        """
+        waketime = self._printer.get_reactor().monotonic() + delay_time
+        self._interrupt_token.wait_until(waketime)
+
+
+class InterruptedSentinel:
+    pass
+
+
+# wrap a ReactorCompletion so callers cannot call complete()
+class InterruptToken:
+    def __init__(self, printer, completion: ReactorCompletion):
+        self._printer = printer
+        self._completion = completion
+
+    def test(self) -> bool:
+        """
+        Test for interruption, returns True if interrupted
+        """
+        return self._completion.test() or self._printer.is_shutdown()
+
+    def check_interrupted(self) -> bool:
+        """
+        Test for interruption and throws WaitInterruption if interrupted
+        or returns False
+        """
+        if self.test():
+            raise klippy_ex.WaitInterruption("Command Interrupted")
+        return False
+
+    def wait(self, waketime=SelectReactor.NEVER) -> bool:
+        """
+        Wait until waketime, return the value of test()
+        """
+        if not self.test():
+            self._completion.wait(waketime, None)
+        return self.test()
+
+    def wait_until(
+        self, waketime=SelectReactor.NEVER, error_on_interrupt=True
+    ) -> bool:
+        """
+        Wait until waketime, the value of test(), raise WaitInterruption if interrupted
+        """
+        self.wait(waketime)
+        if error_on_interrupt:
+            self.check_interrupted()
+        return self.test()
+
+
+class GCodeCommandStacks:
+    def __init__(self, printer):
+        self._printer = printer
+        # weak keys, so greenlets can be garbage collected without coordination
+        self._gcmd_stacks: WeakKeyDictionary[
+            greenlet.greenlet, collections.deque[GCodeCommand]
+        ] = WeakKeyDictionary()
+        self._interrupt_completion = printer.get_reactor().completion()
+
+    def _get_stack(self) -> Optional[collections.deque[GCodeCommand]]:
+        return self._gcmd_stacks.get(greenlet.getcurrent(), None)
+
+    def _get_default_stack(self) -> collections.deque[GCodeCommand]:
+        current_greenlet = greenlet.getcurrent()
+        if current_greenlet not in self._gcmd_stacks:
+            self._gcmd_stacks[current_greenlet] = collections.deque()
+        return self._gcmd_stacks.get(current_greenlet)
+
+    def create_interrupt_token(self):
+        """
+        Create an interrupt token based directly on the interrupt_completion
+        """
+        return InterruptToken(self._printer, self._interrupt_completion)
+
+    def get_interrupt_token(self) -> InterruptToken:
+        """
+        Get the InterruptToken for the currently executing GCodeCommand on
+        the active greenlet.
+        """
+        gcmd_stack = self._get_stack()
+        if gcmd_stack:
+            return gcmd_stack[-1].get_interrupt_token()
+        return self.create_interrupt_token()
+
+    def push(self, gcmd: GCodeCommand):
+        self._get_default_stack().append(gcmd)
+
+    def pop(self, gcmd: GCodeCommand):
+        current_greenlet = greenlet.getcurrent()
+        gcmd_stack = self._get_stack()
+        if not gcmd_stack:
+            raise RuntimeError("GCode command stack corrupted")
+        popped_gcmd = gcmd_stack.pop()
+        if popped_gcmd is not gcmd:
+            raise RuntimeError("GCode command stack corrupted")
+        if not gcmd_stack:
+            del self._gcmd_stacks[current_greenlet]
+
+    def trigger_interrupt(self):
+        self._interrupt_completion.complete(InterruptedSentinel)
+        self._interrupt_completion = self._printer.get_reactor().completion()
+
+    def async_trigger_interrupt(self):
+        self._printer.get_reactor().register_callback(self.trigger_interrupt)
+
 
 # Parse and dispatch G-Code commands
 class GCodeDispatch:
@@ -163,7 +310,7 @@ class GCodeDispatch:
         self.mux_commands = {}
         self.gcode_help = {}
         self.status_commands = {}
-        self._interrupt_counter = 0
+        self._gcmd_stacks = GCodeCommandStacks(printer)
         self._script_context = 0
         # Register commands needed before config file is loaded
         handlers = [
@@ -183,11 +330,13 @@ class GCodeDispatch:
             desc = getattr(self, "cmd_" + cmd + "_help", None)
             self.register_command(cmd, func, True, desc)
 
-    def get_interrupt_counter(self):
-        return self._interrupt_counter
+    # get the token for the active GCodeCommand context
+    def get_interrupt_token(self) -> InterruptToken:
+        return self._gcmd_stacks.get_interrupt_token()
 
-    def increment_interrupt_counter(self):
-        self._interrupt_counter += 1
+    # trigger interrupt from another OS thread safely
+    def async_trigger_interrupt(self):
+        self._gcmd_stacks.async_trigger_interrupt()
 
     def is_traditional_gcode(self, cmd):
         # A "traditional" g-code command is a letter and followed by a number
@@ -274,6 +423,7 @@ class GCodeDispatch:
         self.output_callbacks.append(cb)
 
     def _handle_shutdown(self):
+        self._gcmd_stacks.trigger_interrupt()
         if not self.is_printer_ready:
             return
         self.is_printer_ready = False
@@ -311,12 +461,22 @@ class GCodeDispatch:
             params = {
                 parts[i]: parts[i + 1].strip() for i in range(1, len(parts), 2)
             }
-            gcmd = GCodeCommand(self, cmd, origline, params, need_ack)
+            gcmd = GCodeCommand(
+                self,
+                cmd,
+                origline,
+                params,
+                need_ack,
+                self._gcmd_stacks.create_interrupt_token(),
+            )
             # Invoke handler for command
             if self._script_context > 0 and cmd == "RETURN":
                 return
             handler = self.gcode_handlers.get(cmd, self.cmd_default)
+            self._gcmd_stacks.push(gcmd)
             try:
+                # raise interrupted exception if interrupted
+                gcmd.check_interrupted()
                 handler(gcmd)
             except klippy_ex.CommandError as e:
                 self._respond_error(str(e))
@@ -330,6 +490,8 @@ class GCodeDispatch:
                 self._respond_error(msg)
                 if not need_ack:
                     raise
+            finally:
+                self._gcmd_stacks.pop(gcmd)
             gcmd.ack()
 
     def run_script_from_command(self, script):
@@ -350,7 +512,14 @@ class GCodeDispatch:
         return self.mutex
 
     def create_gcode_command(self, command, commandline, params):
-        return GCodeCommand(self, command, commandline, params, False)
+        return GCodeCommand(
+            self,
+            command,
+            commandline,
+            params,
+            False,
+            self.get_interrupt_token(),
+        )
 
     # Response handling
     def respond_raw(self, msg):
@@ -510,7 +679,7 @@ class GCodeDispatch:
         gcmd.respond_info("\n".join(cmdhelp), log=False)
 
     def cmd_HEATER_INTERRUPT(self, gcmd):
-        self.increment_interrupt_counter()
+        self._gcmd_stacks.trigger_interrupt()
 
     def cmd_LOG_ROLLOVER(self, gcmd):
         self.printer.bglogger.doRollover()

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -334,9 +334,13 @@ class GCodeDispatch:
     def get_interrupt_token(self) -> InterruptToken:
         return self._gcmd_stacks.get_interrupt_token()
 
+    def _trigger_interrupt(self):
+        self._gcmd_stacks.trigger_interrupt()
+        self.mutex.throw(klippy_ex.WaitInterruption("Command Interrupted"))
+
     # trigger interrupt from another OS thread safely
     def async_trigger_interrupt(self):
-        self._gcmd_stacks.async_trigger_interrupt()
+        self.printer.get_reactor().register_callback(self._trigger_interrupt)
 
     def is_traditional_gcode(self, cmd):
         # A "traditional" g-code command is a letter and followed by a number
@@ -423,7 +427,7 @@ class GCodeDispatch:
         self.output_callbacks.append(cb)
 
     def _handle_shutdown(self):
-        self._gcmd_stacks.trigger_interrupt()
+        self._trigger_interrupt()
         if not self.is_printer_ready:
             return
         self.is_printer_ready = False
@@ -679,7 +683,7 @@ class GCodeDispatch:
         gcmd.respond_info("\n".join(cmdhelp), log=False)
 
     def cmd_HEATER_INTERRUPT(self, gcmd):
-        self._gcmd_stacks.trigger_interrupt()
+        self._trigger_interrupt()
 
     def cmd_LOG_ROLLOVER(self, gcmd):
         self.printer.bglogger.doRollover()

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Generator, Optional, Union
 
+import klippy.exceptions as klippy_ex
 from klippy.configfile import ConfigWrapper
 
 from . import (
@@ -79,9 +80,8 @@ config, and restart the host software.
 Printer is shutdown
 """
 
-
-class WaitInterruption(gcode.CommandError):
-    pass
+# legacy export, use exceptions.WaitInterruption
+WaitInterruption = klippy_ex.WaitInterruption
 
 
 class SubsystemComponentCollection:
@@ -156,7 +156,10 @@ class PrinterModule:
 
 class Printer:
     config_error = configfile.error
-    command_error = gcode.CommandError
+    # legacy export, use exceptions.CommandError
+    command_error = klippy_ex.CommandError
+    # legacy export, use exceptions.WaitInterruption
+    wait_interrupted = WaitInterruption
 
     def __init__(self, main_reactor, bglogger, start_args):
         if sys.version_info[0] < 3:
@@ -499,8 +502,6 @@ class Printer:
             self.run_result = result
         self.reactor.end()
 
-    wait_interrupted = WaitInterruption
-
     def wait_while(self, condition_cb, error_on_cancel=True, interval=1.0):
         """
         receives a callback
@@ -513,7 +514,7 @@ class Printer:
         while condition_cb(eventtime):
             if self.is_shutdown() or counter != gcode.get_interrupt_counter():
                 if error_on_cancel:
-                    raise WaitInterruption("Command interrupted")
+                    raise klippy_ex.WaitInterruption("Command interrupted")
                 else:
                     return
             eventtime = self.reactor.pause(eventtime + interval)

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -509,15 +509,14 @@ class Printer:
             (or is interrupted, or printer shuts down)
         """
         gcode = self.lookup_object("gcode")
-        counter = gcode.get_interrupt_counter()
+        interrupt_token = gcode.get_interrupt_token()
         eventtime = self.reactor.monotonic()
         while condition_cb(eventtime):
-            if self.is_shutdown() or counter != gcode.get_interrupt_counter():
-                if error_on_cancel:
-                    raise klippy_ex.WaitInterruption("Command interrupted")
-                else:
-                    return
-            eventtime = self.reactor.pause(eventtime + interval)
+            if interrupt_token.wait_until(
+                eventtime + interval, error_on_interrupt=error_on_cancel
+            ):
+                return
+            eventtime = self.reactor.monotonic()
 
 
 ######################################################################

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -88,33 +88,60 @@ class ReactorMutex:
     def __init__(self, reactor, is_locked):
         self.reactor = reactor
         self.is_locked = is_locked
+        self.owner = None
         self.next_pending = False
         self.queue = []
+        self.pending_exceptions = {}
         self.lock = self.__enter__
         self.unlock = self.__exit__
 
     def test(self):
         return self.is_locked
 
+    def owns_lock(self):
+        return self.owner is greenlet.getcurrent()
+
     def __enter__(self):
         if not self.is_locked:
             self.is_locked = True
+            self.owner = greenlet.getcurrent()
             return
         g = greenlet.getcurrent()
         self.queue.append(g)
         while True:
             self.reactor.pause(self.reactor.NEVER)
+            exc = self.pending_exceptions.pop(g, None)
+            if exc is not None:
+                self.queue.remove(g)
+                if self.next_pending:
+                    # wake next pending. __exit__ won't run for this greenlet
+                    # because it never successfully completes __enter__
+                    if self.queue:
+                        self.reactor.update_timer(
+                            self.queue[0].timer, self.reactor.NOW
+                        )
+                    else:
+                        self.next_pending = False
+                        self.is_locked = False
+                raise exc
             if self.next_pending and self.queue[0] is g:
                 self.next_pending = False
                 self.queue.pop(0)
+                self.owner = g
                 return
 
     def __exit__(self, type=None, value=None, tb=None):
+        self.owner = None
         if not self.queue:
             self.is_locked = False
             return
         self.next_pending = True
         self.reactor.update_timer(self.queue[0].timer, self.reactor.NOW)
+
+    def throw(self, exception):
+        for g in list(self.queue):
+            self.pending_exceptions[g] = exception
+            self.reactor.update_timer(g.timer, self.reactor.NOW)
 
 
 class SelectReactor:

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -203,6 +203,31 @@ class SelectReactor:
     def completion(self):
         return ReactorCompletion(self)
 
+    def completion_any(self, child_completions):
+        if len(child_completions) == 1:
+            return child_completions[0]
+        any_completion = self.completion()
+        waiting_greenlets = set()
+
+        def complete_once(child_completion):
+            if any_completion.test():
+                return
+            g = greenlet.getcurrent()
+            waiting_greenlets.add(g)
+            result = child_completion.wait()
+            # complete only once, don't overwrite the completion value
+            if any_completion.test():
+                return
+            any_completion.complete(result)
+            # wake remaining tasks to allow them to return
+            for waiting in waiting_greenlets:
+                if waiting is not g:
+                    self.update_timer(waiting.timer, self.NOW)
+
+        for child in child_completions:
+            self.register_callback(lambda e, c=child: complete_once(c))
+        return any_completion
+
     def register_callback(self, callback, waketime=NOW):
         rcb = ReactorCallback(self, callback, waketime)
         return rcb.completion

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -3,13 +3,18 @@
 # Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+
 import importlib
 import logging
 import math
 
 from . import chelper
+from .exceptions import WaitInterruption
 from .extras.danger_options import get_danger_options
+from .gcode import GCodeDispatch, InterruptToken
 from .kinematics import extruder as kinematics_extruder
+from .reactor import ReactorCompletion, SelectReactor
 
 # Common suffixes: _d is distance (in mm), _v is velocity (in
 #   mm/second), _v2 is velocity squared (mm^2/s^2), _t is time (in
@@ -253,11 +258,38 @@ DRIP_SEGMENT_TIME = 0.050
 DRIP_TIME = 0.100
 
 
+class DripMoveCompletion:
+    def __init__(
+        self,
+        reactor: SelectReactor,
+        drip_completion: ReactorCompletion,
+        interrupt_token: InterruptToken,
+    ):
+        self.drip_completion = drip_completion
+        self.interrupt_token = interrupt_token
+        self.wait_completion = drip_completion
+        if interrupt_token:
+            self.wait_completion = reactor.completion_any(
+                [drip_completion, interrupt_token]
+            )
+
+    def check(self):
+        return (
+            self.interrupt_token.check_interrupted()
+            or self.drip_completion.test()
+        )
+
+    def wait(self, waketime):
+        self.wait_completion.wait(waketime)
+        self.check()
+
+
 # Main code to track events (and their timing) on the printer toolhead
 class ToolHead:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
+        self.gcode: GCodeDispatch = self.printer.lookup_object("gcode")
         self.all_mcus = [
             m for n, m in self.printer.lookup_objects(module="mcu")
         ]
@@ -532,7 +564,9 @@ class ToolHead:
             if not self.can_pause:
                 self.need_check_pause = self.reactor.NEVER
                 return
-            eventtime = self.reactor.pause(eventtime + min(1.0, pause_time))
+            interrupt_token = self.gcode.get_interrupt_token()
+            interrupt_token.wait_until(eventtime + min(1.0, pause_time))
+            eventtime = self.reactor.monotonic()
             est_print_time = self.mcu.estimated_print_time(eventtime)
             buffer_time = self.print_time - est_print_time
         if not self.special_queuing_state:
@@ -607,6 +641,7 @@ class ToolHead:
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
             return
+        self.gcode.get_interrupt_token().check_interrupted()
         if move.is_kinematic_move:
             self.kin.check_move(move)
         for e_index, ea in enumerate(self.extra_axes):
@@ -641,7 +676,9 @@ class ToolHead:
         ):
             if not self.can_pause:
                 break
-            eventtime = self.reactor.pause(eventtime + 0.100)
+            interrupt_token = self.gcode.get_interrupt_token()
+            interrupt_token.wait_until(eventtime + 0.100)
+            eventtime = self.reactor.monotonic()
 
     def set_extruder(self, extruder, extrude_pos):
         # XXX - should use add_extra_axis
@@ -693,7 +730,7 @@ class ToolHead:
         # Update print_time in segments until drip_completion signal
         flush_delay = DRIP_TIME + STEPCOMPRESS_FLUSH_TIME + self.kin_flush_delay
         while self.print_time < next_print_time:
-            if drip_completion.test():
+            if drip_completion.check():
                 break
             curtime = self.reactor.monotonic()
             est_print_time = self.mcu.estimated_print_time(curtime)
@@ -714,50 +751,62 @@ class ToolHead:
         self.flush_step_generation()
 
     def _drip_load_trapq(self, submit_move):
-        # Queue move into trapezoid motion queue (trapq)
-        if submit_move.move_d:
-            self.commanded_pos[:] = submit_move.end_pos
-            self.lookahead.add_move(submit_move)
-        moves = self.lookahead.flush()
-        self._calc_print_time()
-        next_move_time = self.print_time
-        for move in moves:
-            self.trapq_append(
-                self.trapq,
-                next_move_time,
-                move.accel_t,
-                move.cruise_t,
-                move.decel_t,
-                move.start_pos[0],
-                move.start_pos[1],
-                move.start_pos[2],
-                move.axes_r[0],
-                move.axes_r[1],
-                move.axes_r[2],
-                move.start_v,
-                move.cruise_v,
-                move.accel,
-            )
-            next_move_time = (
-                next_move_time + move.accel_t + move.cruise_t + move.decel_t
-            )
-        self.lookahead.reset()
+        try:
+            # Queue move into trapezoid motion queue (trapq)
+            if submit_move.move_d:
+                self.commanded_pos[:] = submit_move.end_pos
+                self.lookahead.add_move(submit_move)
+            moves = self.lookahead.flush()
+            self._calc_print_time()
+            next_move_time = self.print_time
+            for move in moves:
+                self.trapq_append(
+                    self.trapq,
+                    next_move_time,
+                    move.accel_t,
+                    move.cruise_t,
+                    move.decel_t,
+                    move.start_pos[0],
+                    move.start_pos[1],
+                    move.start_pos[2],
+                    move.axes_r[0],
+                    move.axes_r[1],
+                    move.axes_r[2],
+                    move.start_v,
+                    move.cruise_v,
+                    move.accel,
+                )
+                next_move_time = (
+                    next_move_time + move.accel_t + move.cruise_t + move.decel_t
+                )
+        except WaitInterruption:
+            logging.info("caught WaitInterruption in _drip_load_trapq")
+            raise
+        finally:
+            self.lookahead.reset()
         return next_move_time
 
     def drip_move(self, newpos, speed, drip_completion):
-        # Create and verify move is valid
-        newpos = newpos[:3] + self.commanded_pos[3:]
-        move = Move(self, self.commanded_pos, newpos, speed)
-        if move.move_d:
-            self.kin.check_move(move)
-        # Make sure stepper movement doesn't start before nominal start time
-        self.dwell(self.kin_flush_delay)
-        # Transmit move in "drip" mode
-        self._process_lookahead()
-        next_move_time = self._drip_load_trapq(move)
-        self.drip_update_time(next_move_time, drip_completion)
-        # Move finished; cleanup any remnants on trapq
-        self.trapq_finalize_moves(self.trapq, self.reactor.NEVER, 0)
+        try:
+            # Create and verify move is valid
+            newpos = newpos[:3] + self.commanded_pos[3:]
+            move = Move(self, self.commanded_pos, newpos, speed)
+            if move.move_d:
+                self.kin.check_move(move)
+            # Make sure stepper movement doesn't start before nominal start time
+            self.dwell(self.kin_flush_delay)
+            # Transmit move in "drip" mode
+            drip_completion = DripMoveCompletion(
+                self.reactor, drip_completion, self.gcode.get_interrupt_token()
+            )
+            self._process_lookahead()
+            next_move_time = self._drip_load_trapq(move)
+            self.drip_update_time(next_move_time, drip_completion)
+        except WaitInterruption:
+            raise
+        finally:
+            # Move finished; cleanup any remnants on trapq
+            self.trapq_finalize_moves(self.trapq, self.reactor.NEVER, 0)
 
     # Misc commands
     def stats(self, eventtime):

--- a/test/klippy_testing/__init__.py
+++ b/test/klippy_testing/__init__.py
@@ -1,9 +1,10 @@
-from .shims import PrinterShim, Restart
+from .shims import InterruptTokenShim, PrinterShim, Restart
 from .utils import configwrapper_to_dict
 
 __all__ = (
     "ConfigRoot",
     "configwrapper_to_dict",
+    "InterruptTokenShim",
     "PrinterShim",
     "Restart",
 )

--- a/test/klippy_testing/shims.py
+++ b/test/klippy_testing/shims.py
@@ -8,11 +8,26 @@ import klippy.gcode
 class Restart(Exception): ...
 
 
+class InterruptTokenShim:
+    def test(self):
+        return False
+
+    def check_interrupted(self):
+        return False
+
+    def wait(self, waketime=None):
+        return False
+
+    def wait_until(self, waketime=None, error_on_interrupt=True):
+        return False
+
+
 class PrinterShim:
     class GCode:
         error = Exception
 
-        def __init__(self):
+        def __init__(self, printer):
+            self.printer = printer
             self.ready_gcode_handlers = {}
 
         def register_command(self, cmd, func, *_, **__):
@@ -32,7 +47,12 @@ class PrinterShim:
             func = self.ready_gcode_handlers[command.upper()]
             params = dict(param.split("=", 1) for param in paramlist)
             gcmd = klippy.gcode.GCodeCommand(
-                self, command, cmdline, params, False
+                self,
+                command,
+                cmdline,
+                params,
+                False,
+                InterruptTokenShim(),
             )
             print("Calling", func, "with", params)
             func(gcmd)
@@ -40,7 +60,7 @@ class PrinterShim:
     def __init__(self, start_args):
         self.start_args = start_args
         self.objects = {}
-        self.add_object("gcode", self.GCode())
+        self.add_object("gcode", self.GCode(self))
         self.add_object("configfile", klippy.configfile.PrinterConfig(self))
 
         self.call = self.lookup_object("gcode").call

--- a/test/test_pid_profile.py
+++ b/test/test_pid_profile.py
@@ -1,7 +1,7 @@
 import pathlib
 import typing
 
-from klippy_testing import PrinterShim
+from klippy_testing import InterruptTokenShim, PrinterShim
 
 import klippy.extras.heaters as heaters
 import klippy.gcode
@@ -35,7 +35,12 @@ def _make_pmgr(heater):
 
 def _gcmd(heater, params):
     return klippy.gcode.GCodeCommand(
-        heater.gcode, "PID_PROFILE", "PID_PROFILE", params, False
+        heater.gcode,
+        "PID_PROFILE",
+        "PID_PROFILE",
+        params,
+        False,
+        InterruptTokenShim(),
     )
 
 
@@ -103,6 +108,17 @@ class _FakeReactor:
         return 0.0
 
 
+class _FakePrinter:
+    def __init__(self, reactor):
+        self.reactor = reactor
+
+    def get_reactor(self):
+        return self.reactor
+
+    def is_shutdown(self):
+        return False
+
+
 class _FakeConfig:
     def getfloat(self, key, default=None, **kw):
         return {"inner_target_temp": 135.0}.get(key, default)
@@ -114,7 +130,8 @@ class _FakeConfig:
 class _FakeGCode:
     error = Exception
 
-    def __init__(self):
+    def __init__(self, printer):
+        self.printer = printer
         self.messages = []
 
     def respond_info(self, msg):
@@ -140,7 +157,7 @@ class _FakeDualLoopHeater:
     def __init__(self):
         self.reactor = _FakeReactor()
         self.config = _FakeConfig()
-        self.gcode = _FakeGCode()
+        self.gcode = _FakeGCode(_FakePrinter(self.reactor))
         self.configfile = _FakeConfigFile()
         self.smooth_time = 1.0
         self.target_temp = 0.0

--- a/test/test_reactor.py
+++ b/test/test_reactor.py
@@ -1,0 +1,48 @@
+from klippy import gcode, reactor
+
+
+class _Printer:
+    def is_shutdown(self):
+        return False
+
+
+def test_completion_any_removes_losing_waiter():
+    event_loop = reactor.PollReactor()
+    interrupt_completion = event_loop.completion()
+    interrupt_token = gcode.InterruptToken(_Printer(), interrupt_completion)
+
+    def run_test(eventtime):
+        try:
+            for result in range(1000):
+                drip_completion = event_loop.completion()
+                completion = event_loop.completion_any(
+                    [drip_completion, interrupt_token]
+                )
+                event_loop.register_callback(
+                    lambda e, c=drip_completion, r=result: c.complete(r)
+                )
+                assert completion.wait() == result
+                event_loop.pause(event_loop.NOW)
+                assert not drip_completion.waiting
+                assert not interrupt_completion.waiting
+            pending_completion = event_loop.completion()
+            completion = event_loop.completion_any(
+                [pending_completion, interrupt_token]
+            )
+            assert completion.wait(event_loop.NOW, "timeout") == "timeout"
+            event_loop.register_callback(
+                lambda e: interrupt_completion.complete(None)
+            )
+            assert completion.wait() is True
+            event_loop.pause(event_loop.NOW)
+            assert not pending_completion.waiting
+            assert not interrupt_completion.waiting
+        finally:
+            event_loop.end()
+
+    event_loop.register_callback(run_test)
+    try:
+        event_loop.run()
+        assert len(event_loop._all_greenlets) < 10
+    finally:
+        event_loop.finalize()


### PR DESCRIPTION
This is a set of changes that causes the printer to stop what its doing when the existing `HEATER_INTERRUPT` gcode is run. This gcode triggers the internal interrupt mechanism inside `GCodeDispatch`. This is now extended to give a contract that much more similar to how `VirtualSD` works: between each gcode command there is a check to see if the interrupt has been triggered and this stops further execution of the gcode script.

This results in the following improvements to the cancel experience:
* Interruption is now instant because its using a ReactorCompletion, not polling
* Instant interruption now happens in the most frequently blocking locations, primarily waiting inside the toolhead and heater waiting.
* Homing and Probing moves (drip moves) can be interrupted mid-move
* Extras that interact with the toolhead are now interruptible, these tend to be long running programs like `bed_mesh`
* GCode Macros can now be interrupted

The existing counter based mechanism was replaced with an `InterruptToken` that wraps a `ReactorCompletion`. `InterruptToken` is a view/observer of the underlying completion. When `trigger_interrupt()` happens the ReactorCompletion is completed and all of its views subsequently wake if they are being waited upon.

### Explanation
The behavior that we want to achieve is interrupting and cancelling whatever the printer is currently doing while allowing a script of cleanup commands to continue to run successfully. E.g. the user might write a macros like:

```
[gcode_macro CANCEL_INTERRUPT]
gcode:
    HEATER_INTERRUPT
    TURN_OFF_HEATERS
    PARK_TOOLHEAD
```

In this case we want any ongoing `GCodeCommand`s to be interrupted when `HEATER_INTERRUPT` runs. But crucially, the subsequent command to shut off the heaters and park the toolhead should be run normally.

This means the interruption state is tied to gcode commands, represented by `gcmd`/`GCodeCommand` objects. Gcode commands are processed through the `GCodeDispatch._process_commands()` method. This is recursive, both macros and extras can invoke additional gcode commands creating a call stack into `_process_commands()`.

When `HEATER_INTERRUPT` runs, its important that commands up the stack from that point uniformly observe that they are interrupted. This includes when the final gcode in the stack eventually returns and the stack begins to unwind. So the current global state is not the correct state to observe, the right state is the one tied to the `gcmd` that is currently at the top of the stack.

To make this more difficult, the `gcmd` object is not universally available in all the places where we want to get that context. `Printer.wait_while()` doesn't have a gcode command context. `gcode_move.py` and the system of movement transforms don't pass the active `gcmd` through that stack to `toolhead.move()`. It would be an invasive change to thread this state through all of these paths . So we need some way to get the interruption state for the current `gcmd` on top of the stack without having the `gcmd` object.

To make this more complicated, to get `CANCEL_INTERRUPT` to run immediately, we bypass the mutex that protects `GCodeDispatch._process_commands()`. This allows 2 greenlets to concurrently enter that block of code. They have independent stacks, so now there are 2 commands at the top of 2 different stacks. So its not good enough to simply look at entry and exit from `_process_commands()` as the boundaries of a stack frame, we have to track which greenlet (green thread) is actually in the method.

The new `GCodeCommandStacks` tracks a stack of `GCodeCommand`s for each `greenlet`. Via this class its possible to get the correct `InterruptToken` from any context in the program. This class is doing the state tracking that would have been required by individual call sites. Its entirely encapsulated inside GCodeDispatch so extra/plugin developers don't have to think about how it works.

In the future if everywhere was passed a `gcmd` object and the `GCodeDispatch.get_interrupt_token()` method was deleted, then `GCodeCommandStacks` could also be deleted. The `gcmd` object has the right state internally and will always behave correctly. But right now that change looks invasive and impractical.

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
