### PR TITLE
stm32: Add STM32H750 with 32kb bootloader offset

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -311,7 +311,7 @@ choice
     config STM32_FLASH_START_7000
         bool "28KiB bootloader" if MACH_STM32F1 && !MACH_AT32F403
     config STM32_FLASH_START_8000
-        bool "32KiB bootloader" if (MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7) && !MACH_AT32F403
+        bool "32KiB bootloader" if (MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7 || MACH_STM32H750) && !MACH_AT32F403
     config STM32_FLASH_START_8800
         bool "34KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_9000
@@ -328,7 +328,7 @@ choice
     config STM32_FLASH_START_4000
         bool "16KiB bootloader" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F4x5 || MACH_STM32F103 || MACH_STM32F072 || MACH_STM32F411
     config STM32_FLASH_START_20000
-        bool "128KiB bootloader" if MACH_STM32H743 || MACH_STM32H723 || MACH_STM32F7
+        bool "128KiB bootloader" if MACH_STM32H743 || MACH_STM32H723 || MACH_STM32F7 || MACH_STM32H750
     config STM32_FLASH_START_20200
         bool "128KiB bootloader with 512 byte offset" if MACH_STM32F4x5 || MACH_STM32F427
 


### PR DESCRIPTION
Cherry-picks upstream Klipper commit [666781a6e](https://github.com/Klipper3d/klipper/commit/666781a6ecd4d72a1c6568f0b5b0fa19b18f9c62), adding the 32KiB and 128KiB bootloader offset options for the STM32H750. Supersedes #854, which only added the 128KiB option.
