### PR TITLE
heaters: Make PID_PROFILE control-aware for non-PID profiles

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1299,6 +1299,11 @@ HEATER generally takes the short name (so for `heater_generic chamber` you would
 only write `chamber`)
 
 #### PID_PROFILE
+Despite the name, profiles are not limited to PID control: a profile
+carries a control algorithm (`pid`, `pid_v`, `dual_loop_pid`,
+`watermark` or `mpc`) along with its settings, and loading a profile
+switches the heater to that algorithm.
+
 `PID_PROFILE LOAD=<profile_name> HEATER=<heater_name> [DEFAULT=<profile_name>]
 [VERBOSE=<verbosity>] [KEEP_TARGET=0|1] [LOAD_CLEAN=0|1]`:
 Loads the given PID_PROFILE for the specified heater. If DEFAULT is specified,
@@ -1317,7 +1322,9 @@ if you encounter weird behaviour while switching profiles.
 
 `PID_PROFILE SAVE=<profile_name> HEATER=<heater_name>`:
 Saves the currently loaded profile of the specified heater to the config under
-the given name.
+the given name. Supported for the PID control types and `watermark`;
+`mpc` profiles cannot be saved this way (use the
+[MPC calibration flow](MPC.md) and SAVE_CONFIG instead).
 
 `PID_PROFILE REMOVE=<profile_name> HEATER=<heater_name>`:
 Removes the given profile from the profiles List for the current session and
@@ -1339,7 +1346,9 @@ By default the information will be kept to reduce overshoot, change this value
 if you encounter weird behaviour while switching profiles.
 
 `PID_PROFILE GET_VALUES HEATER=<heater_name>`:
-Outputs the values of the current loaded pid_profile of the given heater to the console.
+Outputs the values of the currently loaded profile of the given heater to the
+console. For non-PID control types (`watermark`, `mpc`) the profile fields are
+listed generically.
 
 ### [pause_resume]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1345,10 +1345,11 @@ started up, if set to 0, the profile will retain previous heating information.
 By default the information will be kept to reduce overshoot, change this value
 if you encounter weird behaviour while switching profiles.
 
-`PID_PROFILE GET_VALUES HEATER=<heater_name>`:
+`PID_PROFILE GET_VALUES=<profile_name> HEATER=<heater_name>`:
 Outputs the values of the currently loaded profile of the given heater to the
-console. For non-PID control types (`watermark`, `mpc`) the profile fields are
-listed generically.
+console (the `GET_VALUES` value is required by the command syntax but
+ignored; the active profile is always shown). For non-PID control types
+(`watermark`, `mpc`) the profile fields are listed generically.
 
 ### [pause_resume]
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -35,6 +35,7 @@ PID_PROFILE_OPTIONS = {
     "pid_ki": (float, "%.3f"),
     "pid_kd": (float, "%.3f"),
 }
+PID_CONTROL_TYPES = ("pid", "pid_v", "dual_loop_pid")
 DUAL_LOOP_PID_INNER_TARGET_OPTION = "inner_target_temp"
 DUAL_LOOP_PID_INNER_TARGET_DEPRECATED_OPTION = "inner_max_temp"
 
@@ -711,8 +712,24 @@ class Heater:
             self.outer_instance.gcode.respond_info(msg)
             self.save_profile(profile_name=profile_name, verbose=True)
 
+        def _profile_fields_msg(self, profile):
+            # Generic field dump for non-PID profile types
+            msg = "Control: %s\n" % (profile["control"],)
+            for key, value in sorted(profile.items()):
+                if key in ("control", "name") or value is None:
+                    continue
+                if isinstance(value, (int, float, str)):
+                    msg += "%s: %s\n" % (key, value)
+            msg += "name: %s" % (profile["name"],)
+            return msg
+
         def get_values(self, profile_name, gcmd, verbose):
             temp_profile = self.outer_instance.get_control().get_profile()
+            if temp_profile["control"] not in PID_CONTROL_TYPES:
+                self.outer_instance.gcode.respond_info(
+                    self._profile_fields_msg(temp_profile)
+                )
+                return
             target = temp_profile["pid_target"]
             tolerance = temp_profile["pid_tolerance"]
             control = temp_profile["control"]
@@ -749,27 +766,47 @@ class Heater:
 
         def save_profile(self, profile_name=None, gcmd=None, verbose=True):
             temp_profile = self.outer_instance.get_control().get_profile()
+            control = temp_profile["control"]
+            if control not in PID_CONTROL_TYPES and control != "watermark":
+                self.outer_instance.gcode.respond_info(
+                    "Saving [%s] profiles with PID_PROFILE SAVE"
+                    " is not supported." % (control,)
+                )
+                return
             if profile_name is None:
                 profile_name = temp_profile["name"]
             section_name = self._compute_section_name(profile_name)
             self.outer_instance.configfile.set(
                 section_name, "pid_version", PID_PROFILE_VERSION
             )
