### PR TITLE
docs: clarify that Switch to Kalico assumes an existing install

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 ## Switch to Kalico
 
 > [!NOTE]
+> The steps below assume an existing Klipper installation (a `klipper`
+> systemd service and a `~/klippy-env` python environment). On a fresh
+> machine, install via [KIAUH](https://github.com/dw-0/kiauh) or run one
+> of the OS-specific setup scripts in [`scripts/`](scripts/) after
+> cloning; see the
+> [installation documentation](https://docs.kalico.gg/Installation.html).
+>
 > Any add-on modules you are using will need to be reinstalled after switching to Kalico. This includes things like Beacon support, led-effect, etc.
 >
 > Any data in ~/printer_data such as printer configs and macros will be unaffected.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -81,6 +81,24 @@ KIAUH can be used to install Kalico and its associated programs on a variety
 of Linux-based systems that run a form of Debian. More information can be found
 at https://github.com/dw-0/kiauh
 
+## Installing with the setup scripts
+
+As an alternative to KIAUH, the repository ships OS-specific setup
+scripts in [scripts/](../scripts/) (for example `install-debian.sh`,
+`install-arch.sh` or `install-ubuntu-22.04.sh`). After cloning the
+repository, the matching script installs the required system packages,
+creates the `~/klippy-env` python environment and registers the
+`klipper` service:
+
+```bash
+git clone https://github.com/KalicoCrew/kalico.git ~/klipper
+~/klipper/scripts/install-debian.sh
+```
+
+Note that these scripts install Kalico itself; Moonraker and a web
+interface such as Mainsail or Fluidd still need to be installed
+separately.
+
 ## Building and flashing the micro-controller
 
 To compile the micro-controller code, start by running these commands


### PR DESCRIPTION
The README steps presume a Klipper service and ~/klippy-env already exist. Point fresh installs at KIAUH or the OS-specific setup scripts, and document the scripts in Installation.md.

Fixes #893