### PR TITLE
Kconfig: note USB vendor/device ids are unused in USB-CAN bridge mode

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -81,10 +81,22 @@ config USB_MANUFACTURER
 
 menu "USB ids"
     depends on USB && LOW_LEVEL_OPTIONS
+comment "USB vendor/device ids are not used in USB to CAN bridge mode"
+    depends on USBCANBUS
 config USB_VENDOR_ID
     hex "USB vendor ID" if USBSERIAL
+    help
+        USB vendor id reported by the device. Not used in "USB to CAN
+        bus bridge" mode - the bridge always reports the gs_usb id
+        1d50:606f so that the kernel gs_usb driver binds to it. The
+        value stored in .config has no effect on bridge builds.
 config USB_DEVICE_ID
     hex "USB device ID" if USBSERIAL
+    help
+        USB device id reported by the device. Not used in "USB to CAN
+        bus bridge" mode - the bridge always reports the gs_usb id
+        1d50:606f so that the kernel gs_usb driver binds to it. The
+        value stored in .config has no effect on bridge builds.
 config USB_SERIAL_NUMBER_CHIPID
     bool "USB serial number from CHIPID" if HAVE_CHIPID
 config USB_SERIAL_NUMBER


### PR DESCRIPTION
Background - I changed from USB serial to USB-CAN and had to do the DFU mode button pressing dance. My buttons on the board are close to fatiguing. I wanted to use the passthrough flashing that the EBB36 over CAN uses. So, here we are - I had an invalid device_id causing the flashtool to fail flashing. I no longer have, but I also want to avoid others having this issue too. 

**What:** Documentation-only Kconfig change — a `comment` entry in the "USB ids" menu (visible under USBCANBUS) plus `help` text on `USB_VENDOR_ID` / `USB_DEVICE_ID`, stating that these options are not used in "USB to CAN bus bridge" mode.

**Why:** `usb_canbus.c` hardcodes the gs_usb identity `1d50:606f` in the bridge's device descriptor (so the kernel `gs_usb` driver binds), which means `CONFIG_USB_VENDOR_ID`/`CONFIG_USB_DEVICE_ID` have no effect on bridge builds. However, because the options' prompts are hidden under USBCANBUS, kconfiglib writes the USB-*serial* default (`0x614e`) into every bridge `.config` and `autoconf.h`. That stored value looks meaningful and sends users debugging bridge/USB issues down a wild-goose chase (speaking from a lost afternoon on a Fysetc Spider v3.0).

The `comment` entry has a nice side effect: kconfiglib writes it into the generated `.config`, annotating the misleading value exactly where users encounter it:

```
#
# USB vendor/device ids are not used in USB to CAN bridge mode
#
```

Verified with `olddefconfig` against a real USBCANBUS config: parses clean, comment lands in the written `.config`, no symbol values change.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible — N/A: documentation-only Kconfig change, no behavior to test (validated `olddefconfig` parses and output above)
- [x] if new feature, added to the readme — N/A: not a feature; the help text itself is the documentation
- [ ] ci is happy and green
