### PR TITLE
resonance_tester: fix motion limits for test overrides and sweeping; fix final decel; input validation

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,15 @@ All dates in this document are approximate.
 
 ## Changes
 
+20260713: The temporary acceleration and velocity limits applied during
+`TEST_RESONANCES` and `SHAPER_CALIBRATE` are now derived from the actual test
+sequence instead of only the configured `accel_per_hz`. Previously an
+`ACCEL_PER_HZ` override above the configured value, or a sweeping test
+(`SWEEPING_PERIOD` > 0), was silently velocity-clamped, attenuating the
+excitation. Such tests now produce larger (correct) vibration amplitudes, which
+can shift the recommended input shaper type and frequency — consider re-running
+shaper calibration if you rely on either option.
+
 20260201: The manual_stepper `STOP_ON_ENDSTOP` feature may now take
 less time to complete. Previously, the command would wait the entire
 time the move could possibly take even if the endstop triggered

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -51,7 +51,7 @@ def _parse_axis(gcmd, raw_axis):
     try:
         dir_x = float(dirs[0].strip())
         dir_y = float(dirs[1].strip())
-    except:
+    except ValueError:
         raise gcmd.error("Unable to parse axis direction '%s'" % (raw_axis,))
     return TestAxis(vib_dir=(dir_x, dir_y))
 
@@ -134,6 +134,10 @@ class VibrationPulseTestGenerator:
         self.hz_per_sec = config.getfloat(
             "hz_per_sec", 1.0, minval=0.1, maxval=2.0
         )