-            is_dual_loop = temp_profile["control"] == "dual_loop_pid"
-            for key, (type, placeholder) in PID_PROFILE_OPTIONS.items():
-                value = temp_profile[key]
-                if value is not None:
-                    self.outer_instance.configfile.set(
-                        section_name, key, placeholder % value
-                    )
-                # Mirror the inner/secondary loop keys read in _init_profile
-                if is_dual_loop and key in ("pid_kp", "pid_ki", "pid_kd"):
-                    inner_key = "inner_" + key
-                    inner_value = temp_profile.get(inner_key)
-                    if inner_value is not None:
+            if control == "watermark":
+                self.outer_instance.configfile.set(
+                    section_name, "control", control
+                )
+                self.outer_instance.configfile.set(
+                    section_name,
+                    "max_delta",
+                    "%.4f" % (temp_profile["max_delta"],),
+                )
+            else:
+                is_dual_loop = control == "dual_loop_pid"
+                for key, (type, placeholder) in PID_PROFILE_OPTIONS.items():
+                    value = temp_profile[key]
+                    if value is not None:
                         self.outer_instance.configfile.set(
-                            section_name, inner_key, placeholder % inner_value
+                            section_name, key, placeholder % value
                         )
+                    # Mirror the inner/secondary loop keys read in
+                    # _init_profile
+                    if is_dual_loop and key in ("pid_kp", "pid_ki", "pid_kd"):
+                        inner_key = "inner_" + key
+                        inner_value = temp_profile.get(inner_key)
+                        if inner_value is not None:
+                            self.outer_instance.configfile.set(
+                                section_name,
+                                inner_key,
+                                placeholder % inner_value,
+                            )
             temp_profile["name"] = profile_name
             self.profiles[profile_name] = temp_profile
             if verbose:
@@ -836,6 +873,11 @@ class Heater:
                 % (profile["name"], self.outer_instance.short_name)
             )
             if verbose == "high":
+                if profile["control"] not in PID_CONTROL_TYPES:
+                    self.outer_instance.gcode.respond_info(
+                        self._profile_fields_msg(profile)
+                    )
+                    return
                 smooth_time = (
                     self.outer_instance.get_smooth_time()
                     if profile["smooth_time"] is None

--- a/test/test_pid_profile.py
+++ b/test/test_pid_profile.py
@@ -264,3 +264,84 @@ def test_load_high_verbose_dual_loop_reports_inner():
     assert "inner_pid_Kp=60.499" in output
     assert "inner_pid_Ki=2.425" in output
     assert "inner_pid_Kd=377.360" in output
+
+
+######################################################################
+# Non-PID profiles (watermark/mpc) must not crash (#848)
+######################################################################
+
+
+def _watermark_profile(name="default"):
+    return {"control": "watermark", "name": name, "max_delta": 2.0}
+
+
+def _mpc_profile(name="default"):
+    return {
+        "control": "mpc",
+        "name": name,
+        "block_heat_capacity": 22.3,
+        "ambient_transfer": 0.15,
+        "heater_power": 60.0,
+        "smoothing": 0.83,
+        "target_reach_time": 2.0,
+        "filament_temp_src": ("ambient",),
+        "ambient_temp_sensor": None,
+        "cooling_fan": None,
+        "fan_ambient_transfer": [],
+    }
+
+
+def _make_control_setup(profile):
+    heater = _FakeDualLoopHeater()
+    heater.control = _FakeControl(profile)
+    pmgr = _make_pmgr(heater)
+    pmgr.profiles = {profile["name"]: profile}
+    return heater, pmgr
+
+
+def test_get_values_watermark_does_not_crash():
+    heater, pmgr = _make_control_setup(_watermark_profile())
+    gcmd = _gcmd(heater, {"GET_VALUES": "default"})
+    pmgr.get_values("default", gcmd, True)
+    output = "\n".join(heater.gcode.messages)
+    assert "watermark" in output
+    assert "max_delta" in output
+
+
+def test_get_values_mpc_does_not_crash():
+    heater, pmgr = _make_control_setup(_mpc_profile())
+    gcmd = _gcmd(heater, {"GET_VALUES": "default"})
+    pmgr.get_values("default", gcmd, True)
+    output = "\n".join(heater.gcode.messages)
+    assert "mpc" in output
+    assert "block_heat_capacity" in output
+
+
+def test_save_profile_watermark_persists():
+    heater, pmgr = _make_control_setup(_watermark_profile())
+    pmgr.save_profile(profile_name="cooler", verbose=False)
+    saved = heater.configfile.data["pid_profile heater_bed cooler"]
+    assert saved["control"] == "watermark"
+    assert saved["max_delta"] == "2.0000"
+    assert pmgr.profiles["cooler"]["max_delta"] == 2.0
+
+
+def test_save_profile_mpc_declines_gracefully():
+    heater, pmgr = _make_control_setup(_mpc_profile())
+    pmgr.save_profile(profile_name="mpc_save", verbose=True)
+    assert heater.configfile.data == {}
+    output = "\n".join(heater.gcode.messages)
+    assert "not supported" in output
+
+
+def test_load_high_verbose_watermark_does_not_crash():
+    heater, pmgr = _make_dual_loop_setup()
+    pmgr.profiles["cooler"] = _watermark_profile("cooler")
+    gcmd = _gcmd(
+        heater,
+        {"LOAD": "cooler", "VERBOSE": "high", "LOAD_CLEAN": "1"},
+    )
+    pmgr.load_profile("cooler", gcmd, True)
+    output = "\n".join(heater.gcode.messages)
+    assert "loaded" in output
+    assert "max_delta" in output


### PR DESCRIPTION
GET_VALUES, SAVE and LOAD VERBOSE=high unconditionally read PID-only keys from the active profile and raised a KeyError when the control was watermark or mpc. Print non-PID profile fields generically, save watermark profiles properly and decline mpc saves with a message.

On hardware, the baseline KeyError escalates to a full printer shutdown (generic exceptions in gcode handlers trigger invoke_shutdown), so this also kills an active print.

Fixes #848