### PR TITLE
docs: Add INDX toolboard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ See the [Kalico Additions document](https://docs.kalico.gg/Kalico_Additions.html
 
 - [extruder: cold_extrude](https://github.com/KalicoCrew/kalico/pull/750)
 
+- [indx: support for the Bondtech INDX toolboard](https://github.com/KalicoCrew/kalico/pull/904)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3742,7 +3742,7 @@ sensor_type: indx
 #   The temperature to report. Available kinds are "heater" (nozzle
 #   temperature), "sensor" (IR sensor die temperature), "board"
 #   (toolboard temperature), "bracket" (sensor bracket temperature),
-#   "ldc_coil" (filament sensor coil thermistor), "check_model"
+#   "ldc_coil" (eddy current probe coil temperature), "check_model"
 #   (thermal model prediction) and "check_model_delta" (difference
 #   between the model prediction and the measured temperature).
 ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3730,6 +3730,23 @@ max_temp: 325
 #   If set to true, limits will be echoed to console instead of just being ignored if ignore_limits is true
 ```
 
+### INDX temperature sensor
+
+Temperature reported by a [Bondtech INDX toolboard](#indx). The
+default "heater" kind reports the nozzle temperature and is the one
+to use for the extruder; the other kinds are mainly diagnostic.
+
+```
+sensor_type: indx
+#indx_sensor: heater
+#   The temperature to report. Available kinds are "heater" (nozzle
+#   temperature), "sensor" (IR sensor die temperature), "board"
+#   (toolboard temperature), "bracket" (sensor bracket temperature),
+#   "ldc_coil" (filament sensor coil thermistor), "check_model"
+#   (thermal model prediction) and "check_model_delta" (difference
+#   between the model prediction and the measured temperature).
+```
+
 
 ## Fans
 
@@ -6172,6 +6189,91 @@ sensor_type:
 See [Tap Quality Components](Load_Cell.md#tap-quality-components) for more details on maximum for tap quality.
 
 ## Board specific hardware support
+
+### [indx]
+
+Support for the Bondtech INDX toolboard with its inductive nozzle
+heater, contactless IR temperature sensor and on-board PID
+controller. The toolboard must run Kalico firmware built with the
+"Bondtech INDX Heater" option enabled. See the
+[INDX document](INDX.md) for setup and calibration instructions and
+[G-Codes](G-Codes.md#indx) for the available commands.
+
+The module registers named aliases for the toolboard pins (e.g.
+`<mcu>:motor_step`, `<mcu>:part_cooling`, `<mcu>:endstop`), exposes
+the nozzle heater as the virtual pin `indx:heater`, the nozzle
+temperature as `sensor_type: indx`, and automatically manages the
+heatsink fan. The heater will not heat until INDX_CALIBRATE has been
+run.
+
+```
+[indx]
+mcu:
+#   The name of the mcu config section for the INDX toolboard (e.g.
+#   "indxmcu" when the toolboard is defined as "[mcu indxmcu]"). This
+#   parameter must be provided.
+#part_cooling_fan: fan
+#   Name of the part cooling fan object on the tool. The fan speed is
+#   used by the thermal model to compensate for part cooling airflow.
+#   Set to an empty string to disable.
+#pid_kp: 4.0
+#pid_ti: 0.0
+#pid_td: 0.0
+#pid_b: 1.0
+#   Parameters for the PID controller running on the toolboard. The
+#   defaults should work for most setups.
+#max_temp_nozzle: 305.0
+#max_temp_sensor: 130.0
+#max_temp_bracket: 130.0
+#max_temp_board: 100.0
+#   Maximum allowed temperature for the nozzle, the IR sensor die,
+#   the sensor bracket and the toolboard. Exceeding any of these
+#   triggers a shutdown.
+#max_model_error: 50.0
+#   Maximum allowed difference (in Celsius) between the measured
+#   nozzle temperature and the thermal model prediction before a
+#   shutdown is triggered.
+#coil_time_on:
+#coil_time_off:
+#coil_time_on_first:
+#   Inductive coil drive timings in microseconds. These are measured
+#   by INDX_CALIBRATE and stored by SAVE_CONFIG; they should not
+#   normally be set by hand.
+#max_power:
+#model_max_power_temp_coeff:
+#model_thermal_capacity:
+#model_to_ambient_r:
+#   Thermal model parameters. These are measured by INDX_CALIBRATE
+#   and stored by SAVE_CONFIG; they should not normally be set by
+#   hand.
+#model_filament_diameter: 1.75
+#model_filament_density: 1.20
+#model_filament_heat_capacity: 1.8
+#   Filament parameters used by the thermal model to account for the
+#   energy carried away by extruded filament. The density is in
+#   g/cm^3 and the heat capacity in J/(g*K). These can also be
+#   measured with INDX_LOAD_FILAMENT or changed at runtime with
+#   INDX_SET_MODEL_PARAMS.
+#model_part_cooling_fan_a: 0.0
+#model_part_cooling_fan_k: 0.0
+#   Part cooling fan compensation for the thermal model, measured by
+#   INDX_FAN_CALIBRATE and stored by SAVE_CONFIG.
+#model_ambient_blend_board: 0.0
+#model_ambient_blend_bracket: 1.0
+#model_ambient_blend_sensor: 1.0
+#   Relative weights of the toolboard, sensor bracket and IR sensor
+#   die temperatures when estimating the ambient temperature for the
+#   thermal model.
+#model_error_application: 1.0
+#   Fraction of the observed model error fed back into the thermal
+#   model on each update.
+#ir_sensor_exponent:
+#ir_sensor_obj_gain:
+#ir_sensor_bracket_gain:
+#   Override the IR sensor tuning parameters stored in the sensor
+#   EEPROM. All three must be provided if any is given. These should
+#   not normally be set.
+```
 
 ### [sx1509]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1039,9 +1039,11 @@ default) the measured values are applied and staged for SAVE_CONFIG.
 
 #### INDX_EXTRUDER_MOVE
 `INDX_EXTRUDER_MOVE DISTANCE=<mm> SPEED=<mm/s> CURRENT=<amps>`:
-Perform an extruder move with the TMC run current temporarily lowered
-to CURRENT, bypassing the cold extrude check. Useful for gently
-loading filament against a stop.
+Perform an extruder move that bypasses the cold extrude check, with
+the TMC run current temporarily lowered to CURRENT (think of it as
+M302 plus a move in a single command). Mainly intended for loading
+and unloading INDX tools without needing to set a low minimum
+extrusion temperature.
 
 #### INDX_SET_MODEL_PARAMS
 `INDX_SET_MODEL_PARAMS [MAX_POWER=<value>]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1000,6 +1000,115 @@ The idle_timeout module is automatically loaded.
 `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`: Allows the user to set the
 idle timeout (in seconds).
 
+### [indx]
+
+The following commands are available when an
+[indx config section](Config_Reference.md#indx) is enabled (also see
+the [INDX document](INDX.md)).
+
+#### INDX_CALIBRATE
+`INDX_CALIBRATE [MIN_TEMP=<temp>] [MAX_TEMP=<temp>]
+[HOLD_TIME=<seconds>] [COOLDOWN_TIME=<seconds>]`: Tune the inductive
+coil drive timings and fit the heater thermal model. The nozzle must
+be cold (below MIN_TEMP, default 60) and the heater off; the nozzle
+is then heated to MAX_TEMP (default 200), held for HOLD_TIME (default
+10 seconds) and allowed to cool for COOLDOWN_TIME (default 15
+seconds). The heater will not heat until this calibration has been
+performed. Run SAVE_CONFIG afterwards to persist the results.
+
+#### INDX_FAN_CALIBRATE
+`INDX_FAN_CALIBRATE [BREAKS=<count>] [HOLD_TIME=<seconds>]
+[MIN_SPEED=<value>] [TEMP=<temp>] [SETTLE_TIME=<seconds>]`: Measure
+the cooling effect of the part cooling fan at BREAKS (default 6) fan
+speeds between MIN_SPEED (default 0.20) and full speed while holding
+the nozzle at TEMP (default 200). Run SAVE_CONFIG afterwards to
+persist the results.
+
+#### INDX_LOAD_FILAMENT
+`INDX_LOAD_FILAMENT [SPEED=<mm/s>] [MAX_LENGTH=<mm>]
+[PRIME_TIME=<seconds>] [PRIME_LENGTH=<mm>] [THRESHOLD=<value>]
+[SEGMENT_TIME=<seconds>] [APPLY=[0|1]]`: Load filament while
+measuring its thermal properties (the density and heat capacity used
+by the thermal model). Requires a calibrated thermal model and the
+active extruder to be at printing temperature. If APPLY is 1 (the
+default) the measured values are applied and staged for SAVE_CONFIG.
+
+#### INDX_CLEAR_FILAMENT
+`INDX_CLEAR_FILAMENT`: Reset the filament thermal parameters to zero
+(no filament compensation). Run SAVE_CONFIG to persist.
+
+#### INDX_EXTRUDER_MOVE
+`INDX_EXTRUDER_MOVE DISTANCE=<mm> SPEED=<mm/s> CURRENT=<amps>`:
+Perform an extruder move with the TMC run current temporarily lowered
+to CURRENT, bypassing the cold extrude check. Useful for gently
+loading filament against a stop.
+
+#### INDX_SET_MODEL_PARAMS
+`INDX_SET_MODEL_PARAMS [MAX_POWER=<value>]
+[MAX_POWER_TEMP_COEFF=<value>] [THERMAL_CAPACITY=<value>]
+[TO_AMBIENT_R=<value>] [FILAMENT_DIAMETER=<mm>]
+[FILAMENT_DENSITY=<g/cm3>] [FILAMENT_HEAT_CAPACITY=<J/g/K>]
+[PART_COOLING_FAN_A=<value>] [PART_COOLING_FAN_K=<value>]
+[AMBIENT_BLEND_BOARD=<value>] [AMBIENT_BLEND_BRACKET=<value>]
+[AMBIENT_BLEND_SENSOR=<value>] [ERROR_APPLICATION=<value>]`: Set
+thermal model parameters at runtime. Updated values are staged for
+SAVE_CONFIG.
+
+#### INDX_SET_PID
+`INDX_SET_PID [KP=<value>] [TI=<value>] [TD=<value>] [B=<value>]`:
+Update the PID parameters of the controller running on the toolboard.
+
+#### INDX_MEASURE_POWER
+`INDX_MEASURE_POWER [DURATION=<seconds>]`: Measure the heater power
+draw over DURATION (default 5) seconds and report the total energy
+and average power.
+
+#### INDX_DOCK_MEASURE
+`INDX_DOCK_MEASURE [X_FIRST=[0|1]]`: Measure the dock X/Y position of
+an INDX toolchanger by energizing the XY motors and homing. Set
+X_FIRST=1 to home X before Y. The result is reported and exported in
+the module status.
+
+#### INDX_FORCE_BRACKET_TEMP
+`INDX_FORCE_BRACKET_TEMP [TEMP=<temp>]`: Override the sensor bracket
+temperature reported to the toolboard. Run without TEMP to remove the
+override.
+
+#### INDX_SET_IR_SENSOR_PARAMS
+`INDX_SET_IR_SENSOR_PARAMS EXPONENT=<value> OBJ_GAIN=<value>
+BRACKET_GAIN=<value>`: Override the IR sensor tuning parameters
+stored in the sensor EEPROM. These should not normally be changed.
+
+#### INDX_SET_CYCLE_LIMIT
+`INDX_SET_CYCLE_LIMIT LIMIT=<value>`: Limit the coil driver duty
+(mainly for development and testing).
+
+#### INDX_LED_FORCE_COLOR
+`INDX_LED_FORCE_COLOR [RED=<0-255>] [GREEN=<0-255>] [BLUE=<0-255>]
+[CLEAR=1]`: Force the toolboard status LED to the given color,
+overriding the automatic status indication. Use CLEAR=1 to return the
+LED to automatic control.
+
+#### INDX_LED_SET_CURRENT
+`INDX_LED_SET_CURRENT RED=<0-255> GREEN=<0-255> BLUE=<0-255>`: Set
+the per-channel drive current of the toolboard status LED.
+
+#### INDX_LOG
+`INDX_LOG`: Toggle logging of heater temperature, model and power
+data to "/tmp/indx_log.csv" (for debugging).
+
+#### INDX_DUMP_MODEL_UPDATE
+`INDX_DUMP_MODEL_UPDATE`: Report the internal state of the last
+thermal model update (for debugging).
+
+#### INDX_DEBUG_IR_SENSOR_EEPROM
+`INDX_DEBUG_IR_SENSOR_EEPROM`: Dump the IR sensor EEPROM contents
+(for debugging).
+
+#### INDX_DEBUG_STREAM_RAW_IR_SENSOR
+`INDX_DEBUG_STREAM_RAW_IR_SENSOR`: Toggle streaming of raw IR sensor
+readings to a timestamped csv file under /tmp (for debugging).
+
 ### [input_shaper]
 
 The following command is enabled if an

--- a/docs/INDX.md
+++ b/docs/INDX.md
@@ -1,0 +1,121 @@
+# Bondtech INDX
+
+This document describes how to set up and calibrate a
+[Bondtech INDX](https://www.bondtech.se/) toolboard with Kalico. The
+INDX toolboard drives an inductive nozzle heater with a contactless IR
+temperature sensor, and runs its own PID controller on the toolboard
+MCU.
+
+Support consists of the `[indx]` host module (see
+[config reference](Config_Reference.md#indx)) and dedicated firmware
+for the toolboard's SAME51 MCU, both included in Kalico. Kalico tracks
+the upstream INDX module maintained at
+[BondtechAB/indx_klipper](https://github.com/BondtechAB/indx_klipper);
+also see the original
+[commissioning guide](https://gist.github.com/dalegaard/b5106af63fcdde305e8c47421a8cc9b9).
+
+## Flashing the firmware
+
+Connect the toolboard over USB and bridge the `CAN RESET` jumper while
+powering up to force the bootloader. The device should show up as
+"INDX Toolboard Bootloader" with USB id `04d8:e483`:
+
+```
+$ lsusb | grep INDX
+```
+
+Kalico ships a ready-made build configuration. From the Kalico
+directory run:
+
+```
+$ KCONFIG_CONFIG=board_configs/bondtech_indx_usb.config make
+$ KCONFIG_CONFIG=board_configs/bondtech_indx_usb.config make flash FLASH_DEVICE=04d8:e483
+```
+
+## Configuration
+
+A minimal configuration looks like:
+
+```
+[mcu indxmcu]
+serial: /dev/serial/by-id/usb-Bondtech_INDX_<YOUR SERIAL>-if00
+
+[indx]
+mcu: indxmcu
+
+[extruder]
+sensor_type: indx
+min_temp: 0
+max_temp: 300
+heater_pin: indx:heater
+control: watermark
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+step_pin: indxmcu:motor_step
+dir_pin: indxmcu:motor_dir
+enable_pin: !indxmcu:motor_enable
+microsteps: 32
+rotation_distance: 5.7
+
+[tmc2240 extruder]
+cs_pin: indxmcu:motor_cs
+spi_software_sclk_pin: indxmcu:motor_sclk
+spi_software_mosi_pin: indxmcu:motor_mosi
+spi_software_miso_pin: indxmcu:motor_miso
+rref: 24000
+run_current: 0.6
+
+[fan]
+pin: indxmcu:part_cooling
+tachometer_pin: indxmcu:part_cooling_tacho
+```
+
+The `[indx]` module registers named aliases for all toolboard pins
+(such as `indxmcu:motor_step`, `indxmcu:part_cooling`,
+`indxmcu:endstop`) and configures the SERCOM peripherals
+automatically. The extruder heater is exposed as the virtual pin
+`indx:heater` and the nozzle temperature as `sensor_type: indx`. The
+heatsink fan is managed by the toolboard module itself: it turns on
+whenever the heater is active, the nozzle is hot or a stepper on the
+toolboard is enabled, and a blocked fan triggers a shutdown.
+
+## Calibration
+
+The heater will not heat until it has been calibrated. With the nozzle
+cold and the printer idle run:
+
+```
+INDX_CALIBRATE
+```
+
+This first tunes the inductive coil drive timings and then performs a
+heat/hold/cooldown cycle to fit the thermal model. Afterwards run
+`SAVE_CONFIG` to persist the results.
+
+Optionally calibrate the part cooling fan compensation (requires the
+part cooling fan to be configured):
+
+```
+INDX_FAN_CALIBRATE
+SAVE_CONFIG
+```
+
+The thermal model also accounts for the energy carried away by molten
+filament. Either set the filament parameters directly:
+
+```
+INDX_SET_MODEL_PARAMS FILAMENT_DENSITY=<g/cm3> FILAMENT_HEAT_CAPACITY=<J/g/K>
+```
+
+or measure them while loading filament with the nozzle at printing
+temperature:
+
+```
+INDX_LOAD_FILAMENT
+```
+
+Use `INDX_CLEAR_FILAMENT` to reset the filament parameters, and
+`SAVE_CONFIG` to persist any of these values.
+
+See the [G-Code reference](G-Codes.md#indx) for the full list of INDX
+commands and their parameters.

--- a/docs/INDX.md
+++ b/docs/INDX.md
@@ -8,10 +8,11 @@ MCU.
 
 Support consists of the `[indx]` host module (see
 [config reference](Config_Reference.md#indx)) and dedicated firmware
-for the toolboard's SAME51 MCU, both included in Kalico. Kalico tracks
-the upstream INDX module maintained at
-[BondtechAB/indx_klipper](https://github.com/BondtechAB/indx_klipper);
-also see the original
+for the toolboard's SAME51 MCU, both included in Kalico. Kalico is
+the reference implementation; the
+[BondtechAB/indx_klipper](https://github.com/BondtechAB/indx_klipper)
+module tracks Kalico to provide compatibility with mainline Klipper.
+Also see the original
 [commissioning guide](https://gist.github.com/dalegaard/b5106af63fcdde305e8c47421a8cc9b9).
 
 ## Flashing the firmware

--- a/docs/Kalico_Additions.md
+++ b/docs/Kalico_Additions.md
@@ -26,6 +26,7 @@
 ## New Kalico Modules
 
 - [gcode_shell_command](./G-Code_Shell_Command.md) - Execute linux commands and scripts from within Kalico
+- [indx](./INDX.md) - Support for the Bondtech INDX toolboard and its inductive nozzle heater
 
 ## Sensorless Homing
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -341,6 +341,14 @@ is always available):
   been in the "Printing" state (as tracked by the idle_timeout
   module).
 
+## indx
+
+The following information is available in the
+[indx](Config_Reference.md#indx) object:
+- `last_dock_measurement`: The result of the last INDX_DOCK_MEASURE
+  command (None if no measurement has been taken). It is a dictionary
+  containing the keys `x`, `y`, `position` and `axis_order`.
+
 ## led
 
 The following information is available for each `[led led_name]`,

--- a/docs/_kalico/mkdocs.yml
+++ b/docs/_kalico/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
     - PID.md
     - MPC.md
     - Dockable_Probe.md
+    - INDX.md
   - G-Code Reference:
     - G-Codes.md
     - Command_Templates.md


### PR DESCRIPTION
- Config reference for `[indx]` and the `indx` temperature sensor
- G-code reference for all INDX commands
- Status reference (`last_dock_measurement`)
- Dedicated INDX.md setup/calibration page, added to the docs nav
- README / Kalico_Additions feature entries

Docs for #904, no code changes.