+        self.freq_start = self.min_freq
+        self.freq_end = self.max_freq
+        self.test_accel_per_hz = self.accel_per_hz
+        self.test_hz_per_sec = self.hz_per_sec
 
     def prepare_test(self, gcmd):
         self.freq_start = gcmd.get_float(
@@ -169,7 +173,9 @@ class VibrationPulseTestGenerator:
         return self.freq_end
 
     def get_accel_per_hz(self):
-        return self.accel_per_hz
+        # The value in effect for the current test (including any
+        # ACCEL_PER_HZ override), not the configured default
+        return self.test_accel_per_hz
 
 
 class SweepingVibrationsTestGenerator:
@@ -181,6 +187,8 @@ class SweepingVibrationsTestGenerator:
         self.sweeping_period = config.getfloat(
             "sweeping_period", 0.0, minval=0.0
         )
+        self.test_sweeping_accel = self.sweeping_accel
+        self.test_sweeping_period = self.sweeping_period
 
     def prepare_test(self, gcmd):
         self.vibration_generator.prepare_test(gcmd)
@@ -221,17 +229,29 @@ class SweepingVibrationsTestGenerator:
     def get_max_freq(self):
         return self.vibration_generator.get_max_freq()
 
+    def get_accel_per_hz(self):
+        return self.vibration_generator.get_accel_per_hz()
+
 
 class ResonanceTestExecutor:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object("gcode")
 
-    def run_test(self, test_seq, axis, freq_end, accel_per_hz, gcmd):
+    def run_test(self, test_seq, axis, gcmd):
+        # Derive the required limits from the actual test sequence, so that
+        # ACCEL_PER_HZ overrides and the sweeping acceleration are covered
+        max_accel = 0.0
+        max_v = v = last_t = 0.0
+        for next_t, accel, freq in test_seq:
+            max_accel = max(max_accel, abs(accel))
+            v += accel * (next_t - last_t)
+            max_v = max(max_v, abs(v))
+            last_t = next_t
         with suspend_limits(
             self.printer,
-            freq_end * accel_per_hz + 10.0,
-            accel_per_hz * 0.25 + 1.0,
+            max_accel + 10.0,
+            max_v + 1.0,
             gcmd.get_int("INPUT_SHAPING", 0),
         ):
             self._run_test(test_seq, axis, gcmd)
@@ -283,7 +303,8 @@ class ResonanceTestExecutor:
             last_v = v
             last_freq = freq
         if last_v:
-            d_decel = -0.5 * last_v2 / old_max_accel
+            # Decelerate to a stop, continuing in the direction of motion
+            d_decel = 0.5 * last_v * abs(last_v) / old_max_accel
             decel_X, decel_Y = axis.get_point(d_decel)
             toolhead.cmd_M204(
                 self.gcode.create_gcode_command(
@@ -370,17 +391,15 @@ class ResonanceTester:
         raw_name_suffix=None,
         accel_chips=None,
         test_point=None,
-        test_accel_per_hz=None,
     ):
         toolhead = self.printer.lookup_object("toolhead")
         calibration_data = {axis: None for axis in axes}
 
+        # Reads all test overrides (FREQ_START/END, ACCEL_PER_HZ, ...)
+        # from gcmd
         self.generator.prepare_test(gcmd)
 
         test_points = [test_point] if test_point else self.probe_points
-
-        if test_accel_per_hz is not None:
-            self.generator.accel_per_hz = test_accel_per_hz
 
         for point in test_points:
             toolhead.manual_move(point, self.move_speed)
@@ -407,13 +426,7 @@ class ResonanceTester:
 
                 # Generate moves
                 test_seq = self.generator.gen_test()
-                self.executor.run_test(
-                    test_seq,
-                    axis,
-                    self.generator.vibration_generator.freq_end,
-                    self.generator.vibration_generator.accel_per_hz,
-                    gcmd,
-                )
+                self.executor.run_test(test_seq, axis, gcmd)
                 for chip_axis, aclient, chip_name in raw_values:
                     aclient.finish_measurements()
                     if raw_name_suffix is not None:
@@ -455,14 +468,13 @@ class ResonanceTester:
     def _get_max_calibration_freq(self):
         return 1.5 * self.generator.get_max_freq()
 
-    cmd_TEST_RESONANCES_help = "Runs the resonance test for a specifed axis"
+    cmd_TEST_RESONANCES_help = "Runs the resonance test for a specified axis"
 
     def cmd_TEST_RESONANCES(self, gcmd):
         # Parse parameters
         axis = _parse_axis(gcmd, gcmd.get("AXIS").lower())
         chips_str = gcmd.get("CHIPS", None)
         test_point = gcmd.get("POINT", None)
-        test_accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", None, above=0.0)
 
         if test_point:
             test_coords = test_point.split(",")
@@ -496,6 +508,9 @@ class ResonanceTester:
         csv_output = "resonances" in outputs
         raw_output = "raw_data" in outputs
 
+        # Check for active fans and display warning if found
+        self._check_active_fans(gcmd)
+
         # Setup calculation of resonances
         if csv_output:
             helper = shaper_calibrate.ShaperCalibrate(self.printer)
@@ -509,7 +524,6 @@ class ResonanceTester:
             raw_name_suffix=name_suffix if raw_output else None,
             accel_chips=accel_chips,
             test_point=test_point,
-            test_accel_per_hz=test_accel_per_hz,
         )[axis]
         if csv_output:
             csv_name = self.save_calibration_data(
@@ -520,14 +534,14 @@ class ResonanceTester:
                 data,
                 point=test_point,
                 max_freq=self._get_max_calibration_freq(),
-                accel_per_hz=self.generator.vibration_generator.get_accel_per_hz(),
+                accel_per_hz=self.generator.get_accel_per_hz(),
             )
             gcmd.respond_info(
                 "Resonances data written to %s file" % (csv_name,)
             )
 
     cmd_SHAPER_CALIBRATE_help = (
-        "Simular to TEST_RESONANCES but suggest input shaper config"
+        "Similar to TEST_RESONANCES but suggest input shaper config"
     )
 
     def cmd_SHAPER_CALIBRATE(self, gcmd):
@@ -535,7 +549,7 @@ class ResonanceTester:
         axis = gcmd.get("AXIS", None)
         if not axis:
             calibrate_axes = [TestAxis("x"), TestAxis("y")]
-        elif axis.lower() not in "xy":
+        elif axis.lower() not in ("x", "y"):
             raise gcmd.error("Unsupported axis '%s'" % (axis,))
         else:
             calibrate_axes = [TestAxis(axis.lower())]
@@ -601,7 +615,7 @@ class ResonanceTester:
                 calibration_data[axis],
                 all_shapers,
                 max_freq=max_freq,
-                accel_per_hz=self.generator.vibration_generator.get_accel_per_hz(),
+                accel_per_hz=self.generator.get_accel_per_hz(),
             )
             gcmd.respond_info(
                 "Shaper calibration data written to %s file" % (csv_name,)
@@ -616,7 +630,7 @@ class ResonanceTester:
     )
 
     def cmd_MEASURE_AXES_NOISE(self, gcmd):
-        meas_time = gcmd.get_float("MEAS_TIME", 2.0)
+        meas_time = gcmd.get_float("MEAS_TIME", 2.0, above=0.0)
         raw_values = [
             (chip_axis, chip.start_internal_client())
             for chip_axis, chip in self.accel_chips
@@ -695,7 +709,7 @@ class ResonanceTester:
                                 )
 
                             active_fans.append(fan_name)
-                    except:
+                    except Exception:
                         continue
 
             if active_fans:


### PR DESCRIPTION
## Summary

