### PR TITLE
indx: Add induction coil tool presence detection

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6291,6 +6291,33 @@ mcu:
 #   Override the IR sensor tuning parameters stored in the sensor
 #   EEPROM. All three must be provided if any is given. These should
 #   not normally be set.
+#ringdown_enable: False
+#ringdown_heat_gate: False
+#ringdown_present_peak_v: 87.0
+#ringdown_absent_peak_v: 91.0
+#   Peak tank volts for classification. Seated (present) peaks are
+#   lower than empty (absent) on Bondtech. present must be < absent.
+#   Peak <= present → present; peak >= absent → absent; else unknown.
+#ringdown_min_peak_v: 20.0
+#   Reject captures weaker than this (status=not_enough_peaks).
+#ringdown_idle_ms: 500
+#ringdown_heat_ms: 500
+#ringdown_excite_scale: 0.8
+#   Multiplier on calibrated soft-start ON ticks for the probe pulse
+#   (0.05-1.0). Soften below 1.0 if empty-head probes trip overvoltage
+#   (Bondtech empty often OV at 1.0). Cannot exceed 1.0 (never hotter
+#   than coil_time_on_first).
+#ringdown_zero_margin_v: 1.0
+#   ADC floor in volts used for DUMP off_start annotation (not for
+#   peak-amplitude classification). Overvoltage mid-probe always
+#   aborts (status=overvoltage).
+#   LC ringdown nozzle-presence detection. When ringdown_enable is
+#   True the toolboard periodically fires a soft coil impulse and
+#   classifies coupling from first-lobe peak amplitude (present /
+#   absent / unknown). Defaults are from Bondtech characterisation;
+#   confirm on your head before enabling ringdown_heat_gate (which
+#   refuses to heat unless presence is present). Use
+#   INDX_RINGDOWN_PROBE DUMP=1 to inspect waveforms. See INDX.md.
 ```
 
 ### [sx1509]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1112,7 +1112,35 @@ override.
 #### INDX_SET_IR_SENSOR_PARAMS
 `INDX_SET_IR_SENSOR_PARAMS EXPONENT=<value> OBJ_GAIN=<value>
 BRACKET_GAIN=<value>`: Override the IR sensor tuning parameters
-stored in the sensor EEPROM. These should not normally be changed.
+stored in the sensor EEPROM. All three must be provided.
+
+#### INDX_RINGDOWN_PROBE
+`INDX_RINGDOWN_PROBE [DUMP=0|1]`: Fire a oneshot LC ringdown probe and
+report nozzle presence (`present` / `absent` / `unknown`), `peak_v`,
+status, and `n_peaks`. Requires calibrated coil timings
+(`INDX_CALIBRATE`). Useful for characterising peak-amplitude thresholds
+and excitation before enabling continuous ringdown or the heat gate.
+Status may be `valid`, `not_enough_peaks`, `overvoltage`, `timeout`,
+or `aborted`. With `DUMP=1`, the MCU streams the capture buffer and
+detected peaks; the host writes `/tmp/indx_ringdown_waveform.csv`
+(index, ns, counts, mv, is_peak; header includes `peak_mv`). Use DUMP
+when classification looks wrong to inspect the waveform.
+
+#### INDX_SET_RINGDOWN_PARAMS
+`INDX_SET_RINGDOWN_PARAMS [ENABLE=0|1] [HEAT_GATE=0|1]
+[PRESENT_PEAK_V=<v>] [ABSENT_PEAK_V=<v>] [MIN_PEAK_V=<v>]
+[IDLE_MS=<ms>] [HEAT_MS=<ms>] [EXCITE_SCALE=<0.05-1.0>]
+[ZERO_MARGIN_V=<v>]`:
+Configure continuous ringdown probing, the optional heat gate, and
+peak-amplitude thresholds. PRESENT_PEAK_V must be less than
+ABSENT_PEAK_V (seated peak is lower than empty on Bondtech). Peak at
+or below PRESENT_PEAK_V → present; at or above ABSENT_PEAK_V → absent;
+between → unknown. MIN_PEAK_V rejects weak captures. EXCITE_SCALE
+multiplies the soft-start ON pulse but cannot exceed 1.0 (never hotter
+than coil_time_on_first); default 0.8. Empty at 1.0 may overvoltage.
+ZERO_MARGIN_V annotates DUMP off_start. Overvoltage mid-probe always
+aborts. Updated values are staged for SAVE_CONFIG. Keep HEAT_GATE
+disabled until thresholds are confirmed on your hardware (see INDX.md).
 
 #### INDX_SET_CYCLE_LIMIT
 `INDX_SET_CYCLE_LIMIT LIMIT=<value>`: Limit the coil driver duty

--- a/docs/INDX.md
+++ b/docs/INDX.md
@@ -118,5 +118,44 @@ INDX_LOAD_FILAMENT
 Use `INDX_CLEAR_FILAMENT` to reset the filament parameters, and
 `SAVE_CONFIG` to persist any of these values.
 
+## Nozzle presence (LC ringdown)
+
+The toolboard classifies whether a steel nozzle is coupled to the
+induction coil by firing a soft single-cycle impulse and measuring the
+**peak voltage of the first resonance lobe**. On Bondtech hardware a
+seated nozzle loads the coil (lower peak); an empty coil rings higher.
+Ambiguous values between the thresholds are reported as `unknown`.
+
+This is independent of load-cell latch preload: ringdown answers "is
+steel in the coil?", while a load cell answers "is the latch
+preloaded?".
+
+Defaults are off. Amplitude thresholds
+(`ringdown_present_peak_v` / `ringdown_absent_peak_v`) and
+`ringdown_excite_scale` (default 0.8) come from Bondtech characterisation
+and should be checked on your head before enabling the heat gate:
+
+1. With coil timings calibrated, seat a tool and run
+   `INDX_RINGDOWN_PROBE`. Note the reported `peak_v` and presence.
+   If classification looks wrong, run `INDX_RINGDOWN_PROBE DUMP=1` and
+   inspect `/tmp/indx_ringdown_waveform.csv` on the host.
+2. Remove the tool (latch open / empty head) and probe again. Empty
+   peak should be clearly higher than seated.
+3. If empty probes report `overvoltage`, lower `EXCITE_SCALE` (do not
+   use 1.0 empty on Bondtech - it OV'd in characterisation). Soften
+   toward 0.7-0.8. Excitation cannot be raised above calibrated
+   soft-start (`EXCITE_SCALE` max 1.0).
+4. Optionally check a half-seated tool; expect `unknown` between the
+   two peak thresholds.
+5. Set `PRESENT_PEAK_V` / `ABSENT_PEAK_V` (present must be less than
+   absent) with a clear hysteresis gap via `INDX_SET_RINGDOWN_PARAMS`,
+   then `SAVE_CONFIG`. Defaults 87 V / 91 V suit EXCITE_SCALE=0.8.
+6. Only then consider `HEAT_GATE=1` / `ringdown_heat_gate: True`, which
+   refuses to heat unless presence is `present`.
+
+Enable continuous probing with `ringdown_enable: True` (about every
+500 ms while idle and while heating by default). Soft probes briefly
+pause heating; keep periods conservative.
+
 See the [G-Code reference](G-Codes.md#indx) for the full list of INDX
 commands and their parameters.

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -348,6 +348,24 @@ The following information is available in the
 - `last_dock_measurement`: The result of the last INDX_DOCK_MEASURE
   command (None if no measurement has been taken). It is a dictionary
   containing the keys `x`, `y`, `position` and `axis_order`.
+- `nozzle_presence`: Latest LC ringdown classification (`present`,
+  `absent`, or `unknown`).
+- `nozzle_presence_peak_v`: Peak tank voltage from the last probe
+  (float, volts).
+- `nozzle_presence_n_peaks`: Number of local maxima found in the last
+  capture window (DUMP annotation; not used for classification).
+- `nozzle_presence_status`: Probe outcome (`idle`, `running`, `valid`,
+  `not_enough_peaks`, `aborted`, `overvoltage`, `timeout`).
+- `nozzle_presence_age`: Seconds since the last completed probe, or
+  None if no probe has completed yet.
+- `ringdown_enable`: Whether continuous ringdown probing is enabled.
+- `ringdown_heat_gate`: Whether heating is gated on `present`.
+- `ringdown_excite_scale`: Soft-start ON multiplier for the probe pulse
+  (max 1.0; default 0.8).
+- `ringdown_zero_margin_v`: ADC floor (volts) for DUMP off_start.
+- `ringdown_present_peak_v` / `ringdown_absent_peak_v` /
+  `ringdown_min_peak_v`: Peak-amplitude classification thresholds
+  (volts). Present must be less than absent.
 
 ## led
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -1,3 +1,4 @@
+from klippy.configfile import PrinterConfig
 import logging
 import math
 import struct
@@ -27,6 +28,38 @@ COIL_TUNE_STATUS_RUNNING = 1
 COIL_TUNE_TIMEOUT = 15.0  # seconds. The MCU self-aborts a stuck tune at 10 s
 COIL_TUNE_POLL_INTERVAL = 0.2  # seconds between latched-status polls
 COIL_TUNE_WAVE_PATH = "/tmp/indx_coil_waveform.csv"
+RINGDOWN_WAVE_PATH = "/tmp/indx_ringdown_waveform.csv"
+
+# Mirrors MCU ringdown_status / nozzle_presence enums.
+RINGDOWN_STATUS = {
+    0: "idle",
+    1: "running",
+    2: "valid",
+    3: "not_enough_peaks",
+    4: "aborted",
+    5: "overvoltage",
+    6: "timeout",
+}
+RINGDOWN_STATUS_IDLE = 0
+RINGDOWN_STATUS_RUNNING = 1
+RINGDOWN_PRESENCE = {0: "unknown", 1: "present", 2: "absent"}
+RINGDOWN_PROBE_TIMEOUT = 5.0
+RINGDOWN_PROBE_POLL_INTERVAL = 0.05
+RINGDOWN_EXCITE_SCALE_DEFAULT = 0.8
+RINGDOWN_EXCITE_SCALE_MAX = 1.0
+RINGDOWN_ZERO_MARGIN_V_DEFAULT = 1.0
+RINGDOWN_PRESENT_PEAK_V_DEFAULT = 87.0
+RINGDOWN_ABSENT_PEAK_V_DEFAULT = 91.0
+RINGDOWN_MIN_PEAK_V_DEFAULT = 20.0
+RINGDOWN_RESPONSE = (
+    "indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u n_peaks=%c"
+)
+RINGDOWN_SET_PARAMS_CMD = (
+    "indx_set_ringdown_params enable=%c heat_gate=%c present_peak_v=%u "
+    "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u zero_margin_v=%u "
+    "min_peak_v=%u"
+)
+
 FILAMENT_LOAD_THRESHOLD = 10.0
 FILAMENT_LOAD_PRIME_TIME = 5.0
 FILAMENT_LOAD_MAX_LENGTH = 120.0
@@ -53,9 +86,7 @@ def float_to_u32(val):
 
 
 class IndxThermistorWrapper:
-    def __init__(
-        self, toolboard, sensor, config, def_max_temp, thermistor_config
-    ):
+    def __init__(self, toolboard, sensor, config, def_max_temp, thermistor_config):
         self.toolboard = toolboard
         self.temperature_callbacks = []
 
@@ -107,9 +138,7 @@ class IndxBracketTempSensor:
         self.force_temp = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
-        gcode.register_command(
-            "INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP
-        )
+        gcode.register_command("INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP)
 
     def build_config(self):
         self.cmd_set_ambient_temp = self.toolboard.mcu.lookup_command(
@@ -174,9 +203,7 @@ class IndxToolboardHeater:
         self.vin_adc = toolboard.mcu.setup_pin("adc", {"pin": "vin_mon"})
         compat.register_adc_callback(self.vin_adc, self.handle_vin_mon)
         query_adc = toolboard.printer.load_object(config, "query_adc")
-        query_adc.register_adc(
-            f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc
-        )
+        query_adc.register_adc(f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc)
         self.supply_voltage = 24.0
 
         # The autotuned thermal-model parameters have no defaults.
@@ -189,26 +216,18 @@ class IndxToolboardHeater:
             thermal_capacity=config.getfloat(
                 "model_thermal_capacity", default=None, above=0.0
             ),
-            to_ambient_r=config.getfloat(
-                "model_to_ambient_r", default=None, above=0.0
-            ),
+            to_ambient_r=config.getfloat("model_to_ambient_r", default=None, above=0.0),
             filament_radius=config.getfloat(
                 "model_filament_diameter",
                 default=1.75,
             )
             / 2.0,
-            filament_density=config.getfloat(
-                "model_filament_density", default=1.20
-            ),
+            filament_density=config.getfloat("model_filament_density", default=1.20),
             filament_heat_capacity=config.getfloat(
                 "model_filament_heat_capacity", default=1.8
             ),
-            part_cooling_fan_a=config.getfloat(
-                "model_part_cooling_fan_a", default=0.0
-            ),
-            part_cooling_fan_k=config.getfloat(
-                "model_part_cooling_fan_k", default=0.0
-            ),
+            part_cooling_fan_a=config.getfloat("model_part_cooling_fan_a", default=0.0),
+            part_cooling_fan_k=config.getfloat("model_part_cooling_fan_k", default=0.0),
             ambient_blend_board=config.getfloat(
                 "model_ambient_blend_board", default=0.0
             ),
@@ -218,28 +237,71 @@ class IndxToolboardHeater:
             ambient_blend_sensor=config.getfloat(
                 "model_ambient_blend_sensor", default=1.0
             ),
-            error_application=config.getfloat(
-                "model_error_application", default=1.0
-            ),
+            error_application=config.getfloat("model_error_application", default=1.0),
         )
         self.thermal_model = ThermalModel(model_params)
         self.max_model_error = config.getfloat("max_model_error", default=50.0)
 
+        # LC ringdown nozzle presence (defaults off until characterised).
+        self.ringdown_enable = config.getboolean("ringdown_enable", False)
+        self.ringdown_heat_gate = config.getboolean("ringdown_heat_gate", False)
+        self.ringdown_present_peak_v = config.getfloat(
+            "ringdown_present_peak_v",
+            default=RINGDOWN_PRESENT_PEAK_V_DEFAULT,
+            above=0.0,
+            maxval=200.0,
+        )
+        self.ringdown_absent_peak_v = config.getfloat(
+            "ringdown_absent_peak_v",
+            default=RINGDOWN_ABSENT_PEAK_V_DEFAULT,
+            above=0.0,
+            maxval=200.0,
+        )
+        if not (self.ringdown_present_peak_v < self.ringdown_absent_peak_v):
+            raise config.error(
+                "ringdown_present_peak_v must be less than ringdown_absent_peak_v"
+            )
+        self.ringdown_min_peak_v = config.getfloat(
+            "ringdown_min_peak_v",
+            default=RINGDOWN_MIN_PEAK_V_DEFAULT,
+            minval=0.0,
+            maxval=200.0,
+        )
+        self.ringdown_idle_ms = config.getint(
+            "ringdown_idle_ms", default=500, minval=20, maxval=5000
+        )
+        self.ringdown_heat_ms = config.getint(
+            "ringdown_heat_ms", default=500, minval=50, maxval=10000
+        )
+        self.ringdown_excite_scale = config.getfloat(
+            "ringdown_excite_scale",
+            default=RINGDOWN_EXCITE_SCALE_DEFAULT,
+            above=0.05,
+            maxval=RINGDOWN_EXCITE_SCALE_MAX,
+        )
+        self.ringdown_zero_margin_v = config.getfloat(
+            "ringdown_zero_margin_v",
+            default=RINGDOWN_ZERO_MARGIN_V_DEFAULT,
+            above=0.0,
+            maxval=50.0,
+        )
+        self.nozzle_presence = "unknown"
+        self.nozzle_presence_peak_v = 0.0
+        self.nozzle_presence_n_peaks = 0
+        self.nozzle_presence_status = "idle"
+        self.nozzle_presence_time = 0.0
+
         self.pid_kp = config.getfloat("pid_kp", default=4.0)
         self.pid_ti = config.getfloat("pid_ti", minval=0.0, default=0.0)
         self.pid_td = config.getfloat("pid_td", minval=0.0, default=0.0)
-        self.pid_b = config.getfloat(
-            "pid_b", minval=0.0, maxval=1.0, default=1.0
-        )
+        self.pid_b = config.getfloat("pid_b", minval=0.0, maxval=1.0, default=1.0)
         self.max_temp_nozzle = config.getfloat("max_temp_nozzle", default=305.0)
         self.max_temp_sensor = config.getfloat("max_temp_sensor", default=130.0)
 
         self.ir_sensor_tuning = None
         ir_sensor_exponent = config.getfloat("ir_sensor_exponent", default=None)
         ir_sensor_obj_gain = config.getfloat("ir_sensor_obj_gain", default=None)
-        ir_sensor_bracket_gain = config.getfloat(
-            "ir_sensor_bracket_gain", default=None
-        )
+        ir_sensor_bracket_gain = config.getfloat("ir_sensor_bracket_gain", default=None)
         tuning = (
             ir_sensor_exponent,
             ir_sensor_obj_gain,
@@ -256,23 +318,15 @@ class IndxToolboardHeater:
         # heating can't be done, but we allow not setting them so the user can run the
         # tuning routine. These are specified in microseconds by the user.
         coil_timings = (
-            config.getfloat(
-                "coil_time_on", default=None, above=0.0, below=10.0
-            ),
-            config.getfloat(
-                "coil_time_off", default=None, above=0.0, below=10.0
-            ),
-            config.getfloat(
-                "coil_time_on_first", default=None, above=0.0, below=10.0
-            ),
+            config.getfloat("coil_time_on", default=None, above=0.0, below=10.0),
+            config.getfloat("coil_time_off", default=None, above=0.0, below=10.0),
+            config.getfloat("coil_time_on_first", default=None, above=0.0, below=10.0),
         )
         self.coil_timings = None
         if all(coil_timings):
             t_on, t_off, t_on_first = coil_timings
             if t_on_first > t_on:
-                raise config.error(
-                    "coil_time_on_first must not exceed coil_time_on"
-                )
+                raise config.error("coil_time_on_first must not exceed coil_time_on")
             # microseconds -> seconds for the MCU
             self.coil_timings = (t_on * 1e-6, t_off * 1e-6, t_on_first * 1e-6)
         elif any(coil_timings):
@@ -288,12 +342,8 @@ class IndxToolboardHeater:
             if fan_obj is None:
                 fan_obj = toolboard.printer.lookup_object(fan_name)
             if fan_obj is None:
-                raise config.error(
-                    f"Unknown cooling_fan '{fan_name}' specified"
-                )
-            if not hasattr(fan_obj, "fan") or not hasattr(
-                fan_obj.fan, "set_speed"
-            ):
+                raise config.error(f"Unknown cooling_fan '{fan_name}' specified")
+            if not hasattr(fan_obj, "fan") or not hasattr(fan_obj.fan, "set_speed"):
                 raise config.error(
                     f"cooling_fan '{fan_name}' is not a valid fan object"
                 )
@@ -323,12 +373,8 @@ class IndxToolboardHeater:
         gcode.register_command("INDX_LOAD_FILAMENT", self.cmd_LOAD_FILAMENT)
         gcode.register_command("INDX_CLEAR_FILAMENT", self.cmd_CLEAR_FILAMENT)
         gcode.register_command("INDX_EXTRUDER_MOVE", self.cmd_EXTRUDER_MOVE)
-        gcode.register_command(
-            "INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS
-        )
-        gcode.register_command(
-            "INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE
-        )
+        gcode.register_command("INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS)
+        gcode.register_command("INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE)
 
         gcode.register_command("INDX_LOG", self.cmd_LOG)
         self.log_file = None
@@ -341,8 +387,29 @@ class IndxToolboardHeater:
             "INDX_DEBUG_STREAM_RAW_IR_SENSOR",
             self.cmd_DEBUG_STREAM_RAW_IR_SENSOR,
         )
+        gcode.register_command("INDX_RINGDOWN_PROBE", self.cmd_RINGDOWN_PROBE)
+        gcode.register_command("INDX_SET_RINGDOWN_PARAMS", self.cmd_SET_RINGDOWN_PARAMS)
         self.raw_ir_log_file = None
         self.raw_ir_log_sensors = []
+
+    def get_ringdown_status(self, eventtime):
+        age = None
+        if self.nozzle_presence_time:
+            age = max(0.0, eventtime - self.nozzle_presence_time)
+        return {
+            "nozzle_presence": self.nozzle_presence,
+            "nozzle_presence_peak_v": self.nozzle_presence_peak_v,
+            "nozzle_presence_n_peaks": self.nozzle_presence_n_peaks,
+            "nozzle_presence_status": self.nozzle_presence_status,
+            "nozzle_presence_age": age,
+            "ringdown_enable": self.ringdown_enable,
+            "ringdown_heat_gate": self.ringdown_heat_gate,
+            "ringdown_excite_scale": self.ringdown_excite_scale,
+            "ringdown_zero_margin_v": self.ringdown_zero_margin_v,
+            "ringdown_present_peak_v": self.ringdown_present_peak_v,
+            "ringdown_absent_peak_v": self.ringdown_absent_peak_v,
+            "ringdown_min_peak_v": self.ringdown_min_peak_v,
+        }
 
     def build_config(self):
         mcu = self.toolboard.mcu
@@ -358,6 +425,13 @@ class IndxToolboardHeater:
             self.handle_debug_raw_ir,
             "indx_debug_raw_ir object=%u ambient=%u",
         )
+
+        compat.register_response(
+            mcu,
+            self.handle_nozzle_presence,
+            RINGDOWN_RESPONSE,
+        )
+
         self.cmd_debug_stream_raw_ir = mcu.lookup_command(
             "indx_debug_stream_raw_ir_sensor enable=%c", cq=self.cmd_queue
         )
@@ -371,9 +445,19 @@ class IndxToolboardHeater:
             "indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
             cq=self.cmd_queue,
         )
-        amp_per_count = mcu.get_constant_float(
-            "INDX_CURRENT_SENSE_AMP_PER_COUNT"
+        self.ringdown_probe_cmd = mcu.lookup_command(
+            "indx_ringdown_probe dump=%c", cq=self.cmd_queue
         )
+        self.query_ringdown_cmd = mcu.lookup_query_command(
+            "indx_query_ringdown",
+            RINGDOWN_RESPONSE,
+            cq=self.cmd_queue,
+        )
+        self.cmd_set_ringdown_params = mcu.lookup_command(
+            RINGDOWN_SET_PARAMS_CMD,
+            cq=self.cmd_queue,
+        )
+        amp_per_count = mcu.get_constant_float("INDX_CURRENT_SENSE_AMP_PER_COUNT")
         current_sense_rate = mcu.get_constant_float("INDX_CURRENT_SENSE_RATE")
         self.power_scale = amp_per_count / current_sense_rate
 
@@ -402,6 +486,24 @@ class IndxToolboardHeater:
                 f" time_on_first={float_to_u32(t_on_first)}"
             )
 
+        # Push LC ringdown config (including amplitude thresholds) to the MCU.
+        mcu.add_config_cmd(
+            "indx_set_ringdown_params enable=%d heat_gate=%d present_peak_v=%u "
+            "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u "
+            "zero_margin_v=%u min_peak_v=%u"
+            % (
+                1 if self.ringdown_enable else 0,
+                1 if self.ringdown_heat_gate else 0,
+                float_to_u32(self.ringdown_present_peak_v),
+                float_to_u32(self.ringdown_absent_peak_v),
+                self.ringdown_idle_ms,
+                self.ringdown_heat_ms,
+                float_to_u32(self.ringdown_excite_scale),
+                float_to_u32(self.ringdown_zero_margin_v),
+                float_to_u32(self.ringdown_min_peak_v),
+            )
+        )
+
     def handle_connect(self):
         # Look for heaters that have us as their PWM output
         pheaters = self.toolboard.printer.lookup_object("heaters")
@@ -424,6 +526,17 @@ class IndxToolboardHeater:
                         "INDX heater has not been calibrated yet. "
                         "Run INDX_CALIBRATE to perform calibration."
                     )
+                if (
+                    degrees
+                    and self.ringdown_enable
+                    and self.ringdown_heat_gate
+                    and self.nozzle_presence != "present"
+                ):
+                    raise self.toolboard.printer.command_error(
+                        "INDX ringdown heat gate: nozzle not present "
+                        "(presence=%s). Seat a tool, run INDX_RINGDOWN_PROBE, "
+                        "or disable ringdown_heat_gate." % (self.nozzle_presence,)
+                    )
                 base_set_temp(degrees)
 
             heater.set_temp = guarded_set_temp
@@ -437,6 +550,222 @@ class IndxToolboardHeater:
                 control.profile = heater.pmgr.init_default_profile()
 
             break
+
+    def _apply_ringdown_result(self, params):
+        status = params["status"]
+        presence = params["presence"]
+        self.nozzle_presence_status = RINGDOWN_STATUS.get(status, status)
+        self.nozzle_presence = RINGDOWN_PRESENCE.get(presence, "unknown")
+        self.nozzle_presence_peak_v = params["peak_mv"] / 1000.0
+        self.nozzle_presence_n_peaks = params.get("n_peaks", 0)
+        self.nozzle_presence_time = self.toolboard.printer.get_reactor().monotonic()
+
+    def handle_nozzle_presence(self, params):
+        # Ignore in-flight running polls from background probes mid-sample.
+        if params["status"] == RINGDOWN_STATUS_RUNNING:
+            return
+        self._apply_ringdown_result(params)
+
+    def _send_ringdown_params(self):
+        self.cmd_set_ringdown_params.send(
+            [
+                1 if self.ringdown_enable else 0,
+                1 if self.ringdown_heat_gate else 0,
+                float_to_u32(self.ringdown_present_peak_v),
+                float_to_u32(self.ringdown_absent_peak_v),
+                self.ringdown_idle_ms,
+                self.ringdown_heat_ms,
+                float_to_u32(self.ringdown_excite_scale),
+                float_to_u32(self.ringdown_zero_margin_v),
+                float_to_u32(self.ringdown_min_peak_v),
+            ]
+        )
+
+    def cmd_RINGDOWN_PROBE(self, gcmd):
+        if self.coil_timings is None:
+            raise gcmd.error(
+                "INDX ringdown requires calibrated coil timings. "
+                "Run INDX_CALIBRATE first."
+            )
+        dump = gcmd.get_int("DUMP", 0, minval=0, maxval=1)
+        reactor = self.toolboard.printer.get_reactor()
+        mcu = self.toolboard.mcu
+        samples = []
+        peaks = []
+        meta = {}
+        wave = peak = meta_resp = None
+        if dump:
+            wave = compat.register_response(
+                mcu,
+                lambda p: samples.append((p["index"], p["ns"], p["counts"], p["mv"])),
+                "indx_ringdown_wave index=%u ns=%u counts=%u mv=%u",
+            )
+            peak = compat.register_response(
+                mcu,
+                lambda p: peaks.append((p["index"], p["sample"], p["counts"], p["mv"])),
+                "indx_ringdown_peak index=%c sample=%u counts=%u mv=%u",
+            )
+            meta_resp = compat.register_response(
+                mcu,
+                lambda p: meta.update(p),
+                "indx_ringdown_meta off_start=%i zero_mv=%u n_peaks=%c "
+                "status=%c peak_mv=%u",
+            )
+        try:
+            self.ringdown_probe_cmd.send([dump])
+            timeout = RINGDOWN_PROBE_TIMEOUT
+            if dump:
+                timeout += 5.0
+            deadline = reactor.monotonic() + timeout
+            result = None
+            while True:
+                result = self.query_ringdown_cmd.send([])
+                if result["status"] != RINGDOWN_STATUS_RUNNING:
+                    break
+                if reactor.monotonic() > deadline:
+                    raise gcmd.error("INDX ringdown probe timed out")
+                reactor.pause(reactor.monotonic() + RINGDOWN_PROBE_POLL_INTERVAL)
+        finally:
+            if wave is not None:
+                wave.unregister()
+            if peak is not None:
+                peak.unregister()
+            if meta_resp is not None:
+                meta_resp.unregister()
+            if dump:
+                with open(RINGDOWN_WAVE_PATH, "w") as f:
+                    f.write(
+                        "# off_start=%s zero_mv=%s n_peaks=%s status=%s "
+                        "peak_mv=%s\n"
+                        % (
+                            meta.get("off_start", ""),
+                            meta.get("zero_mv", ""),
+                            meta.get("n_peaks", ""),
+                            meta.get("status", ""),
+                            meta.get("peak_mv", ""),
+                        )
+                    )
+                    f.write("index,ns,counts,mv,is_peak\n")
+                    peak_samples = {p[1] for p in peaks}
+                    for index, ns, counts, mv in samples:
+                        is_peak = 1 if index in peak_samples else 0
+                        f.write("%d,%d,%d,%d,%d\n" % (index, ns, counts, mv, is_peak))
+                    f.write("# peaks: index,sample,counts,mv\n")
+                    for index, sample, counts, mv in peaks:
+                        f.write("# peak,%d,%d,%d,%d\n" % (index, sample, counts, mv))
+                gcmd.respond_info(
+                    "INDX ringdown waveform (%d samples, %d peaks) saved to %s"
+                    % (len(samples), len(peaks), RINGDOWN_WAVE_PATH)
+                )
+        self._apply_ringdown_result(result)
+        if result["status"] == RINGDOWN_STATUS_IDLE:
+            raise gcmd.error(
+                "INDX ringdown probe did not start (is another probe/tune active?)"
+            )
+        gcmd.respond_info(
+            "INDX ringdown: presence=%s status=%s peak_v=%.1f n_peaks=%u"
+            % (
+                self.nozzle_presence,
+                self.nozzle_presence_status,
+                self.nozzle_presence_peak_v,
+                self.nozzle_presence_n_peaks,
+            )
+        )
+
+    def cmd_SET_RINGDOWN_PARAMS(self, gcmd):
+        self.ringdown_enable = bool(
+            gcmd.get_int("ENABLE", int(self.ringdown_enable), minval=0, maxval=1)
+        )
+        self.ringdown_heat_gate = bool(
+            gcmd.get_int("HEAT_GATE", int(self.ringdown_heat_gate), minval=0, maxval=1)
+        )
+        self.ringdown_present_peak_v = gcmd.get_float(
+            "PRESENT_PEAK_V",
+            self.ringdown_present_peak_v,
+            above=0.0,
+            maxval=200.0,
+        )
+        self.ringdown_absent_peak_v = gcmd.get_float(
+            "ABSENT_PEAK_V",
+            self.ringdown_absent_peak_v,
+            above=0.0,
+            maxval=200.0,
+        )
+        if not (self.ringdown_present_peak_v < self.ringdown_absent_peak_v):
+            raise gcmd.error("PRESENT_PEAK_V must be less than ABSENT_PEAK_V")
+        self.ringdown_min_peak_v = gcmd.get_float(
+            "MIN_PEAK_V",
+            self.ringdown_min_peak_v,
+            minval=0.0,
+            maxval=200.0,
+        )
+        self.ringdown_idle_ms = gcmd.get_int(
+            "IDLE_MS", self.ringdown_idle_ms, minval=20, maxval=5000
+        )
+        self.ringdown_heat_ms = gcmd.get_int(
+            "HEAT_MS", self.ringdown_heat_ms, minval=50, maxval=10000
+        )
+        self.ringdown_excite_scale = gcmd.get_float(
+            "EXCITE_SCALE",
+            self.ringdown_excite_scale,
+            above=0.05,
+            maxval=RINGDOWN_EXCITE_SCALE_MAX,
+        )
+        self.ringdown_zero_margin_v = gcmd.get_float(
+            "ZERO_MARGIN_V",
+            self.ringdown_zero_margin_v,
+            above=0.0,
+            maxval=50.0,
+        )
+        self._send_ringdown_params()
+        configfile: PrinterConfig = self.toolboard.printer.lookup_object("configfile")
+        section = self.toolboard.name
+        configfile.set(
+            section, "ringdown_enable", "True" if self.ringdown_enable else "False"
+        )
+        configfile.set(
+            section,
+            "ringdown_heat_gate",
+            "True" if self.ringdown_heat_gate else "False",
+        )
+        configfile.set(
+            section,
+            "ringdown_present_peak_v",
+            "%.3f" % self.ringdown_present_peak_v,
+        )
+        configfile.set(
+            section,
+            "ringdown_absent_peak_v",
+            "%.3f" % self.ringdown_absent_peak_v,
+        )
+        configfile.set(
+            section, "ringdown_min_peak_v", "%.3f" % self.ringdown_min_peak_v
+        )
+        configfile.set(section, "ringdown_idle_ms", "%d" % self.ringdown_idle_ms)
+        configfile.set(section, "ringdown_heat_ms", "%d" % self.ringdown_heat_ms)
+        configfile.set(
+            section, "ringdown_excite_scale", "%.4f" % self.ringdown_excite_scale
+        )
+        configfile.set(
+            section, "ringdown_zero_margin_v", "%.3f" % self.ringdown_zero_margin_v
+        )
+        gcmd.respond_info(
+            "INDX ringdown params updated (enable=%s heat_gate=%s "
+            "present_peak_v=%.1f absent_peak_v=%.1f min_peak_v=%.1f "
+            "idle_ms=%d heat_ms=%d excite_scale=%.3f zero_margin_v=%.2f). "
+            "Run SAVE_CONFIG to persist."
+            % (
+                self.ringdown_enable,
+                self.ringdown_heat_gate,
+                self.ringdown_present_peak_v,
+                self.ringdown_absent_peak_v,
+                self.ringdown_min_peak_v,
+                self.ringdown_idle_ms,
+                self.ringdown_heat_ms,
+                self.ringdown_excite_scale,
+                self.ringdown_zero_margin_v,
+            )
+        )
 
     def apply_pid_params(self):
         self.cmd_set_control_params.send(
@@ -469,11 +798,7 @@ class IndxToolboardHeater:
     def cur_target_temp(self):
         time = self.toolboard.printer.get_reactor().monotonic()
         return next(
-            (
-                h.get_temp(time)[1]
-                for h in self.heaters
-                if h.get_temp(time)[1] != 0.0
-            ),
+            (h.get_temp(time)[1] for h in self.heaters if h.get_temp(time)[1] != 0.0),
             None,
         )
 
@@ -492,9 +817,7 @@ class IndxToolboardHeater:
     def fan_speed(self, time):
         if self.part_cooling_fan is None:
             return 0.0
-        return max(
-            0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"])
-        )
+        return max(0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"]))
 
     def _blend_ambient_temp(self, sensor_temp):
         # Weighted blend of the board/bracket thermistors and the IR sensor's
@@ -566,9 +889,7 @@ class IndxToolboardHeater:
                 # because the user isn't allowed to start heating when no thermal
                 # model is set. We need this check to allow the tuner to work.
                 if self.thermal_model.is_valid():
-                    filament_distance = max(
-                        0.0, extruder_pos - self.last_report[3]
-                    )
+                    filament_distance = max(0.0, extruder_pos - self.last_report[3])
                     fan_speed = self.fan_speed(time)
 
                     ambient_temp = self._blend_ambient_temp(sensor_temp)
@@ -762,9 +1083,7 @@ class IndxToolboardHeater:
         (t_on, t_off, t_on_first) = self.coil_timings
         configfile.set(section, "coil_time_on", "%.3f" % (t_on * 1e6))
         configfile.set(section, "coil_time_off", "%.3f" % (t_off * 1e6))
-        configfile.set(
-            section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6)
-        )
+        configfile.set(section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6))
 
     def _toggle_steppers(self, toolhead, ets, enable):
         # Enable/disable a set of EnableTracking lines with proper toolhead
@@ -790,9 +1109,7 @@ class IndxToolboardHeater:
                 return
             if reactor.monotonic() > deadline:
                 raise gcmd.error(timeout_msg)
-            reactor.pause(
-                reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL
-            )
+            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL)
 
     def _wait_cooldown(self, gcmd, min_temp):
         # Block until the nozzle has cooled below min_temp (the heater must
@@ -817,9 +1134,7 @@ class IndxToolboardHeater:
                 "INDX: no temperature reports received",
             )
             if last_temp[0] > min_temp:
-                gcmd.respond_info(
-                    "INDX: cooling below %.0f C before tuning" % min_temp
-                )
+                gcmd.respond_info("INDX: cooling below %.0f C before tuning" % min_temp)
                 self._model_cal_wait_temp(
                     reactor,
                     gcmd,
@@ -934,9 +1249,7 @@ class IndxToolboardHeater:
             # Baseline (heater off) draw to subtract from measured power.
             phase[0] = "baseline"
             gcmd.respond_info("INDX: measuring baseline power")
-            reactor.pause(
-                reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME
-            )
+            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME)
             baseline_power = calibration.mean_phase_power(samples, "baseline")
             if baseline_power is None:
                 raise gcmd.error("INDX: no baseline power samples received")
@@ -944,8 +1257,7 @@ class IndxToolboardHeater:
             # Heatup to MAX_TEMP.
             phase[0] = "heat"
             gcmd.respond_info(
-                "INDX: heating to %.0f C (baseline %.2f W)"
-                % (max_temp, baseline_power)
+                "INDX: heating to %.0f C (baseline %.2f W)" % (max_temp, baseline_power)
             )
             self.heater_raw_set_temp(max_temp)
             self._model_cal_wait_temp(
@@ -967,9 +1279,7 @@ class IndxToolboardHeater:
             self.heater.set_temp(0.0)
             if cooldown_time > 0.0:
                 phase[0] = "cooldown"
-                gcmd.respond_info(
-                    "INDX: measuring cooldown for %.0f s" % cooldown_time
-                )
+                gcmd.respond_info("INDX: measuring cooldown for %.0f s" % cooldown_time)
                 reactor.pause(reactor.monotonic() + cooldown_time)
 
             self.temperature_callbacks.remove(sampler)
@@ -996,9 +1306,7 @@ class IndxToolboardHeater:
             self._toggle_steppers(toolhead, reenable, True)
 
         if result.get("error"):
-            raise gcmd.error(
-                "INDX thermal model fit failed: %s" % result["error"]
-            )
+            raise gcmd.error("INDX thermal model fit failed: %s" % result["error"])
         self._apply_model_calibration(gcmd, result)
 
     def _apply_model_calibration(self, gcmd, result):
@@ -1054,16 +1362,13 @@ class IndxToolboardHeater:
                 % (p_lo, t_min, p_hi, t_max, -drop_pct)
             )
         lines.append(
-            "thermal_capacity: "
-            + fmt(capacity, result["thermal_capacity_ci"], "J/K")
+            "thermal_capacity: " + fmt(capacity, result["thermal_capacity_ci"], "J/K")
         )
         lines.append(
-            "to_ambient_r: "
-            + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
+            "to_ambient_r: " + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
         )
         lines.append(
-            "fit RMS error: %.2f C over %d samples"
-            % (result["rms"], result["n_fit"])
+            "fit RMS error: %.2f C over %d samples" % (result["rms"], result["n_fit"])
         )
         gcmd.respond_info("INDX thermal model calibrated:\n" + "\n".join(lines))
 
@@ -1073,9 +1378,7 @@ class IndxToolboardHeater:
         if self.part_cooling_fan is None:
             raise gcmd.error("INDX part cooling fan is not configured")
 
-        breaks = gcmd.get_int(
-            "BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3
-        )
+        breaks = gcmd.get_int("BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3)
         hold_time = gcmd.get_float(
             "HOLD_TIME", calibration.FAN_CAL_HOLD_TIME_DEFAULT, above=0.0
         )
@@ -1129,9 +1432,7 @@ class IndxToolboardHeater:
             self.temperature_callbacks.append(sampler)
             installed = True
             self.heater_raw_set_temp(target)
-            gcmd.respond_info(
-                "INDX: waiting for %.0f C for fan calibration" % target
-            )
+            gcmd.respond_info("INDX: waiting for %.0f C for fan calibration" % target)
             self._model_cal_wait_temp(
                 reactor,
                 gcmd,
@@ -1227,9 +1528,7 @@ class IndxToolboardHeater:
             self.temperature_callbacks.remove(cb)
 
         if totals[0] == 0:
-            raise gcmd.error(
-                "No power meansurements received over entire duration"
-            )
+            raise gcmd.error("No power meansurements received over entire duration")
 
         power = totals[1] / totals[0]
         gcmd.respond_info(
@@ -1260,27 +1559,19 @@ class IndxToolboardHeater:
             )
 
         speed = gcmd.get_float("SPEED", FILAMENT_LOAD_SPEED, above=0.0)
-        max_length = gcmd.get_float(
-            "MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0
-        )
-        prime_time = gcmd.get_float(
-            "PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0
-        )
+        max_length = gcmd.get_float("MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0)
+        prime_time = gcmd.get_float("PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0)
         prime_length = gcmd.get_float("PRIME_LENGTH", None, above=0.0)
         if prime_length is None:
             prime_length = speed * prime_time
-        threshold = gcmd.get_float(
-            "THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0
-        )
+        threshold = gcmd.get_float("THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0)
         segment_time = gcmd.get_float(
             "SEGMENT_TIME", FILAMENT_LOAD_SEGMENT_TIME, above=0.0
         )
         apply_result = gcmd.get_int("APPLY", 1, minval=0, maxval=1)
 
         params = self.thermal_model.params
-        filament_area = (
-            params.filament_radius * params.filament_radius * math.pi
-        )
+        filament_area = params.filament_radius * params.filament_radius * math.pi
         last_temp = last_pos = start_pos = loaded_at_pos = None
         load_energy = loaded_energy = loaded_denominator = 0.0
         loaded = False
@@ -1302,9 +1593,7 @@ class IndxToolboardHeater:
                 return
             dt = reading.delta_time
             ambient = self._blend_ambient_temp(reading.sensor_temperature)
-            loss_ambient = (
-                reading.nozzle_temperature - ambient
-            ) / params.to_ambient_r
+            loss_ambient = (reading.nozzle_temperature - ambient) / params.to_ambient_r
             loss_part_cooling = 0.0
             fan_speed = self.fan_speed(reading.time)
             if fan_speed > 0.0:
@@ -1316,9 +1605,7 @@ class IndxToolboardHeater:
                         0.0,
                         (reading.nozzle_temperature - ambient) / pcf_ambient_r,
                     )
-            stored = params.thermal_capacity * (
-                reading.nozzle_temperature - last_temp
-            )
+            stored = params.thermal_capacity * (reading.nozzle_temperature - last_temp)
             loss = (loss_ambient + loss_part_cooling) * dt
             residual = reading.delta_pwm_energy - loss - stored
             load_energy = max(0.0, load_energy + residual)
@@ -1326,9 +1613,7 @@ class IndxToolboardHeater:
             temp_delta = max(0.0, reading.nozzle_temperature - ambient)
             if loaded:
                 loaded_energy += max(0.0, residual)
-                loaded_denominator += (
-                    pos_delta * filament_area / 1000.0 * temp_delta
-                )
+                loaded_denominator += pos_delta * filament_area / 1000.0 * temp_delta
             elif load_energy >= threshold:
                 loaded = True
                 loaded_at_pos = pos
@@ -1391,9 +1676,11 @@ class IndxToolboardHeater:
                 loaded_at_pos - start_pos,
                 last_pos - loaded_at_pos,
                 heat_capacity,
-                "Run SAVE_CONFIG to save the new filament parameters."
-                if apply_result
-                else "Use APPLY=1 to apply the measured filament parameters.",
+                (
+                    "Run SAVE_CONFIG to save the new filament parameters."
+                    if apply_result
+                    else "Use APPLY=1 to apply the measured filament parameters."
+                ),
             )
         )
 
@@ -1406,9 +1693,7 @@ class IndxToolboardHeater:
         section = self.toolboard.name
         configfile.set(section, "model_filament_density", "0.0000")
         configfile.set(section, "model_filament_heat_capacity", "0.0000")
-        gcmd.respond_info(
-            "INDX filament model cleared. Run SAVE_CONFIG to save."
-        )
+        gcmd.respond_info("INDX filament model cleared. Run SAVE_CONFIG to save.")
 
     def cmd_EXTRUDER_MOVE(self, gcmd):
         distance = gcmd.get_float("DISTANCE")
@@ -1424,13 +1709,9 @@ class IndxToolboardHeater:
         stepper = extruder.extruder_stepper.stepper
         current_helper = compat.get_tmc_current_helper(stepper)
         if current_helper is None:
-            raise gcmd.error(
-                "Active extruder does not have a TMC current helper"
-            )
+            raise gcmd.error("Active extruder does not have a TMC current helper")
 
-        run_current, hold_current, req_hold_current, *_ = (
-            current_helper.get_current()
-        )
+        run_current, hold_current, req_hold_current, *_ = current_helper.get_current()
         current = min(current, run_current)
         restore_hold_current = (
             req_hold_current if req_hold_current is not None else hold_current
@@ -1451,16 +1732,12 @@ class IndxToolboardHeater:
             toolhead.wait_moves()
         finally:
             print_time = toolhead.get_last_move_time()
-            current_helper.set_current(
-                run_current, restore_hold_current, print_time
-            )
+            current_helper.set_current(run_current, restore_hold_current, print_time)
 
     def cmd_SET_MODEL_PARAMS(self, gcmd):
         cur = self.thermal_model.params
 
-        max_power = gcmd.get_float(
-            "MAX_POWER", default=cur.max_power, minval=0.0
-        )
+        max_power = gcmd.get_float("MAX_POWER", default=cur.max_power, minval=0.0)
         max_power_temp_coeff = gcmd.get_float(
             "MAX_POWER_TEMP_COEFF", default=cur.max_power_temp_coeff
         )
@@ -1551,9 +1828,7 @@ class IndxToolboardHeater:
         )
         res = cmd.send([])
         print(res)
-        gcmd.respond_info(
-            "".join(hex(c)[2:].ljust(2, "0") for c in res["data"])
-        )
+        gcmd.respond_info("".join(hex(c)[2:].ljust(2, "0") for c in res["data"]))
 
     def cmd_DEBUG_STREAM_RAW_IR_SENSOR(self, gcmd):
         if self.raw_ir_log_file is not None:
@@ -1576,9 +1851,11 @@ class IndxToolboardHeater:
         path = "/tmp/indx_raw_ir_%s.csv" % strftime("%Y%m%d_%H%M%S")
         self.raw_ir_log_file = open(path, "w")
         names = [
-            n[len("temperature_sensor ") :]
-            if n.startswith("temperature_sensor ")
-            else n
+            (
+                n[len("temperature_sensor ") :]
+                if n.startswith("temperature_sensor ")
+                else n
+            )
             for n in self.raw_ir_log_sensors
         ]
         header = ["time", "raw_object", "raw_ambient"] + names
@@ -1600,9 +1877,7 @@ class IndxToolboardHeater:
             try:
                 cols.append(
                     "%.2f"
-                    % printer.lookup_object(name).get_status(eventtime)[
-                        "temperature"
-                    ]
+                    % printer.lookup_object(name).get_status(eventtime)["temperature"]
                 )
             except Exception as e:
                 cols.append("")
@@ -1726,18 +2001,14 @@ class ThermalModel:
                     0.0, (self.temperature - ambient_temp) / pcf_ambient_r
                 )
 
-        loss_ambient = (
-            self.temperature - ambient_temp
-        ) / self.params.to_ambient_r
+        loss_ambient = (self.temperature - ambient_temp) / self.params.to_ambient_r
         loss_filament = (
             filament_distance
             * filament_heat_capacity_mm
             * (self.temperature - filament_temp)
             / dt
         )
-        total_power = (
-            avg_input_power - loss_ambient - loss_filament - loss_part_cooling
-        )
+        total_power = avg_input_power - loss_ambient - loss_filament - loss_part_cooling
         delta_temp_rate = total_power / self.params.thermal_capacity
         new_temp = self.temperature + delta_temp_rate * dt
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -87,7 +87,9 @@ def float_to_u32(val):
 
 
 class IndxThermistorWrapper:
-    def __init__(self, toolboard, sensor, config, def_max_temp, thermistor_config):
+    def __init__(
+        self, toolboard, sensor, config, def_max_temp, thermistor_config
+    ):
         self.toolboard = toolboard
         self.temperature_callbacks = []
 
@@ -139,7 +141,9 @@ class IndxBracketTempSensor:
         self.force_temp = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
-        gcode.register_command("INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP)
+        gcode.register_command(
+            "INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP
+        )
 
     def build_config(self):
         self.cmd_set_ambient_temp = self.toolboard.mcu.lookup_command(
@@ -204,7 +208,9 @@ class IndxToolboardHeater:
         self.vin_adc = toolboard.mcu.setup_pin("adc", {"pin": "vin_mon"})
         compat.register_adc_callback(self.vin_adc, self.handle_vin_mon)
         query_adc = toolboard.printer.load_object(config, "query_adc")
-        query_adc.register_adc(f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc)
+        query_adc.register_adc(
+            f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc
+        )
         self.supply_voltage = 24.0
 
         # The autotuned thermal-model parameters have no defaults.
@@ -217,18 +223,26 @@ class IndxToolboardHeater:
             thermal_capacity=config.getfloat(
                 "model_thermal_capacity", default=None, above=0.0
             ),
-            to_ambient_r=config.getfloat("model_to_ambient_r", default=None, above=0.0),
+            to_ambient_r=config.getfloat(
+                "model_to_ambient_r", default=None, above=0.0
+            ),
             filament_radius=config.getfloat(
                 "model_filament_diameter",
                 default=1.75,
             )
             / 2.0,
-            filament_density=config.getfloat("model_filament_density", default=1.20),
+            filament_density=config.getfloat(
+                "model_filament_density", default=1.20
+            ),
             filament_heat_capacity=config.getfloat(
                 "model_filament_heat_capacity", default=1.8
             ),
-            part_cooling_fan_a=config.getfloat("model_part_cooling_fan_a", default=0.0),
-            part_cooling_fan_k=config.getfloat("model_part_cooling_fan_k", default=0.0),
+            part_cooling_fan_a=config.getfloat(
+                "model_part_cooling_fan_a", default=0.0
+            ),
+            part_cooling_fan_k=config.getfloat(
+                "model_part_cooling_fan_k", default=0.0
+            ),
             ambient_blend_board=config.getfloat(
                 "model_ambient_blend_board", default=0.0
             ),
@@ -238,7 +252,9 @@ class IndxToolboardHeater:
             ambient_blend_sensor=config.getfloat(
                 "model_ambient_blend_sensor", default=1.0
             ),
-            error_application=config.getfloat("model_error_application", default=1.0),
+            error_application=config.getfloat(
+                "model_error_application", default=1.0
+            ),
         )
         self.thermal_model = ThermalModel(model_params)
         self.max_model_error = config.getfloat("max_model_error", default=50.0)
@@ -295,14 +311,18 @@ class IndxToolboardHeater:
         self.pid_kp = config.getfloat("pid_kp", default=4.0)
         self.pid_ti = config.getfloat("pid_ti", minval=0.0, default=0.0)
         self.pid_td = config.getfloat("pid_td", minval=0.0, default=0.0)
-        self.pid_b = config.getfloat("pid_b", minval=0.0, maxval=1.0, default=1.0)
+        self.pid_b = config.getfloat(
+            "pid_b", minval=0.0, maxval=1.0, default=1.0
+        )
         self.max_temp_nozzle = config.getfloat("max_temp_nozzle", default=305.0)
         self.max_temp_sensor = config.getfloat("max_temp_sensor", default=130.0)
 
         self.ir_sensor_tuning = None
         ir_sensor_exponent = config.getfloat("ir_sensor_exponent", default=None)
         ir_sensor_obj_gain = config.getfloat("ir_sensor_obj_gain", default=None)
-        ir_sensor_bracket_gain = config.getfloat("ir_sensor_bracket_gain", default=None)
+        ir_sensor_bracket_gain = config.getfloat(
+            "ir_sensor_bracket_gain", default=None
+        )
         tuning = (
             ir_sensor_exponent,
             ir_sensor_obj_gain,
@@ -319,15 +339,23 @@ class IndxToolboardHeater:
         # heating can't be done, but we allow not setting them so the user can run the
         # tuning routine. These are specified in microseconds by the user.
         coil_timings = (
-            config.getfloat("coil_time_on", default=None, above=0.0, below=10.0),
-            config.getfloat("coil_time_off", default=None, above=0.0, below=10.0),
-            config.getfloat("coil_time_on_first", default=None, above=0.0, below=10.0),
+            config.getfloat(
+                "coil_time_on", default=None, above=0.0, below=10.0
+            ),
+            config.getfloat(
+                "coil_time_off", default=None, above=0.0, below=10.0
+            ),
+            config.getfloat(
+                "coil_time_on_first", default=None, above=0.0, below=10.0
+            ),
         )
         self.coil_timings = None
         if all(coil_timings):
             t_on, t_off, t_on_first = coil_timings
             if t_on_first > t_on:
-                raise config.error("coil_time_on_first must not exceed coil_time_on")
+                raise config.error(
+                    "coil_time_on_first must not exceed coil_time_on"
+                )
             # microseconds -> seconds for the MCU
             self.coil_timings = (t_on * 1e-6, t_off * 1e-6, t_on_first * 1e-6)
         elif any(coil_timings):
@@ -343,8 +371,12 @@ class IndxToolboardHeater:
             if fan_obj is None:
                 fan_obj = toolboard.printer.lookup_object(fan_name)
             if fan_obj is None:
-                raise config.error(f"Unknown cooling_fan '{fan_name}' specified")
-            if not hasattr(fan_obj, "fan") or not hasattr(fan_obj.fan, "set_speed"):
+                raise config.error(
+                    f"Unknown cooling_fan '{fan_name}' specified"
+                )
+            if not hasattr(fan_obj, "fan") or not hasattr(
+                fan_obj.fan, "set_speed"
+            ):
                 raise config.error(
                     f"cooling_fan '{fan_name}' is not a valid fan object"
                 )
@@ -374,8 +406,12 @@ class IndxToolboardHeater:
         gcode.register_command("INDX_LOAD_FILAMENT", self.cmd_LOAD_FILAMENT)
         gcode.register_command("INDX_CLEAR_FILAMENT", self.cmd_CLEAR_FILAMENT)
         gcode.register_command("INDX_EXTRUDER_MOVE", self.cmd_EXTRUDER_MOVE)
-        gcode.register_command("INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS)
-        gcode.register_command("INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE)
+        gcode.register_command(
+            "INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS
+        )
+        gcode.register_command(
+            "INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE
+        )
 
         gcode.register_command("INDX_LOG", self.cmd_LOG)
         self.log_file = None
@@ -389,7 +425,9 @@ class IndxToolboardHeater:
             self.cmd_DEBUG_STREAM_RAW_IR_SENSOR,
         )
         gcode.register_command("INDX_RINGDOWN_PROBE", self.cmd_RINGDOWN_PROBE)
-        gcode.register_command("INDX_SET_RINGDOWN_PARAMS", self.cmd_SET_RINGDOWN_PARAMS)
+        gcode.register_command(
+            "INDX_SET_RINGDOWN_PARAMS", self.cmd_SET_RINGDOWN_PARAMS
+        )
         self.raw_ir_log_file = None
         self.raw_ir_log_sensors = []
 
@@ -458,7 +496,9 @@ class IndxToolboardHeater:
             RINGDOWN_SET_PARAMS_CMD,
             cq=self.cmd_queue,
         )
-        amp_per_count = mcu.get_constant_float("INDX_CURRENT_SENSE_AMP_PER_COUNT")
+        amp_per_count = mcu.get_constant_float(
+            "INDX_CURRENT_SENSE_AMP_PER_COUNT"
+        )
         current_sense_rate = mcu.get_constant_float("INDX_CURRENT_SENSE_RATE")
         self.power_scale = amp_per_count / current_sense_rate
 
@@ -536,7 +576,8 @@ class IndxToolboardHeater:
                     raise self.toolboard.printer.command_error(
                         "INDX ringdown heat gate: nozzle not present "
                         "(presence=%s). Seat a tool, run INDX_RINGDOWN_PROBE, "
-                        "or disable ringdown_heat_gate." % (self.nozzle_presence,)
+                        "or disable ringdown_heat_gate."
+                        % (self.nozzle_presence,)
                     )
                 base_set_temp(degrees)
 
@@ -559,7 +600,9 @@ class IndxToolboardHeater:
         self.nozzle_presence = RINGDOWN_PRESENCE.get(presence, "unknown")
         self.nozzle_presence_peak_v = params["peak_mv"] / 1000.0
         self.nozzle_presence_n_peaks = params.get("n_peaks", 0)
-        self.nozzle_presence_time = self.toolboard.printer.get_reactor().monotonic()
+        self.nozzle_presence_time = (
+            self.toolboard.printer.get_reactor().monotonic()
+        )
 
     def handle_nozzle_presence(self, params):
         # Ignore in-flight running polls from background probes mid-sample.
@@ -598,12 +641,16 @@ class IndxToolboardHeater:
         if dump:
             wave = compat.register_response(
                 mcu,
-                lambda p: samples.append((p["index"], p["ns"], p["counts"], p["mv"])),
+                lambda p: samples.append(
+                    (p["index"], p["ns"], p["counts"], p["mv"])
+                ),
                 "indx_ringdown_wave index=%u ns=%u counts=%u mv=%u",
             )
             peak = compat.register_response(
                 mcu,
-                lambda p: peaks.append((p["index"], p["sample"], p["counts"], p["mv"])),
+                lambda p: peaks.append(
+                    (p["index"], p["sample"], p["counts"], p["mv"])
+                ),
                 "indx_ringdown_peak index=%c sample=%u counts=%u mv=%u",
             )
             meta_resp = compat.register_response(
@@ -625,7 +672,9 @@ class IndxToolboardHeater:
                     break
                 if reactor.monotonic() > deadline:
                     raise gcmd.error("INDX ringdown probe timed out")
-                reactor.pause(reactor.monotonic() + RINGDOWN_PROBE_POLL_INTERVAL)
+                reactor.pause(
+                    reactor.monotonic() + RINGDOWN_PROBE_POLL_INTERVAL
+                )
         finally:
             if wave is not None:
                 wave.unregister()
@@ -650,10 +699,15 @@ class IndxToolboardHeater:
                     peak_samples = {p[1] for p in peaks}
                     for index, ns, counts, mv in samples:
                         is_peak = 1 if index in peak_samples else 0
-                        f.write("%d,%d,%d,%d,%d\n" % (index, ns, counts, mv, is_peak))
+                        f.write(
+                            "%d,%d,%d,%d,%d\n"
+                            % (index, ns, counts, mv, is_peak)
+                        )
                     f.write("# peaks: index,sample,counts,mv\n")
                     for index, sample, counts, mv in peaks:
-                        f.write("# peak,%d,%d,%d,%d\n" % (index, sample, counts, mv))
+                        f.write(
+                            "# peak,%d,%d,%d,%d\n" % (index, sample, counts, mv)
+                        )
                 gcmd.respond_info(
                     "INDX ringdown waveform (%d samples, %d peaks) saved to %s"
                     % (len(samples), len(peaks), RINGDOWN_WAVE_PATH)
@@ -675,10 +729,14 @@ class IndxToolboardHeater:
 
     def cmd_SET_RINGDOWN_PARAMS(self, gcmd):
         self.ringdown_enable = bool(
-            gcmd.get_int("ENABLE", int(self.ringdown_enable), minval=0, maxval=1)
+            gcmd.get_int(
+                "ENABLE", int(self.ringdown_enable), minval=0, maxval=1
+            )
         )
         self.ringdown_heat_gate = bool(
-            gcmd.get_int("HEAT_GATE", int(self.ringdown_heat_gate), minval=0, maxval=1)
+            gcmd.get_int(
+                "HEAT_GATE", int(self.ringdown_heat_gate), minval=0, maxval=1
+            )
         )
         self.ringdown_present_peak_v = gcmd.get_float(
             "PRESENT_PEAK_V",
@@ -719,10 +777,14 @@ class IndxToolboardHeater:
             maxval=50.0,
         )
         self._send_ringdown_params()
-        configfile: PrinterConfig = self.toolboard.printer.lookup_object("configfile")
+        configfile: PrinterConfig = self.toolboard.printer.lookup_object(
+            "configfile"
+        )
         section = self.toolboard.name
         configfile.set(
-            section, "ringdown_enable", "True" if self.ringdown_enable else "False"
+            section,
+            "ringdown_enable",
+            "True" if self.ringdown_enable else "False",
         )
         configfile.set(
             section,
@@ -742,13 +804,21 @@ class IndxToolboardHeater:
         configfile.set(
             section, "ringdown_min_peak_v", "%.3f" % self.ringdown_min_peak_v
         )
-        configfile.set(section, "ringdown_idle_ms", "%d" % self.ringdown_idle_ms)
-        configfile.set(section, "ringdown_heat_ms", "%d" % self.ringdown_heat_ms)
         configfile.set(
-            section, "ringdown_excite_scale", "%.4f" % self.ringdown_excite_scale
+            section, "ringdown_idle_ms", "%d" % self.ringdown_idle_ms
         )
         configfile.set(
-            section, "ringdown_zero_margin_v", "%.3f" % self.ringdown_zero_margin_v
+            section, "ringdown_heat_ms", "%d" % self.ringdown_heat_ms
+        )
+        configfile.set(
+            section,
+            "ringdown_excite_scale",
+            "%.4f" % self.ringdown_excite_scale,
+        )
+        configfile.set(
+            section,
+            "ringdown_zero_margin_v",
+            "%.3f" % self.ringdown_zero_margin_v,
         )
         gcmd.respond_info(
             "INDX ringdown params updated (enable=%s heat_gate=%s "
@@ -799,7 +869,11 @@ class IndxToolboardHeater:
     def cur_target_temp(self):
         time = self.toolboard.printer.get_reactor().monotonic()
         return next(
-            (h.get_temp(time)[1] for h in self.heaters if h.get_temp(time)[1] != 0.0),
+            (
+                h.get_temp(time)[1]
+                for h in self.heaters
+                if h.get_temp(time)[1] != 0.0
+            ),
             None,
         )
 
@@ -818,7 +892,9 @@ class IndxToolboardHeater:
     def fan_speed(self, time):
         if self.part_cooling_fan is None:
             return 0.0
-        return max(0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"]))
+        return max(
+            0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"])
+        )
 
     def _blend_ambient_temp(self, sensor_temp):
         # Weighted blend of the board/bracket thermistors and the IR sensor's
@@ -890,7 +966,9 @@ class IndxToolboardHeater:
                 # because the user isn't allowed to start heating when no thermal
                 # model is set. We need this check to allow the tuner to work.
                 if self.thermal_model.is_valid():
-                    filament_distance = max(0.0, extruder_pos - self.last_report[3])
+                    filament_distance = max(
+                        0.0, extruder_pos - self.last_report[3]
+                    )
                     fan_speed = self.fan_speed(time)
 
                     ambient_temp = self._blend_ambient_temp(sensor_temp)
@@ -1084,7 +1162,9 @@ class IndxToolboardHeater:
         (t_on, t_off, t_on_first) = self.coil_timings
         configfile.set(section, "coil_time_on", "%.3f" % (t_on * 1e6))
         configfile.set(section, "coil_time_off", "%.3f" % (t_off * 1e6))
-        configfile.set(section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6))
+        configfile.set(
+            section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6)
+        )
 
     def _toggle_steppers(self, toolhead, ets, enable):
         # Enable/disable a set of EnableTracking lines with proper toolhead
@@ -1110,7 +1190,9 @@ class IndxToolboardHeater:
                 return
             if reactor.monotonic() > deadline:
                 raise gcmd.error(timeout_msg)
-            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL)
+            reactor.pause(
+                reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL
+            )
 
     def _wait_cooldown(self, gcmd, min_temp):
         # Block until the nozzle has cooled below min_temp (the heater must
@@ -1135,7 +1217,9 @@ class IndxToolboardHeater:
                 "INDX: no temperature reports received",
             )
             if last_temp[0] > min_temp:
-                gcmd.respond_info("INDX: cooling below %.0f C before tuning" % min_temp)
+                gcmd.respond_info(
+                    "INDX: cooling below %.0f C before tuning" % min_temp
+                )
                 self._model_cal_wait_temp(
                     reactor,
                     gcmd,
@@ -1250,7 +1334,9 @@ class IndxToolboardHeater:
             # Baseline (heater off) draw to subtract from measured power.
             phase[0] = "baseline"
             gcmd.respond_info("INDX: measuring baseline power")
-            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME)
+            reactor.pause(
+                reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME
+            )
             baseline_power = calibration.mean_phase_power(samples, "baseline")
             if baseline_power is None:
                 raise gcmd.error("INDX: no baseline power samples received")
@@ -1258,7 +1344,8 @@ class IndxToolboardHeater:
             # Heatup to MAX_TEMP.
             phase[0] = "heat"
             gcmd.respond_info(
-                "INDX: heating to %.0f C (baseline %.2f W)" % (max_temp, baseline_power)
+                "INDX: heating to %.0f C (baseline %.2f W)"
+                % (max_temp, baseline_power)
             )
             self.heater_raw_set_temp(max_temp)
             self._model_cal_wait_temp(
@@ -1280,7 +1367,9 @@ class IndxToolboardHeater:
             self.heater.set_temp(0.0)
             if cooldown_time > 0.0:
                 phase[0] = "cooldown"
-                gcmd.respond_info("INDX: measuring cooldown for %.0f s" % cooldown_time)
+                gcmd.respond_info(
+                    "INDX: measuring cooldown for %.0f s" % cooldown_time
+                )
                 reactor.pause(reactor.monotonic() + cooldown_time)
 
             self.temperature_callbacks.remove(sampler)
@@ -1307,7 +1396,9 @@ class IndxToolboardHeater:
             self._toggle_steppers(toolhead, reenable, True)
 
         if result.get("error"):
-            raise gcmd.error("INDX thermal model fit failed: %s" % result["error"])
+            raise gcmd.error(
+                "INDX thermal model fit failed: %s" % result["error"]
+            )
         self._apply_model_calibration(gcmd, result)
 
     def _apply_model_calibration(self, gcmd, result):
@@ -1363,13 +1454,16 @@ class IndxToolboardHeater:
                 % (p_lo, t_min, p_hi, t_max, -drop_pct)
             )
         lines.append(
-            "thermal_capacity: " + fmt(capacity, result["thermal_capacity_ci"], "J/K")
+            "thermal_capacity: "
+            + fmt(capacity, result["thermal_capacity_ci"], "J/K")
         )
         lines.append(
-            "to_ambient_r: " + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
+            "to_ambient_r: "
+            + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
         )
         lines.append(
-            "fit RMS error: %.2f C over %d samples" % (result["rms"], result["n_fit"])
+            "fit RMS error: %.2f C over %d samples"
+            % (result["rms"], result["n_fit"])
         )
         gcmd.respond_info("INDX thermal model calibrated:\n" + "\n".join(lines))
 
@@ -1379,7 +1473,9 @@ class IndxToolboardHeater:
         if self.part_cooling_fan is None:
             raise gcmd.error("INDX part cooling fan is not configured")
 
-        breaks = gcmd.get_int("BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3)
+        breaks = gcmd.get_int(
+            "BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3
+        )
         hold_time = gcmd.get_float(
             "HOLD_TIME", calibration.FAN_CAL_HOLD_TIME_DEFAULT, above=0.0
         )
@@ -1433,7 +1529,9 @@ class IndxToolboardHeater:
             self.temperature_callbacks.append(sampler)
             installed = True
             self.heater_raw_set_temp(target)
-            gcmd.respond_info("INDX: waiting for %.0f C for fan calibration" % target)
+            gcmd.respond_info(
+                "INDX: waiting for %.0f C for fan calibration" % target
+            )
             self._model_cal_wait_temp(
                 reactor,
                 gcmd,
@@ -1529,7 +1627,9 @@ class IndxToolboardHeater:
             self.temperature_callbacks.remove(cb)
 
         if totals[0] == 0:
-            raise gcmd.error("No power meansurements received over entire duration")
+            raise gcmd.error(
+                "No power meansurements received over entire duration"
+            )
 
         power = totals[1] / totals[0]
         gcmd.respond_info(
@@ -1560,19 +1660,27 @@ class IndxToolboardHeater:
             )
 
         speed = gcmd.get_float("SPEED", FILAMENT_LOAD_SPEED, above=0.0)
-        max_length = gcmd.get_float("MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0)
-        prime_time = gcmd.get_float("PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0)
+        max_length = gcmd.get_float(
+            "MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0
+        )
+        prime_time = gcmd.get_float(
+            "PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0
+        )
         prime_length = gcmd.get_float("PRIME_LENGTH", None, above=0.0)
         if prime_length is None:
             prime_length = speed * prime_time
-        threshold = gcmd.get_float("THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0)
+        threshold = gcmd.get_float(
+            "THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0
+        )
         segment_time = gcmd.get_float(
             "SEGMENT_TIME", FILAMENT_LOAD_SEGMENT_TIME, above=0.0
         )
         apply_result = gcmd.get_int("APPLY", 1, minval=0, maxval=1)
 
         params = self.thermal_model.params
-        filament_area = params.filament_radius * params.filament_radius * math.pi
+        filament_area = (
+            params.filament_radius * params.filament_radius * math.pi
+        )
         last_temp = last_pos = start_pos = loaded_at_pos = None
         load_energy = loaded_energy = loaded_denominator = 0.0
         loaded = False
@@ -1594,7 +1702,9 @@ class IndxToolboardHeater:
                 return
             dt = reading.delta_time
             ambient = self._blend_ambient_temp(reading.sensor_temperature)
-            loss_ambient = (reading.nozzle_temperature - ambient) / params.to_ambient_r
+            loss_ambient = (
+                reading.nozzle_temperature - ambient
+            ) / params.to_ambient_r
             loss_part_cooling = 0.0
             fan_speed = self.fan_speed(reading.time)
             if fan_speed > 0.0:
@@ -1606,7 +1716,9 @@ class IndxToolboardHeater:
                         0.0,
                         (reading.nozzle_temperature - ambient) / pcf_ambient_r,
                     )
-            stored = params.thermal_capacity * (reading.nozzle_temperature - last_temp)
+            stored = params.thermal_capacity * (
+                reading.nozzle_temperature - last_temp
+            )
             loss = (loss_ambient + loss_part_cooling) * dt
             residual = reading.delta_pwm_energy - loss - stored
             load_energy = max(0.0, load_energy + residual)
@@ -1614,7 +1726,9 @@ class IndxToolboardHeater:
             temp_delta = max(0.0, reading.nozzle_temperature - ambient)
             if loaded:
                 loaded_energy += max(0.0, residual)
-                loaded_denominator += pos_delta * filament_area / 1000.0 * temp_delta
+                loaded_denominator += (
+                    pos_delta * filament_area / 1000.0 * temp_delta
+                )
             elif load_energy >= threshold:
                 loaded = True
                 loaded_at_pos = pos
@@ -1694,7 +1808,9 @@ class IndxToolboardHeater:
         section = self.toolboard.name
         configfile.set(section, "model_filament_density", "0.0000")
         configfile.set(section, "model_filament_heat_capacity", "0.0000")
-        gcmd.respond_info("INDX filament model cleared. Run SAVE_CONFIG to save.")
+        gcmd.respond_info(
+            "INDX filament model cleared. Run SAVE_CONFIG to save."
+        )
 
     def cmd_EXTRUDER_MOVE(self, gcmd):
         distance = gcmd.get_float("DISTANCE")
@@ -1710,9 +1826,13 @@ class IndxToolboardHeater:
         stepper = extruder.extruder_stepper.stepper
         current_helper = compat.get_tmc_current_helper(stepper)
         if current_helper is None:
-            raise gcmd.error("Active extruder does not have a TMC current helper")
+            raise gcmd.error(
+                "Active extruder does not have a TMC current helper"
+            )
 
-        run_current, hold_current, req_hold_current, *_ = current_helper.get_current()
+        run_current, hold_current, req_hold_current, *_ = (
+            current_helper.get_current()
+        )
         current = min(current, run_current)
         restore_hold_current = (
             req_hold_current if req_hold_current is not None else hold_current
@@ -1733,12 +1853,16 @@ class IndxToolboardHeater:
             toolhead.wait_moves()
         finally:
             print_time = toolhead.get_last_move_time()
-            current_helper.set_current(run_current, restore_hold_current, print_time)
+            current_helper.set_current(
+                run_current, restore_hold_current, print_time
+            )
 
     def cmd_SET_MODEL_PARAMS(self, gcmd):
         cur = self.thermal_model.params
 
-        max_power = gcmd.get_float("MAX_POWER", default=cur.max_power, minval=0.0)
+        max_power = gcmd.get_float(
+            "MAX_POWER", default=cur.max_power, minval=0.0
+        )
         max_power_temp_coeff = gcmd.get_float(
             "MAX_POWER_TEMP_COEFF", default=cur.max_power_temp_coeff
         )
@@ -1829,7 +1953,9 @@ class IndxToolboardHeater:
         )
         res = cmd.send([])
         print(res)
-        gcmd.respond_info("".join(hex(c)[2:].ljust(2, "0") for c in res["data"]))
+        gcmd.respond_info(
+            "".join(hex(c)[2:].ljust(2, "0") for c in res["data"])
+        )
 
     def cmd_DEBUG_STREAM_RAW_IR_SENSOR(self, gcmd):
         if self.raw_ir_log_file is not None:
@@ -1878,7 +2004,9 @@ class IndxToolboardHeater:
             try:
                 cols.append(
                     "%.2f"
-                    % printer.lookup_object(name).get_status(eventtime)["temperature"]
+                    % printer.lookup_object(name).get_status(eventtime)[
+                        "temperature"
+                    ]
                 )
             except Exception as e:
                 cols.append("")
@@ -2002,14 +2130,18 @@ class ThermalModel:
                     0.0, (self.temperature - ambient_temp) / pcf_ambient_r
                 )
 
-        loss_ambient = (self.temperature - ambient_temp) / self.params.to_ambient_r
+        loss_ambient = (
+            self.temperature - ambient_temp
+        ) / self.params.to_ambient_r
         loss_filament = (
             filament_distance
             * filament_heat_capacity_mm
             * (self.temperature - filament_temp)
             / dt
         )
-        total_power = avg_input_power - loss_ambient - loss_filament - loss_part_cooling
+        total_power = (
+            avg_input_power - loss_ambient - loss_filament - loss_part_cooling
+        )
         delta_temp_rate = total_power / self.params.thermal_capacity
         new_temp = self.temperature + delta_temp_rate * dt
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -1,9 +1,10 @@
-from klippy.configfile import PrinterConfig
 import logging
 import math
 import struct
 from collections import namedtuple
 from time import strftime
+
+from klippy.configfile import PrinterConfig
 
 from ..thermistor import CustomThermistor
 from . import calibration, compat

--- a/klippy/extras/indx/toolboard.py
+++ b/klippy/extras/indx/toolboard.py
@@ -96,9 +96,11 @@ class IndxToolboard:
         gcode.register_command("INDX_LED_SET_CURRENT", self.cmd_LED_SET_CURRENT)
 
     def get_status(self, eventtime):
-        return {
+        status = {
             "last_dock_measurement": self.dock_measurement.last_dock_measurement
         }
+        status.update(self.heater.get_ringdown_status(eventtime))
+        return status
 
     def cmd_LED_FORCE_COLOR(self, gcmd):
         cmd = self.mcu.lookup_command(

--- a/src/indx/coil_driver.c++
+++ b/src/indx/coil_driver.c++
@@ -315,6 +315,120 @@ struct tuner_state {
 
 static tuner_state tuner;
 
+// --- Nozzle presence ringdown (first-lobe peak amplitude) ---
+
+static constexpr uint32_t RINGDOWN_SAMPLE_STEP = 16;
+static constexpr uint32_t RINGDOWN_N_SAMPLES = 64;
+static constexpr uint32_t RINGDOWN_TIMEOUT_US = 2000000;
+static constexpr float RINGDOWN_ZERO_MARGIN_V_DEFAULT = 1.0f;
+// Only allow softening the soft-start pulse (never hotter than calibrated
+// coil_time_on_first). Raising excitation past soft-start is a board risk.
+// Default 0.8 from Bondtech characterisation (empty OV at 1.0).
+static constexpr float RINGDOWN_EXCITE_SCALE_DEFAULT = 0.8f;
+static constexpr float RINGDOWN_EXCITE_SCALE_MIN = 0.05f;
+static constexpr float RINGDOWN_EXCITE_SCALE_MAX = 1.0f;
+// Peak-voltage thresholds from Bondtech EXCITE_SCALE=0.8 sweep
+// (seated ~84 V, empty ~95 V). Re-characterise before heat_gate.
+static constexpr float RINGDOWN_PRESENT_PEAK_V_DEFAULT = 87.0f;
+static constexpr float RINGDOWN_ABSENT_PEAK_V_DEFAULT = 91.0f;
+static constexpr float RINGDOWN_MIN_PEAK_V_DEFAULT = 20.0f;
+static constexpr uint32_t RINGDOWN_IDLE_MS_DEFAULT = 500;
+static constexpr uint32_t RINGDOWN_HEAT_MS_DEFAULT = 500;
+
+enum class ringdown_phase : uint8_t {
+    idle,
+    pause_wait,
+    sample,
+    analyze,
+    dump,
+    done,
+};
+
+struct ringdown_config {
+    bool enable{false};
+    bool heat_gate{false};
+    float present_peak_v{RINGDOWN_PRESENT_PEAK_V_DEFAULT};
+    float absent_peak_v{RINGDOWN_ABSENT_PEAK_V_DEFAULT};
+    float min_peak_v{RINGDOWN_MIN_PEAK_V_DEFAULT};
+    float excite_scale{RINGDOWN_EXCITE_SCALE_DEFAULT};
+    float zero_margin_v{RINGDOWN_ZERO_MARGIN_V_DEFAULT};
+    uint32_t idle_ms{RINGDOWN_IDLE_MS_DEFAULT};
+    uint32_t heat_ms{RINGDOWN_HEAT_MS_DEFAULT};
+};
+
+struct ringdown_state {
+    ringdown_phase phase{ringdown_phase::idle};
+    ringdown_status status{ringdown_status::idle};
+    nozzle_presence presence{nozzle_presence::unknown};
+    bool want_report{false};
+    bool want_dump{false};
+    bool burst_in_flight{false};
+    uint32_t next_fire_time{0};
+    uint32_t ov_count_at_start{0};
+    uint32_t deadline{0};
+    uint32_t sample_idx{0};
+    uint32_t dump_idx{0};
+    uint32_t dump_count{0};
+    uint32_t saved_pending_on_cycles{0};
+    uint32_t saved_on_ticks{0};
+    uint32_t saved_on_ticks_first{0};
+    uint32_t saved_off_ticks{0};
+    uint32_t peak_mv{0};
+    uint8_t n_peaks{0};
+    int16_t off_start{-1};
+    ringdown_status pending_status{ringdown_status::idle};
+    uint16_t peak_counts[10]{};
+    uint16_t peak_sample_idx[10]{};
+    uint32_t next_schedule_time{0};
+
+    // Shared with TCC3/ADC ISRs (mirrors tuner test-burst fields).
+    volatile bool test_active{false};
+    volatile uint32_t cycles_done{0};
+    volatile uint32_t stop_after{0};
+    volatile bool burst_done{false};
+    volatile bool adc_active{false};
+    volatile bool adc_capture_armed{false};
+    volatile uint16_t adc_sample{0};
+
+    bool
+    active() {
+        return phase != ringdown_phase::idle;
+    }
+    void
+    start(bool report, bool dump);
+    void
+    step();
+    void
+    abort(ringdown_status s);
+    void
+    finish(ringdown_status s);
+    void
+    schedule_finish_or_dump(ringdown_status s);
+    void
+    fire_burst();
+    bool
+    on_drive_overflow();
+    bool
+    capture_adc_sample(uint16_t result);
+    burst_status
+    burst_poll();
+    void
+    adc_arm();
+    void
+    adc_restore();
+    void
+    analyze();
+    void
+    restore_drive();
+    uint32_t
+    excite_on_ticks();
+};
+
+static ringdown_state ringdown;
+static ringdown_config ringdown_cfg;
+static nozzle_presence last_presence{nozzle_presence::unknown};
+static uint16_t ringdown_samples[RINGDOWN_N_SAMPLES];
+
 // IRQ declarations and assert correct indices.
 
 static_assert(FEEDBACK_ADC_1_IRQn == 121);
@@ -396,10 +510,19 @@ coil_driver::set_duty(float duty) {
     if (duty != 0.0f && tune_active()) {
         shutdown("INDX heater target set while coil tuning");
     }
+    if (duty != 0.0f && ringdown_active()) {
+        // Ringdown owns the tank briefly; drop the request rather than fault.
+        duty = 0.0f;
+    }
     // The coil timings have no default. Driving without first setting them
     // (explicitly or via a successful tune) is a fault.
     if (duty != 0.0f && !state.timings_valid) {
         shutdown("INDX heater started before coil timings were set");
+    }
+    // Optional safety gate: refuse to drive without a present nozzle.
+    if (duty != 0.0f && ringdown_cfg.enable && ringdown_cfg.heat_gate &&
+        last_presence != nozzle_presence::present) {
+        duty = 0.0f;
     }
 
     uint32_t cycles;
@@ -412,6 +535,12 @@ coil_driver::set_duty(float duty) {
     }
     if (this->duty_limit && cycles > this->duty_limit) {
         cycles = this->duty_limit;
+    }
+    // While a ringdown probe has paused heating, keep the requested duty
+    // latched for restore instead of programming the timer.
+    if (ringdown_active()) {
+        ringdown.saved_pending_on_cycles = cycles;
+        return;
     }
     state.pending_on_cycles = cycles;
 
@@ -494,6 +623,8 @@ driver_state::schedule_next_cycle() {
 extern "C" void
 TCC3_0_Handler(void) {
     DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
+    if (ringdown.on_drive_overflow())
+        return;
     if (tuner.on_drive_overflow())
         return;
     state.schedule_next_cycle();
@@ -508,6 +639,8 @@ AC_Handler(void) {
 extern "C" void
 FEEDBACK_ADC_1_Handler(void) {
     uint16_t result = FEEDBACK_ADC->RESULT.reg;
+    if (ringdown.capture_adc_sample(result))
+        return;
     if (tuner.capture_adc_sample(result))
         return;
     current_sense.on_sample(result);
@@ -1125,7 +1258,7 @@ tuner_state::step() {
 
 void
 coil_driver::start_tune(bool want_details) {
-    if (tuner.active()) {
+    if (tuner.active() || ringdown.active()) {
         return;
     }
     if (state.pending_on_cycles != 0) {
@@ -1158,4 +1291,468 @@ coil_driver::report_params() {
     uint32_t off = state.period_minus_1 + 1 - on;
     sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
           ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
+}
+
+// ---------------------------------------------------------------------------
+// Ringdown nozzle-presence probe
+// ---------------------------------------------------------------------------
+
+void
+ringdown_state::adc_arm() {
+    FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(DRAIN_SENSE_ADC_MUXPOS) |
+                                  ADC_INPUTCTRL_MUXNEG(0x18);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+        ;
+    adc_active = true;
+    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg =
+        DRIVE_TCC_TUNE_EVSYS_CHANNEL + 1;
+}
+
+void
+ringdown_state::adc_restore() {
+    FEEDBACK_ADC->INPUTCTRL.reg =
+        ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
+        ADC_INPUTCTRL_MUXNEG(0x18);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+        ;
+    adc_active = false;
+    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
+}
+
+void
+ringdown_state::fire_burst() {
+    cycles_done = 0;
+    stop_after = 1 + TUNE_TRAILING_OFF;
+    burst_done = false;
+    test_active = true;
+    state.pending_on_cycles = 1;
+    burst_in_flight = true;
+    state.arm_timer();
+}
+
+bool
+ringdown_state::on_drive_overflow() {
+    if (!test_active)
+        return false;
+
+    uint32_t started = cycles_done + 1;
+    cycles_done = started;
+
+    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(0);
+    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(state.period_minus_1);
+
+    if (started >= stop_after) {
+        DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+        test_active = false;
+        burst_done = true;
+    }
+    return true;
+}
+
+bool
+ringdown_state::capture_adc_sample(uint16_t result) {
+    if (!adc_active)
+        return false;
+    if (adc_capture_armed) {
+        adc_sample = result;
+        adc_capture_armed = false;
+    }
+    return true;
+}
+
+burst_status
+ringdown_state::burst_poll() {
+    if (burst_in_flight) {
+        if (!burst_done)
+            return burst_status::busy;
+        burst_in_flight = false;
+        next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+        return burst_status::completed;
+    }
+    if (timer_is_before(timer_read_time(), next_fire_time))
+        return burst_status::busy;
+    return burst_status::ready;
+}
+
+void
+ringdown_state::restore_drive() {
+    if (adc_active)
+        adc_restore();
+    state.set_drive_ticks(saved_on_ticks, saved_on_ticks_first, saved_off_ticks);
+    state.pending_on_cycles = saved_pending_on_cycles;
+    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+    if (saved_pending_on_cycles > 0 && idle) {
+        state.arm_timer();
+    }
+}
+
+void
+ringdown_state::abort(ringdown_status s) {
+    test_active = false;
+    burst_in_flight = false;
+    restore_drive();
+    presence = nozzle_presence::unknown;
+    last_presence = nozzle_presence::unknown;
+    // Already dumping: finish with the abort status (do not restart dump).
+    if (phase == ringdown_phase::dump) {
+        finish(s);
+        return;
+    }
+    // Dump whatever was captured so far (may be empty on early abort).
+    dump_count = sample_idx < RINGDOWN_N_SAMPLES ? sample_idx : RINGDOWN_N_SAMPLES;
+    schedule_finish_or_dump(s);
+}
+
+void
+ringdown_state::schedule_finish_or_dump(ringdown_status s) {
+    pending_status = s;
+    if (want_dump) {
+        dump_idx = 0;
+        next_fire_time = timer_read_time();
+        phase = ringdown_phase::dump;
+        return;
+    }
+    finish(s);
+}
+
+void
+ringdown_state::finish(ringdown_status s) {
+    status = s;
+    if (s == ringdown_status::valid) {
+        last_presence = presence;
+    } else if (s != ringdown_status::running) {
+        // Failed / aborted probes do not claim present.
+        if (presence == nozzle_presence::present)
+            presence = nozzle_presence::unknown;
+        last_presence = presence;
+    }
+    if (want_report) {
+        sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u "
+              "n_peaks=%c",
+              timer_read_time(), (uint32_t)status, (uint32_t)presence, peak_mv,
+              (uint32_t)n_peaks);
+    }
+    // Stamp completion time; ringdown_step() adds the idle/heat period.
+    next_schedule_time = timer_read_time();
+    phase = ringdown_phase::idle;
+}
+
+uint32_t
+ringdown_state::excite_on_ticks() {
+    float scale = ringdown_cfg.excite_scale;
+    if (scale < RINGDOWN_EXCITE_SCALE_MIN)
+        scale = RINGDOWN_EXCITE_SCALE_MIN;
+    if (scale > RINGDOWN_EXCITE_SCALE_MAX)
+        scale = RINGDOWN_EXCITE_SCALE_MAX;
+    uint32_t ticks = (uint32_t)(saved_on_ticks_first * scale + 0.5f);
+    if (ticks < 1)
+        ticks = 1;
+    // Never exceed calibrated soft-start ON (on_first), even if scale is wrong.
+    if (saved_on_ticks_first && ticks > saved_on_ticks_first)
+        ticks = saved_on_ticks_first;
+    return ticks;
+}
+
+void
+ringdown_state::start(bool report, bool dump) {
+    // Volatile ISR fields: reset explicitly (assignment of *this is ill-formed).
+    phase = ringdown_phase::pause_wait;
+    status = ringdown_status::running;
+    presence = nozzle_presence::unknown;
+    want_report = report;
+    want_dump = dump;
+    burst_in_flight = false;
+    next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+    ov_count_at_start = state.overvoltage_count();
+    // Dump streaming adds ~3 ms per sample; give the deadline headroom.
+    uint32_t timeout_us = RINGDOWN_TIMEOUT_US;
+    if (dump)
+        timeout_us += RINGDOWN_N_SAMPLES * TUNE_DUMP_INTERVAL_US + 50000;
+    deadline = timer_read_time() + timer_from_us(timeout_us);
+    sample_idx = 0;
+    dump_idx = 0;
+    dump_count = 0;
+    peak_mv = 0;
+    n_peaks = 0;
+    off_start = -1;
+    pending_status = ringdown_status::idle;
+    for (uint8_t i = 0; i < 10; i++) {
+        peak_counts[i] = 0;
+        peak_sample_idx[i] = 0;
+    }
+    test_active = false;
+    cycles_done = 0;
+    stop_after = 0;
+    burst_done = false;
+    adc_active = false;
+    adc_capture_armed = false;
+    adc_sample = 0;
+    saved_pending_on_cycles = state.pending_on_cycles;
+    saved_on_ticks = state.on_ticks;
+    saved_on_ticks_first = state.on_ticks_first;
+    saved_off_ticks = state.period_minus_1 + 1 - state.on_ticks;
+    // Pause continuous heating for the probe window.
+    state.pending_on_cycles = 0;
+}
+
+void
+ringdown_state::analyze() {
+    auto zero_threshold = volts_to_count(ringdown_cfg.zero_margin_v);
+    n_peaks = 0;
+    off_start = -1;
+    dump_count = RINGDOWN_N_SAMPLES;
+    peak_mv = 0;
+
+    // Absolute max of the capture - Bondtech shows one resonance lobe.
+    uint16_t max_counts = 0;
+    uint16_t max_idx = 0;
+    for (uint32_t i = 0; i < RINGDOWN_N_SAMPLES; i++) {
+        if (ringdown_samples[i] > max_counts) {
+            max_counts = ringdown_samples[i];
+            max_idx = (uint16_t)i;
+        }
+    }
+    peak_mv = counts_to_mv(max_counts);
+    float peak_v = (float)peak_mv / 1000.0f;
+
+    // DUMP annotation: first sample above zero_margin (may be floor noise).
+    for (uint32_t i = 0; i < RINGDOWN_N_SAMPLES; i++) {
+        if (ringdown_samples[i] >= zero_threshold) {
+            off_start = (int16_t)i;
+            break;
+        }
+    }
+
+    // Local maxima for DUMP peak markers only (do not drive classification).
+    constexpr uint8_t max_peaks = 10;
+    if (off_start >= 0) {
+        for (uint32_t i = (uint32_t)off_start + 1; i + 1 < RINGDOWN_N_SAMPLES;
+             i++) {
+            int16_t slope1 =
+                (int16_t)ringdown_samples[i] - (int16_t)ringdown_samples[i - 1];
+            int16_t slope2 =
+                (int16_t)ringdown_samples[i + 1] - (int16_t)ringdown_samples[i];
+            if (slope1 >= 0 && slope2 < 0 && n_peaks < max_peaks) {
+                peak_counts[n_peaks] = ringdown_samples[i];
+                peak_sample_idx[n_peaks] = (uint16_t)i;
+                n_peaks++;
+            }
+        }
+    }
+    // Ensure the absolute max is marked even if slope detection missed it.
+    bool have_max = false;
+    for (uint8_t i = 0; i < n_peaks; i++) {
+        if (peak_sample_idx[i] == max_idx) {
+            have_max = true;
+            break;
+        }
+    }
+    if (!have_max && max_counts > 0 && n_peaks < max_peaks) {
+        peak_counts[n_peaks] = max_counts;
+        peak_sample_idx[n_peaks] = max_idx;
+        n_peaks++;
+    }
+
+    if (peak_v < ringdown_cfg.min_peak_v) {
+        presence = nozzle_presence::unknown;
+        restore_drive();
+        schedule_finish_or_dump(ringdown_status::not_enough_peaks);
+        return;
+    }
+
+    // Seated loads the coil → lower peak; empty → higher peak.
+    if (peak_v <= ringdown_cfg.present_peak_v) {
+        presence = nozzle_presence::present;
+    } else if (peak_v >= ringdown_cfg.absent_peak_v) {
+        presence = nozzle_presence::absent;
+    } else {
+        presence = nozzle_presence::unknown;
+    }
+
+    restore_drive();
+    schedule_finish_or_dump(ringdown_status::valid);
+}
+
+void
+ringdown_state::step() {
+    if (phase == ringdown_phase::idle)
+        return;
+
+    if (state.overvoltage_count() != ov_count_at_start) {
+        // Always stop on OV. The AC comparator already faulted the drive;
+        // continuing to arm bursts after that is unsafe. Status is
+        // overvoltage (not generic aborted) so the host can tell.
+        abort(ringdown_status::overvoltage);
+        return;
+    }
+    if (!timer_is_before(timer_read_time(), deadline)) {
+        abort(ringdown_status::timeout);
+        return;
+    }
+
+    uint32_t on_ticks = excite_on_ticks();
+    switch (phase) {
+    case ringdown_phase::pause_wait: {
+        // Wait until the drive timer has stopped after clearing duty.
+        bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+        if (!idle || timer_is_before(timer_read_time(), next_fire_time))
+            return;
+        // Soft single-cycle excitation using scaled soft-start ON.
+        state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+        adc_arm();
+        sample_idx = 0;
+        phase = ringdown_phase::sample;
+        return;
+    }
+    case ringdown_phase::sample: {
+        switch (burst_poll()) {
+        case burst_status::busy:
+            return;
+        case burst_status::completed:
+            ringdown_samples[sample_idx] = adc_sample;
+            if (++sample_idx >= RINGDOWN_N_SAMPLES) {
+                adc_restore();
+                phase = ringdown_phase::analyze;
+            }
+            return;
+        case burst_status::ready:
+            // Equivalent-time sample further into the soft-start OFF/resonance.
+            state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+            tune_set_cc0(sample_idx * RINGDOWN_SAMPLE_STEP);
+            adc_capture_armed = true;
+            fire_burst();
+            return;
+        }
+        return;
+    }
+    case ringdown_phase::analyze:
+        analyze();
+        return;
+    case ringdown_phase::dump: {
+        // Stream capture + peaks for host CSV (diagnostic; drops ok).
+        if (timer_is_before(timer_read_time(), next_fire_time))
+            return;
+        if (dump_idx < dump_count) {
+            sendf("indx_ringdown_wave index=%u ns=%u counts=%u mv=%u", dump_idx,
+                  ticks_to_ns(dump_idx * RINGDOWN_SAMPLE_STEP),
+                  (uint32_t)ringdown_samples[dump_idx],
+                  counts_to_mv(ringdown_samples[dump_idx]));
+            dump_idx++;
+            next_fire_time =
+                timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+            return;
+        }
+        // After samples, stream detected peaks once (reuse dump_idx offset).
+        uint32_t peak_i = dump_idx - dump_count;
+        if (peak_i < n_peaks) {
+            sendf("indx_ringdown_peak index=%c sample=%u counts=%u mv=%u",
+                  peak_i, (uint32_t)peak_sample_idx[peak_i],
+                  (uint32_t)peak_counts[peak_i],
+                  counts_to_mv(peak_counts[peak_i]));
+            dump_idx++;
+            next_fire_time =
+                timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+            return;
+        }
+        // Meta once at end so the host can annotate the CSV header/comments.
+        sendf("indx_ringdown_meta off_start=%i zero_mv=%u n_peaks=%c "
+              "status=%c peak_mv=%u",
+              (int32_t)off_start,
+              (uint32_t)(ringdown_cfg.zero_margin_v * 1000.0f + 0.5f),
+              (uint32_t)n_peaks, (uint32_t)pending_status, peak_mv);
+        finish(pending_status);
+        return;
+    }
+    case ringdown_phase::done:
+    case ringdown_phase::idle:
+        break;
+    }
+}
+
+void
+coil_driver::set_ringdown_params(bool enable, bool heat_gate, float present_peak_v,
+                                 float absent_peak_v, uint32_t idle_ms,
+                                 uint32_t heat_ms, float excite_scale,
+                                 float zero_margin_v, float min_peak_v) {
+    if (!(present_peak_v < absent_peak_v)) {
+        // Keep a hysteresis band; ignore invalid host updates.
+        return;
+    }
+    if (min_peak_v < 0.0f)
+        return;
+    ringdown_cfg.enable = enable;
+    ringdown_cfg.heat_gate = heat_gate;
+    ringdown_cfg.present_peak_v = present_peak_v;
+    ringdown_cfg.absent_peak_v = absent_peak_v;
+    ringdown_cfg.min_peak_v = min_peak_v > 0.0f ? min_peak_v
+                                                : RINGDOWN_MIN_PEAK_V_DEFAULT;
+    ringdown_cfg.idle_ms = idle_ms ? idle_ms : RINGDOWN_IDLE_MS_DEFAULT;
+    ringdown_cfg.heat_ms = heat_ms ? heat_ms : RINGDOWN_HEAT_MS_DEFAULT;
+    if (excite_scale < RINGDOWN_EXCITE_SCALE_MIN)
+        excite_scale = RINGDOWN_EXCITE_SCALE_MIN;
+    if (excite_scale > RINGDOWN_EXCITE_SCALE_MAX)
+        excite_scale = RINGDOWN_EXCITE_SCALE_MAX;
+    ringdown_cfg.excite_scale = excite_scale;
+    ringdown_cfg.zero_margin_v = zero_margin_v > 0.0f
+                                     ? zero_margin_v
+                                     : RINGDOWN_ZERO_MARGIN_V_DEFAULT;
+}
+
+void
+coil_driver::start_ringdown(bool report, bool dump) {
+    if (ringdown.active() || tuner.active())
+        return;
+    if (!state.timings_valid) {
+        // Fail closed: report unknown without driving.
+        last_presence = nozzle_presence::unknown;
+        ringdown.status = ringdown_status::aborted;
+        ringdown.presence = nozzle_presence::unknown;
+        ringdown.peak_mv = 0;
+        ringdown.n_peaks = 0;
+        if (report) {
+            sendf("indx_nozzle_presence clock=%u status=%c presence=%c "
+                  "peak_mv=%u n_peaks=%c",
+                  timer_read_time(), (uint32_t)ringdown_status::aborted,
+                  (uint32_t)nozzle_presence::unknown, 0u, 0u);
+        }
+        return;
+    }
+    ringdown.start(report, dump);
+}
+
+bool
+coil_driver::ringdown_active() {
+    return ringdown.active();
+}
+
+void
+coil_driver::ringdown_step(bool heating) {
+    if (ringdown.active()) {
+        ringdown.step();
+        return;
+    }
+    if (!ringdown_cfg.enable || tuner.active() || !state.timings_valid)
+        return;
+    uint32_t period_ms = heating ? ringdown_cfg.heat_ms : ringdown_cfg.idle_ms;
+    uint32_t due =
+        ringdown.next_schedule_time + timer_from_us(period_ms * 1000);
+    // next_schedule_time is set at finish; on first boot it is 0 so we fire.
+    if (ringdown.next_schedule_time != 0 &&
+        timer_is_before(timer_read_time(), due))
+        return;
+    start_ringdown(true, false);
+}
+
+nozzle_presence
+coil_driver::get_nozzle_presence() {
+    return last_presence;
+}
+
+void
+coil_driver::report_ringdown_status() {
+    sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u "
+          "n_peaks=%c",
+          timer_read_time(), (uint32_t)ringdown.status,
+          (uint32_t)ringdown.presence, ringdown.peak_mv,
+          (uint32_t)ringdown.n_peaks);
 }

--- a/src/indx/coil_driver.h
+++ b/src/indx/coil_driver.h
@@ -6,6 +6,23 @@ extern "C" {
 #include <stdint.h>
 }
 
+// Latched outcome of a nozzle-presence ringdown probe.
+enum class ringdown_status : uint8_t {
+    idle = 0,
+    running = 1,
+    valid = 2,
+    not_enough_peaks = 3,
+    aborted = 4,
+    overvoltage = 5,
+    timeout = 6,
+};
+
+enum class nozzle_presence : uint8_t {
+    unknown = 0,
+    present = 1,
+    absent = 2,
+};
+
 struct coil_driver {
     // Maximum number of fired cycles per 512-cycle frame (0 = no limit).
     uint32_t duty_limit{0};
@@ -50,6 +67,43 @@ struct coil_driver {
     // Send the drive timings currently in effect to the host.
     void
     report_params();
+
+    // --- Nozzle presence via LC ringdown ---
+
+    // Configure continuous probe, heat gate, and amplitude thresholds.
+    // present_peak_v / absent_peak_v / min_peak_v are tank volts (Bondtech:
+    // seated loads the coil so peak is lower; require present < absent).
+    // Periods are milliseconds. excite_scale multiplies soft-start ON ticks
+    // (clamped to <= 1.0 so the pulse cannot exceed coil_time_on_first).
+    // zero_margin_v is the ADC floor used for DUMP off_start annotation.
+    // Overvoltage mid-probe always aborts.
+    void
+    set_ringdown_params(bool enable, bool heat_gate, float present_peak_v,
+                        float absent_peak_v, uint32_t idle_ms, uint32_t heat_ms,
+                        float excite_scale, float zero_margin_v,
+                        float min_peak_v);
+
+    // Start a oneshot ringdown probe. Fails closed if tune is active or coil
+    // timings are not set. report=true sends indx_nozzle_presence when done.
+    // dump=true streams the capture buffer (and peaks) before the status.
+    void
+    start_ringdown(bool report, bool dump);
+
+    bool
+    ringdown_active();
+
+    // Advance the ringdown state machine; also starts background probes when
+    // enabled. heating=true selects the longer recheck period.
+    void
+    ringdown_step(bool heating);
+
+    // Last latched presence classification (unknown until a valid probe).
+    nozzle_presence
+    get_nozzle_presence();
+
+    // Send latched ringdown outcome to the host.
+    void
+    report_ringdown_status();
 };
 
 coil_driver

--- a/src/indx/heater.c++
+++ b/src/indx/heater.c++
@@ -60,9 +60,19 @@ indx_heater::run() {
     } else {
         this->state.max_power_cycles = 0;
     }
+    // Background ringdown (when enabled) runs between control updates. Heating
+    // selects the slower recheck cadence so probe energy stays small.
+    this->coil_driver_inst.ringdown_step(output > 0.0f);
     this->coil_driver_inst.set_duty(output);
 
-    this->state.power_sum += output;
+    // Report only power actually applied to the coil. During ringdown the PID
+    // request is latched but drive is paused; summing output would inflate the
+    // host thermal model and trip max_model_error on first heatup.
+    float report_power = output;
+    if (this->coil_driver_inst.ringdown_active()) {
+        report_power = 0.0f;
+    }
+    this->state.power_sum += report_power;
     this->state.updates_since_report += 1;
     if (timer_is_before(this->next_temperature_report, now)) {
         this->report_temperature(now);
@@ -367,6 +377,53 @@ command_indx_query_coil_driver_params(uint32_t *args) {
 DECL_COMMAND(command_indx_query_coil_driver_params,
              "indx_query_coil_driver_params");
 
+// Start a oneshot LC ringdown nozzle-presence probe.
+// args[0]: dump - stream capture buffer + peaks before status report.
+extern "C" void
+command_indx_ringdown_probe(uint32_t *args) {
+    if (!indx_heater_instance)
+        return;
+    bool dump = args[0] != 0;
+    indx_heater_instance->coil_driver_inst.start_ringdown(true, dump);
+}
+DECL_COMMAND(command_indx_ringdown_probe, "indx_ringdown_probe dump=%c");
+
+// Poll latched ringdown outcome (replies indx_nozzle_presence).
+extern "C" void
+command_indx_query_ringdown(uint32_t *args) {
+    (void)args;
+    if (!indx_heater_instance)
+        return;
+    indx_heater_instance->coil_driver_inst.report_ringdown_status();
+}
+DECL_COMMAND(command_indx_query_ringdown, "indx_query_ringdown");
+
+// Configure continuous ringdown + optional heat gate + amplitude knobs.
+// present/absent/min peak volts and excite/zero_margin are float bits;
+// periods in ms.
+extern "C" void
+command_indx_set_ringdown_params(uint32_t *args) {
+    if (!indx_heater_instance)
+        return;
+    bool enable = args[0] != 0;
+    bool heat_gate = args[1] != 0;
+    auto present_peak_v = *reinterpret_cast<float *>(&args[2]);
+    auto absent_peak_v = *reinterpret_cast<float *>(&args[3]);
+    uint32_t idle_ms = args[4];
+    uint32_t heat_ms = args[5];
+    auto excite_scale = *reinterpret_cast<float *>(&args[6]);
+    auto zero_margin_v = *reinterpret_cast<float *>(&args[7]);
+    auto min_peak_v = *reinterpret_cast<float *>(&args[8]);
+    indx_heater_instance->coil_driver_inst.set_ringdown_params(
+        enable, heat_gate, present_peak_v, absent_peak_v, idle_ms, heat_ms,
+        excite_scale, zero_margin_v, min_peak_v);
+}
+DECL_COMMAND(
+    command_indx_set_ringdown_params,
+    "indx_set_ringdown_params enable=%c heat_gate=%c present_peak_v=%u "
+    "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u zero_margin_v=%u "
+    "min_peak_v=%u");
+
 extern "C" void
 command_indx_led_force_color(uint32_t *args) {
     if (!indx_heater_instance)
@@ -431,11 +488,16 @@ indx_heater_task(void) {
         return;
     }
 
-    // Pump the auto-tuner every scheduler pass while it runs, so bounded test
-    // bursts fire back to back. Cheap flag check otherwise.
+    // Pump the auto-tuner / ringdown every scheduler pass while active, so
+    // bounded test bursts fire back to back. Cheap flag check otherwise.
     auto &coil = indx_heater_instance->coil_driver_inst;
-    if (coil.tune_active() && !sched_is_shutdown()) {
-        coil.tune_step();
+    if (!sched_is_shutdown()) {
+        if (coil.tune_active()) {
+            coil.tune_step();
+        }
+        if (coil.ringdown_active()) {
+            coil.ringdown_step(false);
+        }
     }
 
     if (!sched_check_wake(&indx_heater_wake)) {

--- a/test/klippy/indx_ringdown_bad_excite.cfg
+++ b/test/klippy/indx_ringdown_bad_excite.cfg
@@ -1,0 +1,33 @@
+# Test config: ringdown excite_scale cannot exceed 1.0
+[mcu]
+serial: /dev/klipper_main
+
+[mcu indxmcu]
+serial: /dev/klipper_indx
+
+[printer]
+kinematics: none
+max_velocity: 300
+max_accel: 3000
+
+[indx]
+mcu: indxmcu
+ringdown_excite_scale: 1.1
+
+[fan]
+pin: indxmcu:part_cooling
+tachometer_pin: indxmcu:part_cooling_tacho
+
+[extruder]
+step_pin: indxmcu:motor_step
+dir_pin: indxmcu:motor_dir
+enable_pin: !indxmcu:motor_enable
+microsteps: 32
+rotation_distance: 5.7
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+heater_pin: indx:heater
+sensor_type: indx
+control: watermark
+min_temp: 0
+max_temp: 300

--- a/test/klippy/indx_ringdown_bad_peak.cfg
+++ b/test/klippy/indx_ringdown_bad_peak.cfg
@@ -1,0 +1,34 @@
+# Test config: ringdown present_peak_v must be < absent_peak_v
+[mcu]
+serial: /dev/klipper_main
+
+[mcu indxmcu]
+serial: /dev/klipper_indx
+
+[printer]
+kinematics: none
+max_velocity: 300
+max_accel: 3000
+
+[indx]
+mcu: indxmcu
+ringdown_present_peak_v: 95
+ringdown_absent_peak_v: 80
+
+[fan]
+pin: indxmcu:part_cooling
+tachometer_pin: indxmcu:part_cooling_tacho
+
+[extruder]
+step_pin: indxmcu:motor_step
+dir_pin: indxmcu:motor_dir
+enable_pin: !indxmcu:motor_enable
+microsteps: 32
+rotation_distance: 5.7
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+heater_pin: indx:heater
+sensor_type: indx
+control: watermark
+min_temp: 0
+max_temp: 300

--- a/test/klippy/indx_ringdown_limits.test
+++ b/test/klippy/indx_ringdown_limits.test
@@ -1,0 +1,5 @@
+# Ringdown config limits: present_peak_v < absent_peak_v, excite_scale <= 1.0
+DICTIONARY atmega2560.dict indxmcu=bondtech_indx.dict
+SHOULD_FAIL
+CONFIG indx_ringdown_bad_peak.cfg
+CONFIG indx_ringdown_bad_excite.cfg


### PR DESCRIPTION
Add LC ringdown nozzle-presence sensing on the INDX toolboard so Kalico can
tell whether a steel nozzle is coupled to the coil, in the same vein as
Prusa's INDX ringdown-style presence check.

A soft coil impulse is classified from first-lobe peak tank voltage
(`present` / `absent` / `unknown`). That is independent of load-cell latch
preload: latch force answers "is the latch preloaded?"; ringdown answers
"is steel in the coil?". An unlocked tool that remains in the coil shows
present to ringdown but not to the load cell. Optional `ringdown_heat_gate`
refuses to heat unless presence is `present`.

- Oneshot probe: `INDX_RINGDOWN_PROBE` (optional `DUMP=1` waveform CSV)
- Continuous probing + thresholds via `INDX_SET_RINGDOWN_PARAMS` / config
- Status fields on `printer.indx` (`nozzle_presence*`, ringdown params)
- Defaults off; Bondtech characterisation defaults (87 V / 91 V at
  `EXCITE_SCALE=0.8`) documented in `INDX.md`
- While a ringdown pulse pauses the drive, report zero coil power to the
  host thermal model so `power_sum` is not inflated

Empty heads at full soft-start often overvolt; `EXCITE_SCALE` defaults to
0.8 and is capped at 1.0. Classification uses peak amplitude (seated peak
lower than empty on Bondtech).

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green