### PR TITLE
Fix to allow canBUS MCUs to connect and disconnect mid print

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -940,6 +940,16 @@ class MCU:
                         }
                     )
 
+        if self.is_non_critical:
+            logging.info(
+                "Non-critical MCU '%s' shutdown: %s - handling as disconnect",
+                self._name,
+                msg,
+            )
+            self._reactor.register_async_callback(
+                lambda e: self.handle_non_critical_disconnect()
+            )
+            return
         self._printer.invoke_async_shutdown(
             prefix + msg + error_help(msg=msg, append_msgs=append_msgs)
         )


### PR DESCRIPTION
Modified a number of files that were causing issues when an MCU is connected/disconnected mid print or between prints.

This allows for example disconnecting an MCU on the carriage for toolchanged. In my specific case this was with Cartographer but should apply to any MCU.

Main change description: (also in the commit)

    trdispatch: unlink trdispatch_mcu before free

    trdispatch_mcu_alloc() links the object into td->tdm_list, but mcu.py
    released it with ffi_lib.free() and nothing ever unlinked it. When
    _build_config() re-runs after a non-critical MCU reconnect, the old
    object is freed while still on the list; trdispatch_start() and
    handle_trsync_state() then walk into freed memory on the next homing
    move.

    Add trdispatch_mcu_free(), which unlinks under td->lock and deregisters
    the fastreader if trdispatch_start() had registered it, and call it
    explicitly from _build_config(). Add trdispatch_free() as the parent's
    destructor so any remaining children are released at teardown: a child
    destructor cannot rely on its parent surviving, because CPython's
    cyclic collector finalizes cycle members in arbitrary order.

    Confirmed with ASAN (heap-use-after-free, 8-byte read at
    trdispatch.c:141). Two core dumps corroborate: SIGSEGV in
    trdispatch_start at the same line, and SIGABRT "corrupted double-linked
    list" detected downstream in serialqueue_alloc.


Also modified the behavior on reconnect timer in serialhdl.py
and canbus_stats.py. This was causing time out errors because it was configured to wait for 1 second for a reconnect (changed to 0.1s)


## Checklist

- [X] pr title makes sense
- [X] added a test case if possible
- [] ~if new feature, added to the readme~
- [X] ci is happy and green
