### PR TITLE
fix: load_cell - report per-batch overflow deltas

### DIFF
--- a/klippy/extras/load_cell/ads1220.py
+++ b/klippy/extras/load_cell/ads1220.py
@@ -234,12 +234,14 @@ class ADS1220(LoadCellSensor):
         logging.info("ADS1220 finished '%s' measurements", self.name)
 
     def _process_batch(self, eventtime) -> BulkAdcData:
+        prev_overflows = self.ffreader.get_last_overflows()
+        prev_error_count = self.last_error_count
         samples = self.ffreader.pull_samples()
         self._convert_samples(samples)
         return {
             "data": samples,
-            "errors": self.last_error_count,
-            "overflows": self.ffreader.get_last_overflows(),
+            "errors": self.last_error_count - prev_error_count,
+            "overflows": self.ffreader.get_last_overflows() - prev_overflows,
         }
 
     def reset_chip(self):

--- a/klippy/extras/load_cell/ads131m0x.py
+++ b/klippy/extras/load_cell/ads131m0x.py
@@ -256,11 +256,14 @@ class ADS131MxBase(LoadCellSensor):
         logging.info(f"{self.sensor_type} finished '{self.name}' measurements")
 
     def _process_batch(self, eventtime):
+        prev_overflows = self.ffreader.get_last_overflows()
+        prev_error_count = self.last_error_count
         samples = self.ffreader.pull_samples()
+        data = self._convert_samples(samples)
         return {
-            "data": self._convert_samples(samples),
-            "errors": self.last_error_count,
-            "overflows": self.ffreader.get_last_overflows(),
+            "data": data,
+            "errors": self.last_error_count - prev_error_count,
+            "overflows": self.ffreader.get_last_overflows() - prev_overflows,
         }
 
     # --- SPI Communication Helpers ---

--- a/klippy/extras/load_cell/hx71x.py
+++ b/klippy/extras/load_cell/hx71x.py
@@ -176,8 +176,8 @@ class HX71xBase(LoadCellSensor):
             self.consecutive_fails = 0
         return {
             "data": samples,
-            "errors": self.last_error_count,
-            "overflows": self.ffreader.get_last_overflows(),
+            "errors": errors,
+            "overflows": overflows,
         }
 
 

--- a/klippy/extras/load_cell/interfaces.py
+++ b/klippy/extras/load_cell/interfaces.py
@@ -12,7 +12,11 @@ from klippy.mcu import MCU
 
 
 class BulkAdcData(TypedDict):
-    """Dictionary returned by sensors containing raw sensor data"""
+    """Dictionary returned by sensors containing raw sensor data.
+
+    `errors` and `overflows` are counts new to this batch only (deltas since
+    the previous batch), not lifetime totals since measurements started.
+    """
 
     data: list[tuple[float, ...]]
     errors: int


### PR DESCRIPTION
## Summary

Load cell sensors were publishing lifetime `errors` / `overflows` totals in each 100 ms batch (`FixedFreqReader.get_last_overflows()` since `note_start`). `LoadCellSampleCollector` does `+=` on those fields, so it assumed per-batch deltas.

That mismatch meant a short MCU backlog could leave a non-zero session total in the stream. Later probe tare / `LOAD_CELL_DIAGNOSTIC` then failed with inflated overflow counts even when the collection window itself was clean. ADS131 does not restart on overflow streaks the way HX71x can, so the poison stuck until `FIRMWARE_RESTART`.

On hardware where the ADS131 shares an MCU with an accelerometer (for example LIS2DW on the same toolhead MCU), starting `ACCELEROMETER_MEASURE` at `sample_rate: 500` is enough to provoke overflows. Concurrent bulk I/O delays the ADS131 SPI task past its poll deadline.

This change makes ADS131, ADS1220, and HX71x report only new errors/overflows in each batch, matching what the collector already sums and what HX71x already computed internally for restart decisions. `BulkAdcData` documents that contract.

Accelerometer dump paths are unchanged; they still publish session totals.

## Reproduction / Testing

Reproduced on Bondtech INDX (ADS131M02 + LIS2DW on `indxmcu`) running latest Kalico ([ae261624](https://github.com/KalicoCrew/kalico/commit/ae261624f57fb597dcffaa46062b1c58d3e5999d)).

Requires ADS131 (or ADS1220) load cell on the same MCU as a bulk accelerometer chip.

- [ ] Set `sample_rate: 500`, restart, idle `LOAD_CELL_DIAGNOSTIC` - expect no overflows
- [ ] Start accel sampling: `ACCELEROMETER_MEASURE CHIP=<accel>` (e.g. `lis2dw`)
- [ ] While it runs, `PROBE` or `LOAD_CELL_DIAGNOSTIC` - expect overflows / probe error on unpatched code
- [ ] Stop accel: `ACCELEROMETER_MEASURE CHIP=<accel>` again
- [ ] Idle ~30 s (no restart), then `PROBE` again:
  - unpatched: still fails (sticky lifetime totals)
  - patched: succeeds if the collection window itself is clean
- [ ] After a known overflow burst, diagnostic overflow count should be small (window deltas), not hundreds

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green