### PR TITLE
controller_fan: Add configurable standby speed

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3904,11 +3904,11 @@ a shutdown_speed equal to max_power.
 ### [controller_fan]
 
 Controller cooling fan (one may define any number of sections with a
-"controller_fan" prefix). A "controller fan" is a fan that will be
-enabled whenever its associated heater or its associated stepper
-driver is active. The fan will stop whenever an idle_timeout is
-reached to ensure no overheating will occur after deactivating a
-watched component.
+"controller_fan" prefix). A "controller fan" changes speed based on
+its associated heater or stepper driver. The fan runs at fan_speed
+while a watched component is active, then at idle_speed for
+idle_timeout seconds. After that timeout, and before the first watched
+activity after startup, the fan runs at standby_speed.
 
 ```
 [controller_fan my_controller_fan]
@@ -3929,13 +3929,17 @@ watched component.
 #   will be set to when a heater or stepper driver is active.
 #   The default is 1.0
 #idle_timeout:
-#   The amount of time (in seconds) after a stepper driver or heater
-#   was active and the fan should be kept running. The default
-#   is 30 seconds.
+#   The amount of time (in seconds) to use idle_speed after a stepper
+#   driver or heater becomes inactive. A value of 0 transitions
+#   directly to standby_speed. The default is 30 seconds.
 #idle_speed:
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
-#   will be set to when a heater or stepper driver was active and
-#   before the idle_timeout is reached. The default is fan_speed.
+#   will be set to after a heater or stepper driver becomes inactive
+#   and before the idle_timeout is reached. The default is fan_speed.
+#standby_speed: 0.0
+#   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
+#   will be set to before the first heater or stepper driver activity
+#   and after idle_timeout is reached. The default is 0.0.
 #heater:
 #stepper:
 #   Name of the config section defining the heater/stepper that this fan

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -26,6 +26,9 @@ class ControllerFan:
         self.idle_speed = config.getfloat(
             "idle_speed", default=self.fan_speed, minval=0.0, maxval=1.0
         )
+        self.standby_speed = config.getfloat(
+            "standby_speed", default=0.0, minval=0.0, maxval=1.0
+        )
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
@@ -57,7 +60,7 @@ class ControllerFan:
         return self.fan.get_status(eventtime)
 
     def callback(self, eventtime):
-        speed = 0.0
+        speed = self.standby_speed
         active = False
         for name in self.stepper_names:
             active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()


### PR DESCRIPTION
## Summary

Add an optional `standby_speed` setting to `[controller_fan]` for systems
that benefit from continuous baseline airflow when monitored steppers and
heaters are inactive.

The state logic is:

- use `fan_speed` while any monitored stepper or heater is active;
- use `idle_speed` after activity stops and until `idle_timeout` expires;
- use `standby_speed` after the timeout expires and before the first
  monitored activity after startup;
- when `idle_timeout` is `0`, transition directly from `fan_speed` to
  `standby_speed`.

`standby_speed` accepts values from `0.0` through `1.0` and defaults to
`0.0`. The zero default preserves the existing off-after-timeout behavior.
Shutdown handling and monitored-component detection are unchanged.

This provides a general-purpose way to keep low airflow across controller
electronics. It does not compensate for a failed fan, wiring fault, or
missing fan supply voltage.

## Documentation

- Updated `docs/Config_Reference.md` to distinguish `fan_speed`,
  `idle_speed`, `idle_timeout`, and `standby_speed`, including the `0.0`
  default and zero-timeout behavior.
- Following maintainer feedback, the mock-heavy standalone controller-fan
  test was removed to keep this small change focused.

## Validation

Local checks for commit `73320a0c`:

- `ruff 0.15.22 check .` — all checks passed.
- `ruff 0.15.22 format --check --diff .` — 253 files already formatted.
- `pre-commit run --all-files` — Ruff and Ruff Format passed.
- `mkdocs build --strict` — passed.
- `git diff --check` — passed.

GitHub Actions:

- [Build test](https://github.com/KalicoCrew/kalico/actions/runs/33634785305)
  passed on Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14. Each run reported
  124 passed and 1 xfailed.
- [Ruff](https://github.com/KalicoCrew/kalico/actions/runs/33634785394)
  passed repository-wide lint and formatting with Ruff 0.15.22.
- [Docs test](https://github.com/KalicoCrew/kalico/actions/runs/33634785418)
  built the documentation successfully.

## Physical verification

- With all monitored drivers inactive after restart, the fan reported
  `value=0.500`, `power=0.575`, and a stable speed of approximately 1523 RPM.
- During a real print with monitored drivers active, the fan reported
  `value=1.000`, `power=1.000`, and approximately 2388 RPM.
- The configured after-run behavior and return to standby after the timeout
  were also verified.
- The hardware test used a four-wire fan with tachometer feedback. Fan
  operation, wiring, and supply voltage were checked independently.

## Checklist

- [x] PR title describes the change
- [x] User-facing configuration reference updated
- [x] Maintainer feedback addressed
- [x] GitHub Actions pass on the updated head
- [x] Physical hardware verification completed
