### PR TITLE
docs: Config references and hybrid corexy clarifications

### DIFF
--- a/config/example-hybrid-corexy.cfg
+++ b/config/example-hybrid-corexy.cfg
@@ -29,6 +29,23 @@ position_endstop: 0
 position_max: 200
 homing_speed: 50
 
+# On four motor hybrid machines (such as the RatRig V-Core hybrid) add
+# a second stepper to the X rail and a second Y stepper. The second X
+# stepper is automatically driven with the mirrored belt direction.
+#[stepper_x1]
+#step_pin: PF3
+#dir_pin: PF4
+#enable_pin: !PD6
+#microsteps: 16
+#rotation_distance: 40
+
+#[stepper_y1]
+#step_pin: PK1
+#dir_pin: PK2
+#enable_pin: !PK3
+#microsteps: 16
+#rotation_distance: 40
+
 [stepper_z]
 step_pin: PL3
 dir_pin: PL1

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -785,6 +785,12 @@ max_z_accel:
 # stepper controlling the X-Y movement.
 [stepper_x]
 
+# Additional steppers may be added to the X rail as [stepper_x1],
+# [stepper_x2], etc. Each additional X stepper is driven with the
+# mirrored belt direction. Combined with additional Y steppers
+# ([stepper_y1]) this supports four motor hybrid machines such as the
+# RatRig V-Core hybrid.
+
 # The stepper_y section is used to describe the stepper controlling
 # the Y axis.
 [stepper_y]
@@ -821,6 +827,10 @@ max_z_accel:
 # The stepper_x section is used to describe the X axis as well as the
 # stepper controlling the X-Z movement.
 [stepper_x]
+
+# Additional steppers may be added to the X rail as [stepper_x1],
+# [stepper_x2], etc. Each additional X stepper is driven with the
+# mirrored belt direction.
 
 # The stepper_y section is used to describe the stepper controlling
 # the Y axis.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -171,6 +171,9 @@ configuration between multiple sections. References take the form of
 `${section.option}` to look up a value elsewhere in your configuration. Note,
 that constants must always be lower case.
 
+References are a plain text substitution: the referenced value is copied
+as-is. Expressions and Python-like functions are not evaluated.
+
 Optionally, a `[constants]` section can be used specifically to store
 these values. Unused constants will display a warning. However, `[constants]`
 will display an error if none of the constants are used.


### PR DESCRIPTION
## Summary
- State explicitly that `${...}` config references are plain text substitution and nothing is evaluated. Follow-up to #716.
- Document that hybrid_corexy/hybrid_corexz accept additional steppers on the X rail (mirrored belt direction, added in #628) and extend the hybrid corexy example config with a commented four motor layout such as the RatRig V-Core hybrid. Follow-up to #847.

## Test plan
- [x] Docs-only change, rendered markdown checked
- [x] Example config additions are commented out, no parse impact