Three fixes for `resonance_tester.py`, found by auditing the test parameter flow. Two are measurement-correctness bugs that silently attenuate the resonance excitation; the third is input validation and hygiene. Host-side Python only.

Same bug patterns and fixes verified to exist verbatim in `bleeding-edge-v2` (see [Hannott#2](https://github.com/Hannott/kalico/pull/2)); this PR ports them to `main`.

## 1. Test motion limits ignored `ACCEL_PER_HZ` overrides and the sweeping motion

The temporary acceleration/velocity limits raised for the test were computed from the **configured** `accel_per_hz` (`freq_end × accel_per_hz + 10`, `accel_per_hz × 0.25 + 1`), while the generated move sequence uses the **effective** parameters. Measured consequences (defaults: `accel_per_hz` 75, `sweeping_accel` 400):

| scenario | accel needed / limit set | velocity needed / limit set |
|---|---|---|
| `ACCEL_PER_HZ=120` override | 16,200 / 10,135 mm/s² | 30.0 / 19.75 mm/s |
| sweeping, period 1.2 s | 10,525 / 10,135 mm/s² | **138.7 / 19.75 mm/s** |

The velocity clamp applies on every kinematics (`toolhead.move` caps at `max_velocity`), so in both cases the actual excitation was silently weaker than requested — `ACCEL_PER_HZ` overrides produced attenuated amplitudes across the sweep, and sweeping tests had their sweeping movement velocity-clamped ~7×.

**Fix:** derive the limits from the generated sequence itself — max segment acceleration and integrated peak velocity, plus the previous margins. This is correct by construction for any override combination or future generator. Also removed the dead `test_accel_per_hz` plumbing in `ResonanceTester._run_test` (it assigned an attribute nothing reads, on the wrong object — the override already flows through `prepare_test`) and made the CSV metadata record the accel_per_hz actually used instead of the configured default.

## 2. Final deceleration move used a stale velocity, in the wrong direction

When the sequence ends with nonzero velocity (happens with sweeping tests), the decel-to-stop move computed its distance from `last_v2` — the velocity at the start of the *previous* segment, since the loop updates `last_v` after `last_v2`. Measured: final velocity 8.7 mm/s, distance computed from 28.2 mm/s (~10× too long). The distance was also unconditionally negative, i.e. opposite to the motion direction whenever the final velocity was positive (the in-loop direction-change decel gets its sign from the signed segment acceleration; the final one divided by the always-positive `old_max_accel`).

**Fix:** `d = 0.5 · v · |v| / max_accel` from the actual final velocity.

![resonance_tester fixes](https://raw.githubusercontent.com/Hannott/kalico/5d32330eb14e9655745719f619581b4e858f2fbf/resonance_tester_fixes.png)

*Top left: a sweeping test demands ±130 mm/s while the old limit clamped everything beyond ±19.8 mm/s (shaded). Top right: acceleration demand vs the old limit — with ACCEL_PER_HZ=120 the excitation was flat-topped above 84 Hz. Bottom: the final deceleration move — the old code targeted a point behind the direction of motion, sized for a stale velocity; the new code stops in 0.013 mm ahead.*

## 3. Validation and hygiene

- `SHAPER_CALIBRATE AXIS=XY` was accepted by the substring check `axis.lower() not in "xy"` — it silently calibrated **only the Y direction** (`TestAxis("xy")` maps any non-`"x"` name to the Y vibration direction) while applying the result to both axes. Now restricted to exactly `x` or `y`.
- `MEASURE_AXES_NOISE MEAS_TIME=` now requires a positive value.
- The active-fans warning is shown for `TEST_RESONANCES` too, not only `SHAPER_CALIBRATE`.
- Two bare `except:` clauses narrowed to the intended exception types; help-string typos fixed.

## Verification

- Stub-config simulation of the generators confirms: derived limits cover the sequence demands in all three scenarios above (override / sweeping / both); CSV metadata reports the effective value; `gen_test()` still works without `prepare_test()` (test values now initialized from config at construction).
- Final-decel math verified: distance matches `v²/2a` with the sign of the final velocity.
- `AXIS` validation: `x`/`y` accepted; `XY`, `Z`, empty rejected.
- Cherry-picked cleanly onto `main` with no conflicts; re-verified against `main`'s codebase directly (same numeric results as above).
- `ruff check` / `ruff format` pass (ruff 0.4.5, matching pre-commit).

Note: behavior change for anyone who relied on the attenuated results — resonance amplitudes measured with `ACCEL_PER_HZ` overrides or sweeping enabled will be larger (correct) after this change, which can shift calibration outcomes.

Signed-off-by: Åsmund Collin <aakjaergaard@gmail.com>

