### PR TITLE
docs: Clarify that MPC cooling_fan accepts any fan section

### DIFF
--- a/docs/MPC.md
+++ b/docs/MPC.md
@@ -46,7 +46,8 @@ filament_heat_capacity: 1.8
   _Default Value: Nothing_  
   The fan that is cooling extruded filament and the hotend. Default is no fan so 
   there will be no fan taken into account for controlling the heater.
-  Specifying "fan" will automatically use the part cooling fan.
+  Specifying "fan" will automatically use the part cooling fan. Any other fan
+  section can also be used, e.g. `cooling_fan: fan_generic <fan_name>`.
   
 - `filament_diameter: 1.75`  
   _Default Value: 1.75 (mm)_  


### PR DESCRIPTION
## Summary
- Clarify in MPC.md that the extruder `cooling_fan` option accepts any fan section (e.g. `fan_generic <fan_name>`), not just `fan`. This has been supported since MPC was introduced but was only documented in the bed heater section.
- Closes #858

## Test plan
- [x] Docs-only change, rendered markdown checked