### PR TITLE
Kconfig: Only default USB_PRODUCT on USB builds

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -79,6 +79,7 @@ config USB_SERIAL_NUMBER
 config USB_MANUFACTURER
     default "Klipper"
 config USB_PRODUCT
+    depends on USB
     default MCU
 
 menu "USB ids"


### PR DESCRIPTION
## Summary
- `USB_PRODUCT` (introduced in #904, `default MCU`) has no `depends on USB`, so every saved `.config` records it, even non-USB builds (an atmega2560 build writes `CONFIG_USB_PRODUCT="atmega2560"`)
- On a later `make menuconfig` run that line is loaded as a user-set value; with `LOW_LEVEL_OPTIONS=y` the "USB product" prompt becomes visible and the stale value wins over the recomputed default
- Result: switching architectures in a reused `.config` keeps the old product string, reported as an stm32g0b1 enumerating as `usb-Klipper_atmega2560` in `/dev/serial/by-id`
- Adding `depends on USB` stops the value from leaking into non-USB configs

## Test plan
- [x] atmega2560 config no longer writes `CONFIG_USB_PRODUCT`
- [x] Reproduced the report (atmega `.config` reused → stm32g0b1 + `LOW_LEVEL_OPTIONS=y`): now resolves to `stm32g0b1xx`
- [x] `board_configs/bondtech_indx_usb.config` still resolves to `"INDX"`
- [x] stm32g0b1 firmware builds