### PR TITLE
mcu: Harden non-critical MCU reconnect path

### DIFF
--- a/klippy/extras/canbus_stats.py
+++ b/klippy/extras/canbus_stats.py
@@ -5,6 +5,8 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
+from klippy import serialhdl
+
 
 class PrinterCANBusStats:
     def __init__(self, config):
@@ -85,7 +87,12 @@ class PrinterCANBusStats:
 
         if prev_rx is None:
             prev_rx = prev_tx = prev_retries = 0
-        params = self.get_canbus_status_cmd.send()
+        try:
+            params = self.get_canbus_status_cmd.send()
+        except (serialhdl.error, self.printer.command_error):
+            # The connection can drop while a query is in flight (e.g. a
+            # non-critical mcu disconnecting) - keep stats and retry later
+            return self.reactor.monotonic() + 1.0
         rx = prev_rx + ((params["rx_error"] - prev_rx) & 0xFFFFFFFF)
         tx = prev_tx + ((params["tx_error"] - prev_tx) & 0xFFFFFFFF)
         retries = prev_retries + (

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1094,14 +1094,57 @@ class MCU:
         return "\n".join(log_info)
 
     def recon_mcu(self):
-        res = self._mcu_identify()
-        if not res:
+        try:
+            if not self._mcu_identify():
+                return False
+            if self._recon_handle_shutdown():
+                return False
+            self._is_shutdown = False
+            self.reset_to_initial_state()
+            self.non_critical_disconnected = False
+            self._connect()
+        except Exception:
+            logging.exception(
+                "Reconnect attempt on MCU '%s' failed", self._name
+            )
+            self._abort_recon_attempt()
             return False
-        self.reset_to_initial_state()
-        self.non_critical_disconnected = False
-        self._connect()
         self._printer.send_event(self._non_critical_reconnect_event_name)
         return True
+
+    def _recon_handle_shutdown(self):
+        # A firmware shutdown survives the loss of the host connection.
+        # Ask the mcu to reset so a later reconnect attempt starts from
+        # a clean state.  Returns True if the mcu was shutdown.
+        get_config_cmd = self.lookup_query_command(
+            "get_config",
+            "config is_config=%c crc=%u is_shutdown=%c move_count=%hu",
+        )
+        if not get_config_cmd.send()["is_shutdown"]:
+            return False
+        logging.info(
+            "MCU '%s' is in a shutdown state - attempting reset", self._name
+        )
+        if self._reset_cmd is not None:
+            self._reset_cmd.send()
+        elif self._config_reset_cmd is not None:
+            self._config_reset_cmd.send()
+        else:
+            # No reset mechanism - clear the shutdown state and let the
+            # next reconnect attempt reuse the retained config
+            clear_shutdown_cmd = self.try_lookup_command("clear_shutdown")
+            if clear_shutdown_cmd is not None:
+                clear_shutdown_cmd.send()
+        self._reactor.pause(self._reactor.monotonic() + 0.015)
+        self._abort_recon_attempt()
+        return True
+
+    def _abort_recon_attempt(self):
+        # Return to the disconnected state; the reconnect timer retries
+        self._clocksync.disconnect()
+        self._disconnect()
+        self.non_critical_disconnected = True
+        self._get_status_info["non_critical_disconnected"] = True
 
     def reset_to_initial_state(self):
         if self._cached_init_state:
@@ -1389,8 +1432,10 @@ class MCU:
         self._steppersync = None
 
     def _shutdown(self, force=False):
-        if self._emergency_stop_cmd is None or (
-            self._is_shutdown and not force
+        if (
+            self._emergency_stop_cmd is None
+            or self.non_critical_disconnected
+            or (self._is_shutdown and not force)
         ):
             return
         self._emergency_stop_cmd.send()

--- a/test/test_canbus_stats.py
+++ b/test/test_canbus_stats.py
@@ -1,0 +1,42 @@
+from klippy import gcode
+from klippy.extras import canbus_stats
+
+
+class _FakeReactor:
+    def monotonic(self):
+        return 100.0
+
+
+class _FakeMcu:
+    non_critical_disconnected = False
+
+
+class _FakePrinter:
+    command_error = gcode.CommandError
+
+
+class _RaisingCmd:
+    def send(self, *args, **kwargs):
+        raise gcode.CommandError("mcu 'sht36': Serial connection closed")
+
+
+def test_query_event_survives_send_error():
+    stats = canbus_stats.PrinterCANBusStats.__new__(
+        canbus_stats.PrinterCANBusStats
+    )
+    stats.printer = _FakePrinter()
+    stats.reactor = _FakeReactor()
+    stats.name = "sht36"
+    stats.mcu = _FakeMcu()
+    stats.get_canbus_status_cmd = _RaisingCmd()
+    stats.status = {
+        "rx_error": 1,
+        "tx_error": 2,
+        "tx_retries": 3,
+        "bus_state": "active",
+    }
+    # A disconnect while the query is in flight must not propagate out of
+    # the reactor timer callback
+    waketime = stats.query_event(100.0)
+    assert waketime == 101.0
+    assert stats.status["rx_error"] == 1

--- a/test/test_mcu_recon.py
+++ b/test/test_mcu_recon.py
@@ -1,0 +1,129 @@
+from klippy import mcu as mcu_mod
+
+RECON_EVENT = "danger:non_critical_mcu_test:reconnected"
+
+
+class _FakeSerial:
+    def __init__(self):
+        self.disconnected = False
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+class _FakeClockSync:
+    def __init__(self):
+        self.disconnected = False
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+class _FakePrinter:
+    def __init__(self):
+        self.events = []
+
+    def send_event(self, name, *args):
+        self.events.append(name)
+
+
+class _FakeReactor:
+    NOW = 0.0
+    NEVER = 9e99
+
+    def monotonic(self):
+        return 0.0
+
+    def pause(self, waketime):
+        pass
+
+
+class _FakeCommand:
+    def __init__(self, response=None):
+        self.sent = 0
+        self._response = response
+
+    def send(self, *args, **kwargs):
+        self.sent += 1
+        return self._response
+
+
+def _make_mcu(is_shutdown_response=0):
+    mcu = mcu_mod.MCU.__new__(mcu_mod.MCU)
+    mcu._name = "test"
+    mcu._printer = _FakePrinter()
+    mcu._reactor = _FakeReactor()
+    mcu._serial = _FakeSerial()
+    mcu._clocksync = _FakeClockSync()
+    mcu._is_shutdown = False
+    mcu._shutdown_msg = ""
+    mcu.non_critical_disconnected = True
+    mcu._get_status_info = {}
+    mcu._steppersync = None
+    mcu._cached_init_state = False
+    mcu._reserved_move_slots = 0
+    mcu._reset_cmd = None
+    mcu._config_reset_cmd = None
+    mcu._non_critical_reconnect_event_name = RECON_EVENT
+    # Fake out the recon path boundaries; recon_mcu itself is the unit
+    mcu._mcu_identify = lambda: True
+    mcu._connect = lambda: None
+    get_config = _FakeCommand(
+        {
+            "is_config": 1,
+            "crc": 0,
+            "is_shutdown": is_shutdown_response,
+            "move_count": 500,
+        }
+    )
+    mcu.lookup_query_command = lambda msg, resp: get_config
+    return mcu
+
+
+def test_failed_connect_does_not_propagate():
+    mcu = _make_mcu()
+
+    def _boom():
+        raise mcu_mod.error("Failed automated reset of MCU 'test'")
+
+    mcu._connect = _boom
+    assert mcu.recon_mcu() is False
+    assert mcu.non_critical_disconnected is True
+    assert mcu._serial.disconnected is True
+    assert RECON_EVENT not in mcu._printer.events
+
+
+def test_shutdown_mcu_gets_reset_and_retries():
+    mcu = _make_mcu(is_shutdown_response=1)
+    mcu._reset_cmd = _FakeCommand()
+    assert mcu.recon_mcu() is False
+    assert mcu._reset_cmd.sent == 1
+    assert mcu._serial.disconnected is True
+    assert mcu.non_critical_disconnected is True
+    assert RECON_EVENT not in mcu._printer.events
+
+
+def test_shutdown_mcu_clear_shutdown_fallback():
+    mcu = _make_mcu(is_shutdown_response=1)
+    clear_cmd = _FakeCommand()
+    mcu.try_lookup_command = lambda name: clear_cmd
+    assert mcu.recon_mcu() is False
+    assert clear_cmd.sent == 1
+    assert mcu._serial.disconnected is True
+
+
+def test_shutdown_skips_disconnected_non_critical_mcu():
+    mcu = _make_mcu()
+    mcu._emergency_stop_cmd = _FakeCommand()
+    mcu.non_critical_disconnected = True
+    mcu._shutdown()
+    assert mcu._emergency_stop_cmd.sent == 0
+
+
+def test_successful_recon_clears_stale_shutdown_flag():
+    mcu = _make_mcu()
+    mcu._is_shutdown = True
+    assert mcu.recon_mcu() is True
+    assert mcu._is_shutdown is False
+    assert mcu.non_critical_disconnected is False
+    assert mcu._printer.events == [RECON_EVENT]


### PR DESCRIPTION
## Summary
- `recon_mcu()` runs in a reactor timer callback with no exception handling, so any error during a reconnect attempt (CRC mismatch, serial error, MCU in shutdown state) crashes all of klippy (#870)
- Contain reconnect failures: log, return to the disconnected state, let the timer retry
- If the MCU reports a shutdown state on reconnect, request `reset` (or `clear_shutdown` as fallback) so the next attempt starts clean; reset host-side `_is_shutdown` after a successful reconnect (unblocks #905)
- Skip `emergency_stop` for disconnected non-critical MCUs during klippy shutdown
- `canbus_stats`: the pre-send `non_critical_disconnected` check can't catch the connection dropping while a query is in flight, so the raised error kills klippy on any CAN disconnect (#900 bug 3)

Fixes #870

## Test plan
- [x] Hardware (F072 CAN toolhead, non-critical): forced firmware shutdown → disconnect → reset → reconnect, printer stays ready
- [x] Hardware: 30s CAN bus loss (`ip link set can0 down/up`) → clean disconnect/reconnect, no crash
- [x] Same scenarios on PR #905 + this branch: firmware shutdown on a non-critical MCU fully recovers