### PR TITLE
trdispatch: unlink trdispatch_mcu before free

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -222,6 +222,8 @@ defs_trdispatch = """
     void trdispatch_start(struct trdispatch *td, uint32_t dispatch_reason);
     void trdispatch_stop(struct trdispatch *td);
     struct trdispatch *trdispatch_alloc(void);
+    void trdispatch_free(struct trdispatch *td);
+    void trdispatch_mcu_free(struct trdispatch_mcu *tdm);
     struct trdispatch_mcu *trdispatch_mcu_alloc(struct trdispatch *td
         , struct serialqueue *sq, struct command_queue *cq, uint32_t trsync_oid
         , uint32_t set_timeout_msgtag, uint32_t trigger_msgtag

--- a/klippy/chelper/trdispatch.c
+++ b/klippy/chelper/trdispatch.c
@@ -178,6 +178,27 @@ trdispatch_alloc(void)
     return td;
 }
 
+// Free a 'struct trdispatch' object and any trdispatch_mcu still attached
+//
+// Used as the cffi destructor for the trdispatch cdata.  Children are freed
+// here rather than via their own destructors: Python's cyclic collector runs
+// finalizers in an arbitrary order within a reference cycle, so a child
+// destructor cannot rely on its parent still being alive.
+void __visible
+trdispatch_free(struct trdispatch *td)
+{
+    if (!td)
+        return;
+    while (!list_empty(&td->tdm_list)) {
+        struct trdispatch_mcu *tdm = list_first_entry(
+            &td->tdm_list, struct trdispatch_mcu, node);
+        list_del(&tdm->node);
+        free(tdm);
+    }
+    pthread_mutex_destroy(&td->lock);
+    free(td);
+}
+
 // Create a new 'struct trdispatch_mcu' object
 struct trdispatch_mcu * __visible
 trdispatch_mcu_alloc(struct trdispatch *td, struct serialqueue *sq
@@ -207,6 +228,37 @@ trdispatch_mcu_alloc(struct trdispatch *td, struct serialqueue *sq
     list_add_tail(&tdm->node, &td->tdm_list);
 
     return tdm;
+}
+
+// Free a 'struct trdispatch_mcu' object
+//
+// trdispatch_mcu_alloc() links the object into td->tdm_list.  It must be
+// unlinked before the memory is released, otherwise handle_trsync_state(),
+// trdispatch_start() and trdispatch_stop() walk into freed memory.
+//
+// The caller must guarantee 'td' is still alive.  Callers are:
+//   - MCU_trsync._build_config(), explicitly, before allocating a replacement
+//   - trdispatch_free(), while tearing down the parent
+void __visible
+trdispatch_mcu_free(struct trdispatch_mcu *tdm)
+{
+    if (!tdm)
+        return;
+    struct trdispatch *td = tdm->td;
+
+    // Unlink under td->lock - handle_trsync_state() walks tdm_list with it held
+    pthread_mutex_lock(&td->lock);
+    uint32_t was_active = td->is_active;
+    list_del(&tdm->node);
+    pthread_mutex_unlock(&td->lock);
+
+    // If trdispatch_start() registered the fastreader then trdispatch_stop()
+    // will no longer see this node - deregister it here.  rm_fastreader() also
+    // acts as a barrier against an in-flight dispatch on the background thread.
+    if (was_active)
+        serialqueue_rm_fastreader(tdm->sq, &tdm->fr);
+
+    free(tdm);
 }
 
 // Setup for a trigger test

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -233,17 +233,21 @@ class MCU_trsync:
         )
         state_tag = state_cmd.get_command_tag()
         ffi_main, ffi_lib = chelper.get_ffi()
-        self._trdispatch_mcu = ffi_main.gc(
-            ffi_lib.trdispatch_mcu_alloc(
-                self._trdispatch,
-                mcu._serial.get_serialqueue(),  # XXX
-                self._cmd_queue,
-                self._oid,
-                set_timeout_tag,
-                trigger_tag,
-                state_tag,
-            ),
-            ffi_lib.free,
+        # Not ffi.gc() - lifetime is managed explicitly.  _build_config() runs
+        # again when a non-critical mcu reconnects; free the previous object
+        # first so it is unlinked from td->tdm_list.  Any object still attached
+        # at teardown is released by trdispatch_free().
+        if self._trdispatch_mcu is not None:
+            ffi_lib.trdispatch_mcu_free(self._trdispatch_mcu)
+            self._trdispatch_mcu = None
+        self._trdispatch_mcu = ffi_lib.trdispatch_mcu_alloc(
+            self._trdispatch,
+            mcu._serial.get_serialqueue(),  # XXX
+            self._cmd_queue,
+            self._oid,
+            set_timeout_tag,
+            trigger_tag,
+            state_tag,
         )
 
     def _shutdown(self):
@@ -321,7 +325,9 @@ class TriggerDispatch:
         self._mcu = mcu
         self._trigger_completion = None
         ffi_main, ffi_lib = chelper.get_ffi()
-        self._trdispatch = ffi_main.gc(ffi_lib.trdispatch_alloc(), ffi_lib.free)
+        self._trdispatch = ffi_main.gc(
+            ffi_lib.trdispatch_alloc(), ffi_lib.trdispatch_free
+        )
         self._trsyncs = [MCU_trsync(mcu, self._trdispatch)]
 
     def get_oid(self):


### PR DESCRIPTION
# Summary
cherry-pick of the chelper commit from #905 (author preserved). `trdispatch_mcu_alloc()` links the object into `td->tdm_list`, but it was released with `ffi_lib.free()` and never unlinked. When `_build_config()` re-runs after a non-critical MCU reconnect, the old object is freed while still on the list and `trdispatch_start()`/`handle_trsync_state()` walk into freed memory on the next homing move

## Test plan
- [x] chelper compiles, unit suite passes, no formatting delta
- [x] Reconnect cycles with this commit in place ran on a real printer during the #905/#918 test session