### PR TITLE
ci: Don't mask docker image build failures

### DIFF
--- a/.github/workflows/ci-build_test.yaml
+++ b/.github/workflows/ci-build_test.yaml
@@ -41,10 +41,9 @@ jobs:
         if: steps.changes.outputs.klipper == 'true'
         run: |
           set -o pipefail
-          sudo apt-get update && sudo apt-get install -y expect
           # Clean up docker output so that github ::group: instructions
           # get recognized
-          unbuffer docker build --progress=plain -f scripts/Dockerfile-build \
+          docker build --progress=plain -f scripts/Dockerfile-build \
             -t dangerklippers/klipper-build:latest . 2>&1 \
             | sed -u -E 's/^#[0-9]+ [0-9.]+ ?//g'
 


### PR DESCRIPTION
## Summary
- On the #895 CI run the docker image rebuild failed with the ar100 size overflow, but the "Test Klipper build" step still went green. The klippy tests then ran against the stale docker hub image with old dicts and failed with a confusing KeyError instead of showing the real build error.
- The unbuffer wrapper masks the docker build exit code. Removed it along with the expect install. With --progress=plain the output pipes fine through sed, and pipefail now fails the step properly.

## Test plan
- [x] Local repro: a failing docker build piped through the same sed exits 1 with pipefail, no unbuffer needed
- [ ] Group formatting still renders on a firmware-touching PR run