### PR TITLE
led: run update function as reactor callback

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -274,9 +274,6 @@ class MCU_I2C:
         )
 
     def i2c_write_noack(self, data, minclock=0, reqclock=0):
-        if self.i2c_write_cmd is None:
-            self._to_write.append(data)
-            return
         self.i2c_write_cmd.send(
             [self.oid, data], minclock=minclock, reqclock=reqclock
         )

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -12,6 +12,7 @@ from . import output_pin
 class LEDHelper:
     def __init__(self, config, update_func, led_count=1):
         self.printer = config.get_printer()
+        self.mutex = self.printer.get_reactor().mutex()
         self.update_func = update_func
         self.led_count = led_count
         self.need_transmit = False
@@ -70,11 +71,18 @@ class LEDHelper:
     def _check_transmit(self, print_time=None):
         if not self.need_transmit:
             return
+        # Just avoid any race conditions
+        led_state = self.led_state
         self.need_transmit = False
-        try:
-            self.update_func(self.led_state, print_time)
-        except self.printer.command_error as e:
-            logging.exception("led update transmit error")
+
+        def reactor_cb(eventtime):
+            try:
+                with self.mutex:
+                    self.update_func(led_state, print_time)
+            except self.printer.command_error as e:
+                logging.exception("led update transmit error")
+
+        self.printer.get_reactor().register_callback(reactor_cb)
 
     cmd_SET_LED_help = "Set the color of an LED"
 

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -18,7 +18,6 @@ MAX_MCU_SIZE = 500  # Sanity check on LED chain length
 class PrinterNeoPixel:
     def __init__(self, config):
         self.printer = printer = config.get_printer()
-        self.mutex = printer.get_reactor().mutex()
         # Configure neopixel
         ppins = printer.lookup_object("pins")
         pin_params = ppins.lookup_pin(config.get("pin"))
@@ -121,12 +120,8 @@ class PrinterNeoPixel:
             logging.info("Neopixel update did not succeed")
 
     def update_leds(self, led_state, print_time):
-        def reactor_bgfunc(eventtime):
-            with self.mutex:
-                self.update_color_data(led_state)
-                self.send_data(print_time)
-
-        self.printer.get_reactor().register_callback(reactor_bgfunc)
+        self.update_color_data(led_state)
+        self.send_data(print_time)
 
     def get_status(self, eventtime=None):
         return self.led_helper.get_status(eventtime)

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -28,7 +28,7 @@ class PCA9533:
         minclock = 0
         if print_time is not None:
             minclock = self.i2c.get_mcu().print_time_to_clock(print_time)
-        self.i2c.i2c_write_noack(
+        self.i2c.i2c_write(
             [PCA9533_PLS0, ls0],
             minclock=minclock,
             reqclock=BACKGROUND_PRIORITY_CLOCK,

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -14,9 +14,12 @@ PCA9533_PLS0 = 0b101
 
 class PCA9533:
     def __init__(self, config):
-        self.printer = config.get_printer()
+        self.printer = printer = config.get_printer()
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
         self.led_helper = led.LEDHelper(config, self.update_leds, 1)
+        printer.register_event_handler("klippy:connect", self.handle_connect)
+
+    def handle_connect(self):
         self.i2c.i2c_write([PCA9533_PWM0, 85])
         self.i2c.i2c_write([PCA9533_PWM1, 170])
         self.update_leds(self.led_helper.get_status()["color_data"], None)

--- a/klippy/extras/pca9632.py
+++ b/klippy/extras/pca9632.py
@@ -39,7 +39,7 @@ class PCA9632:
         if self.prev_regs.get(reg) == val:
             return
         self.prev_regs[reg] = val
-        self.i2c.i2c_write_noack(
+        self.i2c.i2c_write(
             [reg, val], minclock=minclock, reqclock=BACKGROUND_PRIORITY_CLOCK
         )
 


### PR DESCRIPTION
## Summary
Cherry-pick of upstream [Klipper#7087](https://github.com/Klipper3d/klipper/pull/7087):

- `led: run update function as reactor callback`: LEDHelper now runs the LED update in a reactor callback with its own mutex (moved out of neopixel). pca9533/pca9632 return to acked `i2c_write`, the noack workaround is not needed outside the lookahead path.
- `pca9533: do write on connect like pca9632 does`: also drops the pre-connect buffering fallback from `i2c_write_noack`.

This brings our LED helper API in line with current upstream, which is what recent klipper-led_effect releases target (Klipper#7067 was already in via #805).

Fixes #762

## Test plan
- [x] Unit suite passes, including the neopixel tests that guard Kalico's non-critical MCU handling
- [x] `klippy/extras/led.py` ends up byte-identical to upstream master
- [x] Hardware (F072 CAN toolhead): SET_LED transmits successfully through the new reactor callback path, is safely skipped while the MCU is disconnected, and the LED state resyncs on reconnect