### PR TITLE
indx: Add induction coil tool presence detection

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -6291,6 +6291,30 @@ mcu:
 #   Override the IR sensor tuning parameters stored in the sensor
 #   EEPROM. All three must be provided if any is given. These should
 #   not normally be set.
+#ringdown_enable: False
+#ringdown_heat_gate: False
+#ringdown_present_peak_v: 87.0
+#ringdown_absent_peak_v: 91.0
+#   Peak tank volts for classification. Seated (present) peaks are
+#   lower than empty (absent) on Bondtech. present must be < absent.
+#   Peak <= present → present; peak >= absent → absent; else unknown.
+#ringdown_min_peak_v: 20.0
+#   Reject captures weaker than this (status=weak_signal).
+#ringdown_idle_ms: 500
+#ringdown_heat_ms: 500
+#ringdown_excite_scale: 0.8
+#   Multiplier on calibrated soft-start ON ticks for the probe pulse
+#   (0.05-1.0). Soften below 1.0 if empty-head probes trip overvoltage
+#   (Bondtech empty often OV at 1.0). Cannot exceed 1.0 (never hotter
+#   than coil_time_on_first). Overvoltage mid-probe always aborts
+#   (status=overvoltage).
+#   Ringdown nozzle-presence detection. When ringdown_enable is
+#   True the toolboard periodically fires a soft coil impulse and
+#   classifies coupling from first-lobe peak amplitude (present /
+#   absent / unknown). Defaults are from Bondtech characterisation;
+#   confirm on your head before enabling ringdown_heat_gate (which
+#   refuses to heat unless presence is present). Use
+#   INDX_RINGDOWN_PROBE DUMP=1 to inspect waveforms. See INDX.md.
 ```
 
 ### [sx1509]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1112,7 +1112,34 @@ override.
 #### INDX_SET_IR_SENSOR_PARAMS
 `INDX_SET_IR_SENSOR_PARAMS EXPONENT=<value> OBJ_GAIN=<value>
 BRACKET_GAIN=<value>`: Override the IR sensor tuning parameters
-stored in the sensor EEPROM. These should not normally be changed.
+stored in the sensor EEPROM. All three must be provided.
+
+#### INDX_RINGDOWN_PROBE
+`INDX_RINGDOWN_PROBE [DUMP=0|1]`: Fire a oneshot ringdown probe and
+report nozzle presence (`present` / `absent` / `unknown`), `peak_v`,
+and status. Requires calibrated coil timings
+(`INDX_CALIBRATE`). Useful for characterising peak-amplitude thresholds
+and excitation before enabling continuous ringdown or the heat gate.
+Status may be `valid`, `weak_signal`, `overvoltage`, `timeout`,
+or `aborted`. With `DUMP=1`, the MCU streams the capture buffer; the
+host writes `/tmp/indx_ringdown_waveform.csv` (index, ns, counts, mv,
+is_peak; header includes `peak_mv`). Use DUMP when classification
+looks wrong to inspect the waveform.
+
+#### INDX_SET_RINGDOWN_PARAMS
+`INDX_SET_RINGDOWN_PARAMS [ENABLE=0|1] [HEAT_GATE=0|1]
+[PRESENT_PEAK_V=<v>] [ABSENT_PEAK_V=<v>] [MIN_PEAK_V=<v>]
+[IDLE_MS=<ms>] [HEAT_MS=<ms>] [EXCITE_SCALE=<0.05-1.0>]`:
+Configure continuous ringdown probing, the optional heat gate, and
+peak-amplitude thresholds. PRESENT_PEAK_V must be less than
+ABSENT_PEAK_V (seated peak is lower than empty on Bondtech). Peak at
+or below PRESENT_PEAK_V → present; at or above ABSENT_PEAK_V → absent;
+between → unknown. MIN_PEAK_V rejects weak captures. EXCITE_SCALE
+multiplies the soft-start ON pulse but cannot exceed 1.0 (never hotter
+than coil_time_on_first); default 0.8. Empty at 1.0 may overvoltage.
+Overvoltage mid-probe always aborts. Updated values are staged for
+SAVE_CONFIG. Keep HEAT_GATE disabled until thresholds are confirmed
+on your hardware (see INDX.md).
 
 #### INDX_SET_CYCLE_LIMIT
 `INDX_SET_CYCLE_LIMIT LIMIT=<value>`: Limit the coil driver duty

--- a/docs/INDX.md
+++ b/docs/INDX.md
@@ -118,5 +118,44 @@ INDX_LOAD_FILAMENT
 Use `INDX_CLEAR_FILAMENT` to reset the filament parameters, and
 `SAVE_CONFIG` to persist any of these values.
 
+## Nozzle presence (ringdown)
+
+The toolboard classifies whether a steel nozzle is coupled to the
+induction coil by firing a soft single-cycle impulse and measuring the
+**peak voltage of the first resonance lobe**. On Bondtech hardware a
+seated nozzle loads the coil (lower peak); an empty coil rings higher.
+Ambiguous values between the thresholds are reported as `unknown`.
+
+This is independent of load-cell latch preload: ringdown answers "is
+steel in the coil?", while a load cell answers "is the latch
+preloaded?".
+
+Defaults are off. Amplitude thresholds
+(`ringdown_present_peak_v` / `ringdown_absent_peak_v`) and
+`ringdown_excite_scale` (default 0.8) come from Bondtech characterisation
+and should be checked on your head before enabling the heat gate:
+
+1. With coil timings calibrated, seat a tool and run
+   `INDX_RINGDOWN_PROBE`. Note the reported `peak_v` and presence.
+   If classification looks wrong, run `INDX_RINGDOWN_PROBE DUMP=1` and
+   inspect `/tmp/indx_ringdown_waveform.csv` on the host.
+2. Remove the tool (latch open / empty head) and probe again. Empty
+   peak should be clearly higher than seated.
+3. If empty probes report `overvoltage`, lower `EXCITE_SCALE` (do not
+   use 1.0 empty on Bondtech - it OV'd in characterisation). Soften
+   toward 0.7-0.8. Excitation cannot be raised above calibrated
+   soft-start (`EXCITE_SCALE` max 1.0).
+4. Optionally check a half-seated tool; expect `unknown` between the
+   two peak thresholds.
+5. Set `PRESENT_PEAK_V` / `ABSENT_PEAK_V` (present must be less than
+   absent) with a clear hysteresis gap via `INDX_SET_RINGDOWN_PARAMS`,
+   then `SAVE_CONFIG`. Defaults 87 V / 91 V suit EXCITE_SCALE=0.8.
+6. Only then consider `HEAT_GATE=1` / `ringdown_heat_gate: True`, which
+   refuses to heat unless presence is `present`.
+
+Enable continuous probing with `ringdown_enable: True` (about every
+500 ms while idle and while heating by default). Soft probes briefly
+pause heating; keep periods conservative.
+
 See the [G-Code reference](G-Codes.md#indx) for the full list of INDX
 commands and their parameters.

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -348,6 +348,21 @@ The following information is available in the
 - `last_dock_measurement`: The result of the last INDX_DOCK_MEASURE
   command (None if no measurement has been taken). It is a dictionary
   containing the keys `x`, `y`, `position` and `axis_order`.
+- `nozzle_presence`: Latest ringdown classification (`present`,
+  `absent`, or `unknown`).
+- `nozzle_presence_peak_v`: Peak tank voltage from the last probe
+  (float, volts).
+- `nozzle_presence_status`: Probe outcome (`idle`, `running`, `valid`,
+  `weak_signal`, `aborted`, `overvoltage`, `timeout`).
+- `nozzle_presence_age`: Seconds since the last completed probe, or
+  None if no probe has completed yet.
+- `ringdown_enable`: Whether continuous ringdown probing is enabled.
+- `ringdown_heat_gate`: Whether heating is gated on `present`.
+- `ringdown_excite_scale`: Soft-start ON multiplier for the probe pulse
+  (max 1.0; default 0.8).
+- `ringdown_present_peak_v` / `ringdown_absent_peak_v` /
+  `ringdown_min_peak_v`: Peak-amplitude classification thresholds
+  (volts). Present must be less than absent.
 
 ## led
 

--- a/klippy/extras/indx/compat.py
+++ b/klippy/extras/indx/compat.py
@@ -1,5 +1,11 @@
+import struct
+
 from klippy.configfile import ConfigWrapper as RealConfigWrapper
 from klippy.configfile import error as ConfigError
+
+
+def float_to_u32(val):
+    return int(struct.unpack("!i", struct.pack("!f", val))[0])
 
 
 class ConfigWrapper(RealConfigWrapper):
@@ -74,6 +80,23 @@ def register_adc_callback(adc, callback):
     # Old klipper and Kalico ADC callback style
     adc.setup_adc_callback(0.3, callback)
     adc.setup_minmax(0.001, 8)
+
+
+def poll_query_until(
+    reactor, query_cmd, status_key, running_value, timeout, poll_interval
+):
+    """Poll an MCU query command until status is no longer running_value.
+
+    Returns the last params dict, or None on timeout.
+    """
+    deadline = reactor.monotonic() + timeout
+    while True:
+        result = query_cmd.send([])
+        if result[status_key] != running_value:
+            return result
+        if reactor.monotonic() > deadline:
+            return None
+        reactor.pause(reactor.monotonic() + poll_interval)
 
 
 def get_tmc_current_helper(stepper):

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -1,13 +1,13 @@
 import logging
 import math
-import struct
 from collections import namedtuple
 from time import strftime
 
 from ..thermistor import CustomThermistor
 from . import calibration, compat
-from .compat import ConfigWrapper
+from .compat import ConfigWrapper, float_to_u32, poll_query_until
 from .heatsink_fan import IndxHeatsinkFan
+from .ringdown import IndxRingdown
 
 KELVIN_OFFSET = 273.15
 
@@ -27,6 +27,7 @@ COIL_TUNE_STATUS_RUNNING = 1
 COIL_TUNE_TIMEOUT = 15.0  # seconds. The MCU self-aborts a stuck tune at 10 s
 COIL_TUNE_POLL_INTERVAL = 0.2  # seconds between latched-status polls
 COIL_TUNE_WAVE_PATH = "/tmp/indx_coil_waveform.csv"
+
 FILAMENT_LOAD_THRESHOLD = 10.0
 FILAMENT_LOAD_PRIME_TIME = 5.0
 FILAMENT_LOAD_MAX_LENGTH = 120.0
@@ -46,10 +47,6 @@ NozzleTemperature = namedtuple(
         "delta_pwm_energy",
     ],
 )
-
-
-def float_to_u32(val):
-    return int(struct.unpack("!i", struct.pack("!f", val))[0])
 
 
 class IndxThermistorWrapper:
@@ -302,6 +299,7 @@ class IndxToolboardHeater:
         self.toolboard.mcu.register_config_callback(self.build_config)
         self.temperature_callbacks = []
         self.cmd_queue = self.toolboard.mcu.alloc_command_queue()
+        self.ringdown = IndxRingdown(self, config)
 
         self.toolboard.printer.register_event_handler(
             "klippy:connect", self.handle_connect
@@ -344,6 +342,9 @@ class IndxToolboardHeater:
         self.raw_ir_log_file = None
         self.raw_ir_log_sensors = []
 
+    def get_ringdown_status(self, eventtime):
+        return self.ringdown.get_status(eventtime)
+
     def build_config(self):
         mcu = self.toolboard.mcu
 
@@ -358,6 +359,7 @@ class IndxToolboardHeater:
             self.handle_debug_raw_ir,
             "indx_debug_raw_ir object=%u ambient=%u",
         )
+
         self.cmd_debug_stream_raw_ir = mcu.lookup_command(
             "indx_debug_stream_raw_ir_sensor enable=%c", cq=self.cmd_queue
         )
@@ -423,6 +425,13 @@ class IndxToolboardHeater:
                     raise self.toolboard.printer.command_error(
                         "INDX heater has not been calibrated yet. "
                         "Run INDX_CALIBRATE to perform calibration."
+                    )
+                if degrees and not self.ringdown.heating_allowed():
+                    raise self.toolboard.printer.command_error(
+                        "INDX ringdown heat gate: nozzle not present "
+                        "(presence=%s). Seat a tool, run INDX_RINGDOWN_PROBE, "
+                        "or disable ringdown_heat_gate."
+                        % (self.ringdown.nozzle_presence,)
                     )
                 base_set_temp(degrees)
 
@@ -707,15 +716,17 @@ class IndxToolboardHeater:
         )
         try:
             self.tune_coil_cmd.send([int(capture)])
-            deadline = reactor.monotonic() + COIL_TUNE_TIMEOUT
-            while True:
-                result = self.query_coil_tune_cmd.send([])
-                if result["status"] != COIL_TUNE_STATUS_RUNNING:
-                    break
-                if reactor.monotonic() > deadline:
-                    self.coil_timings = None
-                    raise gcmd.error("INDX coil driver tuning timed out")
-                reactor.pause(reactor.monotonic() + COIL_TUNE_POLL_INTERVAL)
+            result = poll_query_until(
+                reactor,
+                self.query_coil_tune_cmd,
+                "status",
+                COIL_TUNE_STATUS_RUNNING,
+                COIL_TUNE_TIMEOUT,
+                COIL_TUNE_POLL_INTERVAL,
+            )
+            if result is None:
+                self.coil_timings = None
+                raise gcmd.error("INDX coil driver tuning timed out")
         finally:
             wave.unregister()
             finished.unregister()
@@ -1391,9 +1402,11 @@ class IndxToolboardHeater:
                 loaded_at_pos - start_pos,
                 last_pos - loaded_at_pos,
                 heat_capacity,
-                "Run SAVE_CONFIG to save the new filament parameters."
-                if apply_result
-                else "Use APPLY=1 to apply the measured filament parameters.",
+                (
+                    "Run SAVE_CONFIG to save the new filament parameters."
+                    if apply_result
+                    else "Use APPLY=1 to apply the measured filament parameters."
+                ),
             )
         )
 
@@ -1576,9 +1589,11 @@ class IndxToolboardHeater:
         path = "/tmp/indx_raw_ir_%s.csv" % strftime("%Y%m%d_%H%M%S")
         self.raw_ir_log_file = open(path, "w")
         names = [
-            n[len("temperature_sensor ") :]
-            if n.startswith("temperature_sensor ")
-            else n
+            (
+                n[len("temperature_sensor ") :]
+                if n.startswith("temperature_sensor ")
+                else n
+            )
             for n in self.raw_ir_log_sensors
         ]
         header = ["time", "raw_object", "raw_ambient"] + names

--- a/klippy/extras/indx/ringdown.py
+++ b/klippy/extras/indx/ringdown.py
@@ -1,0 +1,418 @@
+import logging
+
+from .compat import float_to_u32, poll_query_until, register_response
+
+RINGDOWN_WAVE_PATH = "/tmp/indx_ringdown_waveform.csv"
+
+# Mirrors MCU ringdown_status / nozzle_presence enums.
+RINGDOWN_STATUS = {
+    0: "idle",
+    1: "running",
+    2: "valid",
+    3: "weak_signal",
+    4: "aborted",
+    5: "overvoltage",
+    6: "timeout",
+}
+RINGDOWN_STATUS_IDLE = 0
+RINGDOWN_STATUS_RUNNING = 1
+RINGDOWN_PRESENCE = {0: "unknown", 1: "present", 2: "absent"}
+RINGDOWN_PROBE_TIMEOUT = 5.0
+RINGDOWN_PROBE_POLL_INTERVAL = 0.05
+RINGDOWN_EXCITE_SCALE_DEFAULT = 0.8
+RINGDOWN_EXCITE_SCALE_MAX = 1.0
+# DUMP CSV annotation only; not a user config and not used for classification.
+RINGDOWN_DUMP_ZERO_MARGIN_V = 1.0
+RINGDOWN_PRESENT_PEAK_V_DEFAULT = 87.0
+RINGDOWN_ABSENT_PEAK_V_DEFAULT = 91.0
+RINGDOWN_MIN_PEAK_V_DEFAULT = 20.0
+RINGDOWN_RESPONSE = (
+    "indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u"
+)
+RINGDOWN_SET_PARAMS_CMD = (
+    "indx_set_ringdown_params enable=%c heat_gate=%c present_peak_v=%u "
+    "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u min_peak_v=%u"
+)
+
+
+class RingdownParams:
+    def __init__(
+        self,
+        enable,
+        heat_gate,
+        present_peak_v,
+        absent_peak_v,
+        min_peak_v,
+        idle_ms,
+        heat_ms,
+        excite_scale,
+    ):
+        self.enable = enable
+        self.heat_gate = heat_gate
+        self.present_peak_v = present_peak_v
+        self.absent_peak_v = absent_peak_v
+        self.min_peak_v = min_peak_v
+        self.idle_ms = idle_ms
+        self.heat_ms = heat_ms
+        self.excite_scale = excite_scale
+
+    @classmethod
+    def from_config(cls, config):
+        present_peak_v = config.getfloat(
+            "ringdown_present_peak_v",
+            default=RINGDOWN_PRESENT_PEAK_V_DEFAULT,
+            above=0.0,
+            maxval=200.0,
+        )
+        absent_peak_v = config.getfloat(
+            "ringdown_absent_peak_v",
+            default=RINGDOWN_ABSENT_PEAK_V_DEFAULT,
+            above=0.0,
+            maxval=200.0,
+        )
+        if not (present_peak_v < absent_peak_v):
+            raise config.error(
+                "ringdown_present_peak_v must be less than ringdown_absent_peak_v"
+            )
+        return cls(
+            enable=config.getboolean("ringdown_enable", False),
+            heat_gate=config.getboolean("ringdown_heat_gate", False),
+            present_peak_v=present_peak_v,
+            absent_peak_v=absent_peak_v,
+            min_peak_v=config.getfloat(
+                "ringdown_min_peak_v",
+                default=RINGDOWN_MIN_PEAK_V_DEFAULT,
+                minval=0.0,
+                maxval=200.0,
+            ),
+            idle_ms=config.getint(
+                "ringdown_idle_ms", default=500, minval=20, maxval=5000
+            ),
+            heat_ms=config.getint(
+                "ringdown_heat_ms", default=500, minval=50, maxval=10000
+            ),
+            excite_scale=config.getfloat(
+                "ringdown_excite_scale",
+                default=RINGDOWN_EXCITE_SCALE_DEFAULT,
+                above=0.05,
+                maxval=RINGDOWN_EXCITE_SCALE_MAX,
+            ),
+        )
+
+    def apply_gcmd(self, gcmd):
+        self.enable = bool(
+            gcmd.get_int("ENABLE", int(self.enable), minval=0, maxval=1)
+        )
+        self.heat_gate = bool(
+            gcmd.get_int("HEAT_GATE", int(self.heat_gate), minval=0, maxval=1)
+        )
+        self.present_peak_v = gcmd.get_float(
+            "PRESENT_PEAK_V",
+            self.present_peak_v,
+            above=0.0,
+            maxval=200.0,
+        )
+        self.absent_peak_v = gcmd.get_float(
+            "ABSENT_PEAK_V",
+            self.absent_peak_v,
+            above=0.0,
+            maxval=200.0,
+        )
+        if not (self.present_peak_v < self.absent_peak_v):
+            raise gcmd.error("PRESENT_PEAK_V must be less than ABSENT_PEAK_V")
+        self.min_peak_v = gcmd.get_float(
+            "MIN_PEAK_V",
+            self.min_peak_v,
+            minval=0.0,
+            maxval=200.0,
+        )
+        self.idle_ms = gcmd.get_int(
+            "IDLE_MS", self.idle_ms, minval=20, maxval=5000
+        )
+        self.heat_ms = gcmd.get_int(
+            "HEAT_MS", self.heat_ms, minval=50, maxval=10000
+        )
+        self.excite_scale = gcmd.get_float(
+            "EXCITE_SCALE",
+            self.excite_scale,
+            above=0.05,
+            maxval=RINGDOWN_EXCITE_SCALE_MAX,
+        )
+
+    def mcu_args(self):
+        return [
+            1 if self.enable else 0,
+            1 if self.heat_gate else 0,
+            float_to_u32(self.present_peak_v),
+            float_to_u32(self.absent_peak_v),
+            self.idle_ms,
+            self.heat_ms,
+            float_to_u32(self.excite_scale),
+            float_to_u32(self.min_peak_v),
+        ]
+
+    def config_cmd(self):
+        args = self.mcu_args()
+        return (
+            "indx_set_ringdown_params enable=%d heat_gate=%d present_peak_v=%u "
+            "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u "
+            "min_peak_v=%u" % tuple(args)
+        )
+
+    def save_config(self, configfile, section):
+        configfile.set(
+            section, "ringdown_enable", "True" if self.enable else "False"
+        )
+        configfile.set(
+            section,
+            "ringdown_heat_gate",
+            "True" if self.heat_gate else "False",
+        )
+        configfile.set(
+            section, "ringdown_present_peak_v", "%.3f" % self.present_peak_v
+        )
+        configfile.set(
+            section, "ringdown_absent_peak_v", "%.3f" % self.absent_peak_v
+        )
+        configfile.set(section, "ringdown_min_peak_v", "%.3f" % self.min_peak_v)
+        configfile.set(section, "ringdown_idle_ms", "%d" % self.idle_ms)
+        configfile.set(section, "ringdown_heat_ms", "%d" % self.heat_ms)
+        configfile.set(
+            section, "ringdown_excite_scale", "%.4f" % self.excite_scale
+        )
+
+    def status_dict(self):
+        return {
+            "ringdown_enable": self.enable,
+            "ringdown_heat_gate": self.heat_gate,
+            "ringdown_excite_scale": self.excite_scale,
+            "ringdown_present_peak_v": self.present_peak_v,
+            "ringdown_absent_peak_v": self.absent_peak_v,
+            "ringdown_min_peak_v": self.min_peak_v,
+        }
+
+
+def _waveform_peaks(samples):
+    """Host-side DUMP annotation: off_start index and local-maxima sample indices."""
+    zero_mv = int(RINGDOWN_DUMP_ZERO_MARGIN_V * 1000.0 + 0.5)
+    off_start = ""
+    for index, _ns, _counts, mv in samples:
+        if mv >= zero_mv:
+            off_start = index
+            break
+    peak_indices = set()
+    for i in range(1, len(samples) - 1):
+        prev_mv, mv, next_mv = (
+            samples[i - 1][3],
+            samples[i][3],
+            samples[i + 1][3],
+        )
+        if mv >= prev_mv and mv > next_mv:
+            peak_indices.add(samples[i][0])
+    if samples:
+        max_i = max(range(len(samples)), key=lambda i: samples[i][3])
+        if samples[max_i][3] > 0:
+            peak_indices.add(samples[max_i][0])
+    return off_start, peak_indices
+
+
+class IndxRingdown:
+    def __init__(self, heater, config):
+        self.heater = heater
+        self.toolboard = heater.toolboard
+        self.params = RingdownParams.from_config(config)
+        self.nozzle_presence = "unknown"
+        self.nozzle_presence_peak_v = 0.0
+        self.nozzle_presence_status = "idle"
+        self.nozzle_presence_time = 0.0
+        self.gcode = self.toolboard.printer.lookup_object("gcode")
+        self.gcode.register_command(
+            "INDX_RINGDOWN_PROBE", self.cmd_RINGDOWN_PROBE
+        )
+        self.gcode.register_command(
+            "INDX_SET_RINGDOWN_PARAMS", self.cmd_SET_RINGDOWN_PARAMS
+        )
+        self.toolboard.mcu.register_config_callback(self.build_config)
+
+    def heating_allowed(self):
+        if not self.params.enable or not self.params.heat_gate:
+            return True
+        return self.nozzle_presence == "present"
+
+    def get_status(self, eventtime):
+        age = None
+        if self.nozzle_presence_time:
+            age = max(0.0, eventtime - self.nozzle_presence_time)
+        status = {
+            "nozzle_presence": self.nozzle_presence,
+            "nozzle_presence_peak_v": self.nozzle_presence_peak_v,
+            "nozzle_presence_status": self.nozzle_presence_status,
+            "nozzle_presence_age": age,
+        }
+        status.update(self.params.status_dict())
+        return status
+
+    def build_config(self):
+        mcu = self.toolboard.mcu
+        cq = self.heater.cmd_queue
+        register_response(mcu, self.handle_nozzle_presence, RINGDOWN_RESPONSE)
+        self.ringdown_probe_cmd = mcu.lookup_command(
+            "indx_ringdown_probe dump=%c", cq=cq
+        )
+        self.query_ringdown_cmd = mcu.lookup_query_command(
+            "indx_query_ringdown",
+            RINGDOWN_RESPONSE,
+            cq=cq,
+        )
+        self.cmd_set_ringdown_params = mcu.lookup_command(
+            RINGDOWN_SET_PARAMS_CMD,
+            cq=cq,
+        )
+        mcu.add_config_cmd(self.params.config_cmd())
+
+    def _apply_result(self, params):
+        status = params["status"]
+        presence = params["presence"]
+        self.nozzle_presence_status = RINGDOWN_STATUS.get(status, status)
+        self.nozzle_presence = RINGDOWN_PRESENCE.get(presence, "unknown")
+        self.nozzle_presence_peak_v = params["peak_mv"] / 1000.0
+        self.nozzle_presence_time = (
+            self.toolboard.printer.get_reactor().monotonic()
+        )
+        # Defer: MCU response handlers must not send commands on the same queue.
+        self.toolboard.printer.get_reactor().register_async_callback(
+            lambda _eventtime: self._heat_gate_block_if_needed()
+        )
+
+    def _heat_gate_block_if_needed(self):
+        # Soft gate: drop the host target and warn. MCU already mutes drive.
+        if self.heating_allowed():
+            return
+        heater = self.heater.heater
+        if heater is None:
+            return
+        eventtime = self.toolboard.printer.get_reactor().monotonic()
+        _temp, target = heater.get_temp(eventtime)
+        if not target:
+            return
+        heater.set_temp(0.0)
+        msg = (
+            "INDX ringdown heat gate: nozzle not present "
+            "(presence=%s). Heating disabled." % (self.nozzle_presence,)
+        )
+        logging.warning(msg)
+        self.gcode.respond_info(msg)
+
+    def handle_nozzle_presence(self, params):
+        if params["status"] == RINGDOWN_STATUS_RUNNING:
+            return
+        self._apply_result(params)
+
+    def _send_params(self):
+        self.cmd_set_ringdown_params.send(self.params.mcu_args())
+
+    def cmd_RINGDOWN_PROBE(self, gcmd):
+        if self.heater.coil_timings is None:
+            raise gcmd.error(
+                "INDX ringdown requires calibrated coil timings. "
+                "Run INDX_CALIBRATE first."
+            )
+        dump = gcmd.get_int("DUMP", 0, minval=0, maxval=1)
+        reactor = self.toolboard.printer.get_reactor()
+        mcu = self.toolboard.mcu
+        samples = []
+        meta = {}
+        wave = meta_resp = None
+        if dump:
+            wave = register_response(
+                mcu,
+                lambda p: samples.append(
+                    (p["index"], p["ns"], p["counts"], p["mv"])
+                ),
+                "indx_ringdown_wave index=%u ns=%u counts=%u mv=%u",
+            )
+            meta_resp = register_response(
+                mcu,
+                lambda p: meta.update(p),
+                "indx_ringdown_meta status=%c peak_mv=%u",
+            )
+        try:
+            self.ringdown_probe_cmd.send([dump])
+            timeout = RINGDOWN_PROBE_TIMEOUT
+            if dump:
+                timeout += 5.0
+            result = poll_query_until(
+                reactor,
+                self.query_ringdown_cmd,
+                "status",
+                RINGDOWN_STATUS_RUNNING,
+                timeout,
+                RINGDOWN_PROBE_POLL_INTERVAL,
+            )
+            if result is None:
+                raise gcmd.error("INDX ringdown probe timed out")
+        finally:
+            if wave is not None:
+                wave.unregister()
+            if meta_resp is not None:
+                meta_resp.unregister()
+            if dump:
+                off_start, peak_indices = _waveform_peaks(samples)
+                with open(RINGDOWN_WAVE_PATH, "w") as f:
+                    f.write(
+                        "# off_start=%s zero_mv=%s n_peaks=%s status=%s "
+                        "peak_mv=%s\n"
+                        % (
+                            off_start,
+                            int(RINGDOWN_DUMP_ZERO_MARGIN_V * 1000.0 + 0.5),
+                            len(peak_indices),
+                            meta.get("status", ""),
+                            meta.get("peak_mv", ""),
+                        )
+                    )
+                    f.write("index,ns,counts,mv,is_peak\n")
+                    for index, ns, counts, mv in samples:
+                        is_peak = 1 if index in peak_indices else 0
+                        f.write(
+                            "%d,%d,%d,%d,%d\n"
+                            % (index, ns, counts, mv, is_peak)
+                        )
+                gcmd.respond_info(
+                    "INDX ringdown waveform (%d samples, %d peaks) saved to %s"
+                    % (len(samples), len(peak_indices), RINGDOWN_WAVE_PATH)
+                )
+        self._apply_result(result)
+        if result["status"] == RINGDOWN_STATUS_IDLE:
+            raise gcmd.error(
+                "INDX ringdown probe did not start (is another probe/tune active?)"
+            )
+        gcmd.respond_info(
+            "INDX ringdown: presence=%s status=%s peak_v=%.1f"
+            % (
+                self.nozzle_presence,
+                self.nozzle_presence_status,
+                self.nozzle_presence_peak_v,
+            )
+        )
+
+    def cmd_SET_RINGDOWN_PARAMS(self, gcmd):
+        self.params.apply_gcmd(gcmd)
+        self._send_params()
+        configfile = self.toolboard.printer.lookup_object("configfile")
+        self.params.save_config(configfile, self.toolboard.name)
+        gcmd.respond_info(
+            "INDX ringdown params updated (enable=%s heat_gate=%s "
+            "present_peak_v=%.1f absent_peak_v=%.1f min_peak_v=%.1f "
+            "idle_ms=%d heat_ms=%d excite_scale=%.3f). "
+            "Run SAVE_CONFIG to persist."
+            % (
+                self.params.enable,
+                self.params.heat_gate,
+                self.params.present_peak_v,
+                self.params.absent_peak_v,
+                self.params.min_peak_v,
+                self.params.idle_ms,
+                self.params.heat_ms,
+                self.params.excite_scale,
+            )
+        )

--- a/klippy/extras/indx/toolboard.py
+++ b/klippy/extras/indx/toolboard.py
@@ -96,9 +96,11 @@ class IndxToolboard:
         gcode.register_command("INDX_LED_SET_CURRENT", self.cmd_LED_SET_CURRENT)
 
     def get_status(self, eventtime):
-        return {
+        status = {
             "last_dock_measurement": self.dock_measurement.last_dock_measurement
         }
+        status.update(self.heater.get_ringdown_status(eventtime))
+        return status
 
     def cmd_LED_FORCE_COLOR(self, gcmd):
         cmd = self.mcu.lookup_command(

--- a/src/indx/coil_driver.c++
+++ b/src/indx/coil_driver.c++
@@ -28,7 +28,7 @@ static constexpr uint32_t FRAME_CYCLES = 512;
 
 // Overvoltage and tuning input is via resistive divider
 static constexpr float OV_DIVIDER_R1 = 45000.0f; // Drain to tap
-static constexpr float OV_DIVIDER_R2 = 1500.0f; // Tap to gnd
+static constexpr float OV_DIVIDER_R2 = 1500.0f;  // Tap to gnd
 // The feedback is on both pins PA06(for AC) and PB05(for ADC)
 DECL_CONSTANT_STR("RESERVE_PINS_INDX_FEEDBACK_SENSE", "PA06,PB05");
 
@@ -39,8 +39,8 @@ DECL_CONSTANT_STR("RESERVE_PINS_INDX_FEEDBACK_SENSE", "PA06,PB05");
 #define FEEDBACK_ADC_PIN_FUNC 'B'
 
 #define OV_EVSYS_CHANNEL 1
-static constexpr float OV_VDDANA = 3.3f; // AC reference voltage
-static constexpr float OV_TRIP_VOLTAGE = 100.0f; // overvoltage threshold
+static constexpr float OV_VDDANA = 3.3f;           // AC reference voltage
+static constexpr float OV_TRIP_VOLTAGE = 100.0f;   // overvoltage threshold
 static constexpr float TUNE_TARGET_PEAK_V = 96.0f; // target drive peak voltage
 //
 static constexpr uint32_t OV_SCALER_VALUE =
@@ -95,7 +95,7 @@ static constexpr float DRAIN_V_PER_COUNT =
 
 // ON-time search bounds (clock ticks).
 static constexpr uint32_t TUNE_ON_FIRST_SEED = 180; // safe starting floor
-static constexpr uint32_t TUNE_ON_STEP = 2; // ramp granularity
+static constexpr uint32_t TUNE_ON_STEP = 2;         // ramp granularity
 static constexpr uint32_t TUNE_ON_MAX = 1080;
 
 // Provisional OFF used while ramping ON: long enough to contain a full positive
@@ -129,191 +129,231 @@ static constexpr uint32_t TUNE_DUMP_INTERVAL_US = 3000;
 
 // Runtime state shared between task context and the TCC3/AC/ADC ISRs.
 struct driver_state {
-    // Compare value (ticks) for the steady ON portion.
-    volatile uint32_t on_ticks;
-    // Compare value for the first cycle ON portion in a burst.
-    volatile uint32_t on_ticks_first;
-    // Period-1 of a normal cycle, = on_ticks + off - 1.
-    volatile uint32_t period_minus_1;
-    // Period-1 of the first cycle in a burst, = on_ticks_first + off - 1
-    volatile uint32_t first_period_minus_1;
-    // ON cycles for the burst being scheduled (latched at the boundary).
-    volatile uint32_t on_cycles;
-    // ON cycles requested by set_duty(), latched into on_cycles each burst.
-    volatile uint32_t pending_on_cycles;
-    // Index (0..FRAME_CYCLES-1) of the next cycle the ISR will program.
-    volatile uint32_t cycle_idx;
-    // Whether the preceding cycle is ON. If not, we should use the first cycle
-    // length instead.
-    volatile bool prev_was_on;
-    // Cumulative overvoltage trips, increased by the AC comparator ISR.
-    volatile uint32_t ov_count;
-    // Whether the drive timings above are valid to fire (set explicitly via
-    // set_timings or by a successful tune).
-    bool timings_valid;
+  // Compare value (ticks) for the steady ON portion.
+  volatile uint32_t on_ticks;
+  // Compare value for the first cycle ON portion in a burst.
+  volatile uint32_t on_ticks_first;
+  // Period-1 of a normal cycle, = on_ticks + off - 1.
+  volatile uint32_t period_minus_1;
+  // Period-1 of the first cycle in a burst, = on_ticks_first + off - 1
+  volatile uint32_t first_period_minus_1;
+  // ON cycles for the burst being scheduled (latched at the boundary).
+  volatile uint32_t on_cycles;
+  // ON cycles requested by set_duty(), latched into on_cycles each burst.
+  volatile uint32_t pending_on_cycles;
+  // Index (0..FRAME_CYCLES-1) of the next cycle the ISR will program.
+  volatile uint32_t cycle_idx;
+  // Whether the preceding cycle is ON. If not, we should use the first cycle
+  // length instead.
+  volatile bool prev_was_on;
+  // Cumulative overvoltage trips, increased by the AC comparator ISR.
+  volatile uint32_t ov_count;
+  // Whether the drive timings above are valid to fire (set explicitly via
+  // set_timings or by a successful tune).
+  bool timings_valid;
 
-    // (Re)start a stopped/faulted drive timer for the pending burst.
-    void
-    arm_timer();
-    // Publish drive timings directly in ticks (ISR blocked across the writes).
-    void
-    set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
-                    uint32_t off_ticks);
-    // Cumulative overvoltage trips since boot
-    uint32_t
-    overvoltage_count() {
-        return __atomic_load_n(&ov_count, __ATOMIC_RELAXED);
-    }
+  // (Re)start a stopped/faulted drive timer for the pending burst.
+  void arm_timer();
+  // Publish drive timings directly in ticks (ISR blocked across the writes).
+  void set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
+                       uint32_t off_ticks);
+  // Cumulative overvoltage trips since boot
+  uint32_t overvoltage_count() {
+    return __atomic_load_n(&ov_count, __ATOMIC_RELAXED);
+  }
 
-    // ISR hooks
-    void
-    schedule_next_cycle();
+  // ISR hooks
+  void schedule_next_cycle();
 
-    void
-    record_overvoltage() {
-        // AC COMP0 overvoltage trip. The EVSYS channel already faulted the
-        // timer, so we just record the event here.
-        __atomic_fetch_add(&ov_count, 1, __ATOMIC_RELAXED);
-    }
+  void record_overvoltage() {
+    // AC COMP0 overvoltage trip. The EVSYS channel already faulted the
+    // timer, so we just record the event here.
+    __atomic_fetch_add(&ov_count, 1, __ATOMIC_RELAXED);
+  }
 };
 
 static driver_state state;
 
 struct current_sense_state {
-    uint32_t tally; // raw ADC counts, __atomic
+  uint32_t tally; // raw ADC counts, __atomic
 
-    void
-    on_sample(uint16_t result) {
-        __atomic_fetch_add(&tally, result, __ATOMIC_RELAXED);
-    }
+  void on_sample(uint16_t result) {
+    __atomic_fetch_add(&tally, result, __ATOMIC_RELAXED);
+  }
 
-    uint32_t
-    total() {
-        return __atomic_load_n(&tally, __ATOMIC_RELAXED);
-    }
+  uint32_t total() { return __atomic_load_n(&tally, __ATOMIC_RELAXED); }
 };
 
 static current_sense_state current_sense;
 
 enum class tune_phase : uint8_t {
-    idle,
-    on_first, // Phase 1: ramp first time_on until cycle 0's peak crosses target
-    on_first_done, // start Phase 2
-    off_measure, // Phase 2: equivalent-time sweep of the positive resonance
+  idle,
+  on_first, // Phase 1: ramp first time_on until cycle 0's peak crosses target
+  on_first_done, // start Phase 2
+  off_measure,   // Phase 2: equivalent-time sweep of the positive resonance
                  // half cycle
-    off_analyze, // find time_off
-    off_dump, // if requested, transfer the reconstructed waveform
-              // (rate-limited)
-    off_done, // start Phase 3
-    steady_on, // Phase 3: ramp time_on until cycle 1's peak crosses target
-    steady_done, // report all three timings
-    error,
+  off_analyze,   // find time_off
+  off_dump,      // if requested, transfer the reconstructed waveform
+                 // (rate-limited)
+  off_done,      // start Phase 3
+  steady_on,     // Phase 3: ramp time_on until cycle 1's peak crosses target
+  steady_done,   // report all three timings
+  error,
 };
 
 enum class tune_error : uint8_t {
-    none = 0,
-    overvoltage = 1, // Overvoltage triggered during the tune (target removed?)
-    initial_on_ceiling =
-        2, // ON-time tuning hit maximum time without reaching the target peak
-    off_no_zero =
-        3, // the resonance never returned to zero within the sweep window
-    steady_ceiling = 4, // steady ON hit the ceiling without reaching the target
-    timeout = 5, // timed out
+  none = 0,
+  overvoltage = 1, // Overvoltage triggered during the tune (target removed?)
+  initial_on_ceiling =
+      2, // ON-time tuning hit maximum time without reaching the target peak
+  off_no_zero =
+      3, // the resonance never returned to zero within the sweep window
+  steady_ceiling = 4, // steady ON hit the ceiling without reaching the target
+  timeout = 5,        // timed out
 };
 
 enum class tune_status : uint8_t {
-    idle = 0, // no tune has run since boot
-    running = 1, // tuning in progress
-    success = 2, // completed. on_first_ticks/off_ticks/on_ticks hold result
-    failed = 3, // aborted. `error` holds the reason
+  idle = 0,    // no tune has run since boot
+  running = 1, // tuning in progress
+  success = 2, // completed. on_first_ticks/off_ticks/on_ticks hold result
+  failed = 3,  // aborted. `error` holds the reason
 };
 
 enum class burst_status : uint8_t { busy, completed, ready };
 
+// Bounded test burst used by coil tune and ringdown. Only one owner at a time.
+struct test_burst {
+  bool burst_in_flight{false};
+  uint32_t next_fire_time{0};
+
+  volatile bool test_active{false};
+  volatile uint32_t cycles_done{0};
+  volatile uint32_t stop_after{0};
+  volatile uint32_t measure_cycle{0};
+  volatile bool burst_done{false};
+  volatile bool adc_active{false};
+  volatile bool adc_capture_armed{false};
+  volatile uint16_t adc_sample{0};
+
+  bool on_drive_overflow();
+  bool capture_adc_sample(uint16_t result);
+  burst_status poll();
+  void fire(uint32_t n_cycles, uint32_t measure);
+  void adc_arm();
+  void adc_restore();
+  void stop_hw();
+};
+
+static test_burst burst;
+
 struct tuner_state {
-    bool want_details{false};
+  bool want_details{false};
 
-    tune_phase phase{tune_phase::idle};
-    tune_error error{tune_error::none};
-    // Latched across the return to idle so the host can poll the outcome.
-    tune_status status{tune_status::idle};
-    bool burst_in_flight;
-    // Don't fire/act before this time
-    uint32_t next_fire_time;
-    // Snapshot of the overvoltage count at start; any change aborts the tune.
-    uint32_t ov_count_at_start;
-    // Whole-tune watchdog deadline; passing it aborts the tune.
-    uint32_t deadline;
-    uint32_t on_first_ticks; // Phase 1 candidate, then the kept result
-    uint32_t waveform_sample_count; // Desired number of waveform samples
-    uint32_t waveform_sample_idx; // OFF-sweep / dump index
-    uint32_t off_ticks; // result (ticks)
-    uint32_t on_ticks; // Phase 3 candidate, then the kept result
-    uint32_t found_steady; // result (ticks)
+  tune_phase phase{tune_phase::idle};
+  tune_error error{tune_error::none};
+  // Latched across the return to idle so the host can poll the outcome.
+  tune_status status{tune_status::idle};
+  // Snapshot of the overvoltage count at start; any change aborts the tune.
+  uint32_t ov_count_at_start;
+  // Whole-tune watchdog deadline; passing it aborts the tune.
+  uint32_t deadline;
+  uint32_t on_first_ticks;        // Phase 1 candidate, then the kept result
+  uint32_t waveform_sample_count; // Desired number of waveform samples
+  uint32_t waveform_sample_idx;   // OFF-sweep / dump index
+  uint32_t off_ticks;             // result (ticks)
+  uint32_t on_ticks;              // Phase 3 candidate, then the kept result
+  uint32_t found_steady;          // result (ticks)
 
-    // --- shared with the TCC3/AC/ADC ISRs ---
-    // A bounded test burst is in flight; the overflow ISR runs its own
-    // scheduling instead of the normal frame/duty path.
-    volatile bool test_active;
-    // Cycle boundaries (overflows) seen since the burst was armed.
-    volatile uint32_t cycles_done;
-    // Stop the burst once this many cycles have started.
-    volatile uint32_t stop_after;
-    // Which fired cycle's peak to keep: cycle 0 (soft-start) is pre-cleared by
-    // the caller; for a later cycle (1 = first steady) the ISR clears the COMP1
-    // latch as that cycle begins, so only its resonance can set it.
-    volatile uint32_t measure_cycle;
-    // Set by the ISR when the burst has stopped; cleared by the task.
-    volatile bool burst_done;
-    // Set if ADC1 is remapped to feedback and needs to be mapped back to
-    // current sensing later.
-    volatile bool adc_active;
-    // Waiting for ADC to capture a sample?
-    volatile bool adc_capture_armed;
-    // Captured ADC sample.
-    volatile uint16_t adc_sample;
-
-    bool
-    active() {
-        return phase != tune_phase::idle;
-    }
-    void
-    start(bool want_details);
-    void
-    step();
-
-    // Called from drive TCC handler. Returns true if tuner handled the event.
-    bool
-    on_drive_overflow();
-    // Called from ADC handler. Returns true if the tuner handled the event.
-    bool
-    capture_adc_sample(uint16_t result);
-
-    burst_status
-    burst_poll();
-    void
-    fire_burst(uint32_t n_cycles, uint32_t measure);
-    void
-    adc_arm();
-    void
-    adc_restore();
-    // Stop everything and enter the error phase.
-    void
-    abort(tune_error e);
-    // Latch the outcome, notify the host, and return to idle.
-    void
-    finish(tune_status s);
-    void
-    step_on_first();
-    void
-    step_off_measure();
-    void
-    analyze_off();
-    void
-    step_steady_on();
+  bool active() { return phase != tune_phase::idle; }
+  void start(bool want_details);
+  void step();
+  void abort(tune_error e);
+  void finish(tune_status s);
+  void step_on_first();
+  void step_off_measure();
+  void analyze_off();
+  void step_steady_on();
 };
 
 static tuner_state tuner;
+
+// --- Nozzle presence ringdown (first-lobe peak amplitude) ---
+
+static constexpr uint32_t RINGDOWN_SAMPLE_STEP = 16;
+static constexpr uint32_t RINGDOWN_N_SAMPLES = 64;
+static constexpr uint32_t RINGDOWN_TIMEOUT_US = 2000000;
+static constexpr float RINGDOWN_EXCITE_SCALE_DEFAULT = 0.8f;
+// Soften the probe pulse (never hotter than calibrated coil_time_on_first).
+// Default 0.8 from Bondtech characterisation (empty OV at 1.0).
+static constexpr float RINGDOWN_EXCITE_SCALE_MIN = 0.05f;
+static constexpr float RINGDOWN_EXCITE_SCALE_MAX = 1.0f;
+// Peak-voltage thresholds from Bondtech EXCITE_SCALE=0.8 sweep
+// (seated ~84 V, empty ~95 V). Re-characterise before heat_gate.
+static constexpr float RINGDOWN_PRESENT_PEAK_V_DEFAULT = 87.0f;
+static constexpr float RINGDOWN_ABSENT_PEAK_V_DEFAULT = 91.0f;
+static constexpr float RINGDOWN_MIN_PEAK_V_DEFAULT = 20.0f;
+static constexpr uint32_t RINGDOWN_IDLE_MS_DEFAULT = 500;
+static constexpr uint32_t RINGDOWN_HEAT_MS_DEFAULT = 500;
+
+enum class ringdown_phase : uint8_t {
+  idle,
+  pause_wait,
+  sample,
+  analyze,
+  dump,
+};
+
+struct ringdown_config {
+  bool enable{false};
+  bool heat_gate{false};
+  float present_peak_v{RINGDOWN_PRESENT_PEAK_V_DEFAULT};
+  float absent_peak_v{RINGDOWN_ABSENT_PEAK_V_DEFAULT};
+  float min_peak_v{RINGDOWN_MIN_PEAK_V_DEFAULT};
+  float excite_scale{RINGDOWN_EXCITE_SCALE_DEFAULT};
+  uint32_t idle_ms{RINGDOWN_IDLE_MS_DEFAULT};
+  uint32_t heat_ms{RINGDOWN_HEAT_MS_DEFAULT};
+};
+
+struct ringdown_state {
+  ringdown_phase phase{ringdown_phase::idle};
+  ringdown_status status{ringdown_status::idle};
+  nozzle_presence presence{nozzle_presence::unknown};
+  bool want_report{false};
+  bool want_dump{false};
+  uint32_t ov_count_at_start{0};
+  uint32_t deadline{0};
+  uint32_t sample_idx{0};
+  uint32_t dump_idx{0};
+  uint32_t dump_count{0};
+  uint32_t saved_pending_on_cycles{0};
+  uint32_t saved_on_ticks{0};
+  uint32_t saved_on_ticks_first{0};
+  uint32_t saved_off_ticks{0};
+  uint32_t peak_mv{0};
+  ringdown_status pending_status{ringdown_status::idle};
+  uint32_t next_schedule_time{0};
+
+  bool active() { return phase != ringdown_phase::idle; }
+  void start(bool report, bool dump);
+  void step();
+  void abort(ringdown_status s);
+  void finish(ringdown_status s);
+  void schedule_finish_or_dump(ringdown_status s);
+  void apply_presence(ringdown_status s);
+  void restore_drive();
+  void analyze();
+  uint32_t excite_on_ticks();
+};
+
+static ringdown_state ringdown;
+static ringdown_config ringdown_cfg;
+static nozzle_presence last_presence{nozzle_presence::unknown};
+static uint16_t ringdown_samples[RINGDOWN_N_SAMPLES];
+
+static bool heat_gate_blocks_drive() {
+  return ringdown_cfg.enable && ringdown_cfg.heat_gate &&
+         last_presence != nozzle_presence::present;
+}
 
 // IRQ declarations and assert correct indices.
 
@@ -330,623 +370,582 @@ DECL_CTR("DECL_ARMCM_IRQ AC_Handler 122");
 // Start a drive burst from an idle tank state. Sets up first two cycles and
 // starts the timer. Future cycles are set up by the timer ISR later on.
 // Only called if the timer is idle, clears any latched overvoltage fault.
-void
-driver_state::arm_timer() {
-    uint32_t on_cycles = pending_on_cycles;
-    this->on_cycles = on_cycles;
-    if (on_cycles == 0) {
-        // Nothing to fire: leave the timer stopped, output low.
-        return;
-    }
+void driver_state::arm_timer() {
+  uint32_t on_cycles = pending_on_cycles;
+  this->on_cycles = on_cycles;
+  if (on_cycles == 0) {
+    // Nothing to fire: leave the timer stopped, output low.
+    return;
+  }
 
-    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
 
-    // A latched fault (STATUS.FAULT0) leaves the counter halted and WO1 low.
-    // STOP then clear FAULT0. Clearing it while stopped keeps it stopped.
-    if (DRIVE_TCC->STATUS.bit.FAULT0) {
-        DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-        while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-            ;
-        DRIVE_TCC->STATUS.reg = TCC_STATUS_FAULT0;
-    }
-
-    // Flush any PERBUF/CCBUF the ISR staged before the timer stopped (at a
-    // frame boundary or a fault); it was never transferred, so PERBUFV/CCBUFV
-    // stay set. A direct PER/CC write below would then never finish syncing (a
-    // stopped counter has no UPDATE event to consume the buffer) and stall into
-    // a watchdog reset. CMD_UPDATE clears them. No-op at first arm.
-    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_UPDATE;
+  // A latched fault (STATUS.FAULT0) leaves the counter halted and WO1 low.
+  // STOP then clear FAULT0. Clearing it while stopped keeps it stopped.
+  if (DRIVE_TCC->STATUS.bit.FAULT0) {
+    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
     while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-        ;
+      ;
+    DRIVE_TCC->STATUS.reg = TCC_STATUS_FAULT0;
+  }
 
-    // Cycle 0 (inital ON ON + shortened period) goes in PER/CC. Cycle 1
-    // (steady ON, or 0 if the burst is a single cycle) goes in
-    // PERBUF/CCBUF, copied to PER/CC at the first overflow.
-    bool on1 = on_cycles > 1;
-    uint32_t cc1 = on1 ? on_ticks : 0;
-    DRIVE_TCC->PER.reg = TCC_PER_PER(first_period_minus_1);
-    DRIVE_TCC->CC[DRIVE_TCC_CC].reg = TCC_CC_CC(on_ticks_first);
-    while (DRIVE_TCC->SYNCBUSY.reg & (TCC_SYNCBUSY_PER | DRIVE_TCC_SYNCBUSY_CC))
-        ;
-    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(period_minus_1);
-    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc1);
+  // Flush any PERBUF/CCBUF the ISR staged before the timer stopped (at a
+  // frame boundary or a fault); it was never transferred, so PERBUFV/CCBUFV
+  // stay set. A direct PER/CC write below would then never finish syncing (a
+  // stopped counter has no UPDATE event to consume the buffer) and stall into
+  // a watchdog reset. CMD_UPDATE clears them. No-op at first arm.
+  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_UPDATE;
+  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+    ;
 
-    cycle_idx = 2;
-    prev_was_on = on1;
+  // Cycle 0 (inital ON ON + shortened period) goes in PER/CC. Cycle 1
+  // (steady ON, or 0 if the burst is a single cycle) goes in
+  // PERBUF/CCBUF, copied to PER/CC at the first overflow.
+  bool on1 = on_cycles > 1;
+  uint32_t cc1 = on1 ? on_ticks : 0;
+  DRIVE_TCC->PER.reg = TCC_PER_PER(first_period_minus_1);
+  DRIVE_TCC->CC[DRIVE_TCC_CC].reg = TCC_CC_CC(on_ticks_first);
+  while (DRIVE_TCC->SYNCBUSY.reg & (TCC_SYNCBUSY_PER | DRIVE_TCC_SYNCBUSY_CC))
+    ;
+  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(period_minus_1);
+  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc1);
 
-    // Unset stale overflow flag so the first ISR aligns with cycle 2.
-    DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
+  cycle_idx = 2;
+  prev_was_on = on1;
 
-    // Zero COUNT before retriggering. A retrigger of a STOPPED counter resumes
-    // from current COUNT. After a fault COUNT is frozen mid-cycle, so cycle 0
-    // would otherwise start partway through.
-    DRIVE_TCC->COUNT.reg = TCC_COUNT_COUNT(0);
-    while (DRIVE_TCC->SYNCBUSY.bit.COUNT)
-        ;
+  // Unset stale overflow flag so the first ISR aligns with cycle 2.
+  DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
 
-    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_RETRIGGER;
-    while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-        ;
+  // Zero COUNT before retriggering. A retrigger of a STOPPED counter resumes
+  // from current COUNT. After a fault COUNT is frozen mid-cycle, so cycle 0
+  // would otherwise start partway through.
+  DRIVE_TCC->COUNT.reg = TCC_COUNT_COUNT(0);
+  while (DRIVE_TCC->SYNCBUSY.bit.COUNT)
+    ;
 
-    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_RETRIGGER;
+  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+    ;
+
+  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 }
 
-void
-coil_driver::set_duty(float duty) {
-    if (duty != 0.0f && tune_active()) {
-        shutdown("INDX heater target set while coil tuning");
-    }
-    // The coil timings have no default. Driving without first setting them
-    // (explicitly or via a successful tune) is a fault.
-    if (duty != 0.0f && !state.timings_valid) {
-        shutdown("INDX heater started before coil timings were set");
-    }
+void coil_driver::set_duty(float duty) {
+  if (duty != 0.0f && tune_active()) {
+    shutdown("INDX heater target set while coil tuning");
+  }
+  // The coil timings have no default. Driving without first setting them
+  // (explicitly or via a successful tune) is a fault.
+  if (duty != 0.0f && !state.timings_valid) {
+    shutdown("INDX heater started before coil timings were set");
+  }
+  // Soft heat gate: mute drive unless a probe has classified present.
+  if (duty != 0.0f && heat_gate_blocks_drive()) {
+    duty = 0.0f;
+  }
 
-    uint32_t cycles;
-    if (duty <= 0.0f) {
-        cycles = 0;
-    } else if (duty >= 1.0f) {
-        cycles = FRAME_CYCLES;
-    } else {
-        cycles = (uint32_t)(duty * (float)FRAME_CYCLES);
-    }
-    if (this->duty_limit && cycles > this->duty_limit) {
-        cycles = this->duty_limit;
-    }
-    state.pending_on_cycles = cycles;
+  uint32_t cycles;
+  if (duty <= 0.0f) {
+    cycles = 0;
+  } else if (duty >= 1.0f) {
+    cycles = FRAME_CYCLES;
+  } else {
+    cycles = (uint32_t)(duty * (float)FRAME_CYCLES);
+  }
+  if (this->duty_limit && cycles > this->duty_limit) {
+    cycles = this->duty_limit;
+  }
+  // Probe owns the tank; latch the requested duty for restore. Do not zero
+  // the request first or restore would drop heat until the next PID tick.
+  if (ringdown_active()) {
+    ringdown.saved_pending_on_cycles = cycles;
+    return;
+  }
+  state.pending_on_cycles = cycles;
 
-    // Rearm the timer if it's not currently active.
-    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
-    if (cycles > 0 && idle) {
-        state.arm_timer();
-    }
+  // Rearm the timer if it's not currently active.
+  bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+  if (cycles > 0 && idle) {
+    state.arm_timer();
+  }
 }
 
-void
-coil_driver::set_cycle_limit(uint32_t limit) {
-    this->duty_limit = limit;
+void coil_driver::set_cycle_limit(uint32_t limit) { this->duty_limit = limit; }
+
+uint32_t coil_driver::get_ov_count() { return state.overvoltage_count(); }
+
+void coil_driver::shutdown_() {
+  // Disconnect timer from drive pin. The external gate pulldown holds the
+  // MOSFET off.
+  gpio_peripheral(DRIVE_PIN, 0, 0);
+  DRIVE_TCC->CTRLA.bit.ENABLE = 0;
+  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+
+  // Disable the overvoltage comparator.
+  AC->CTRLA.reg = 0;
+  NVIC_DisableIRQ(AC_IRQn);
+
+  // Stop ADC start events first so no further conversions begin.
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.ENABLE = 0;
+  NVIC_DisableIRQ(FEEDBACK_ADC_1_IRQn);
+  NVIC_DisableIRQ(FEEDBACK_ADC_0_IRQn);
 }
 
-uint32_t
-coil_driver::get_ov_count() {
-    return state.overvoltage_count();
-}
-
-void
-coil_driver::shutdown_() {
-    // Disconnect timer from drive pin. The external gate pulldown holds the
-    // MOSFET off.
-    gpio_peripheral(DRIVE_PIN, 0, 0);
-    DRIVE_TCC->CTRLA.bit.ENABLE = 0;
-    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
-
-    // Disable the overvoltage comparator.
-    AC->CTRLA.reg = 0;
-    NVIC_DisableIRQ(AC_IRQn);
-
-    // Stop ADC start events first so no further conversions begin.
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.ENABLE = 0;
-    NVIC_DisableIRQ(FEEDBACK_ADC_1_IRQn);
-    NVIC_DisableIRQ(FEEDBACK_ADC_0_IRQn);
-}
-
-uint32_t
-coil_driver::get_total_charge() {
-    return current_sense.total();
-}
+uint32_t coil_driver::get_total_charge() { return current_sense.total(); }
 
 // Per-cycle scheduler. Runs at each overflow and stages the next
 // cycle's CCBUF/PERBUF, which are the timings for the cycle that will begin
 // _after_ the one that just started.
-void
-driver_state::schedule_next_cycle() {
-    uint32_t idx = cycle_idx;
+void driver_state::schedule_next_cycle() {
+  uint32_t idx = cycle_idx;
 
-    // Shape the next cycle. Default = OFF/skipped (CC=0, full period). The
-    // burst's first fired cycle (prev OFF) is soft-start (shorter ON + period,
-    // preserving OFF/ZVS time); other fired cycles are steady ON.
-    bool on = idx < on_cycles;
-    bool initial = on && !prev_was_on;
-    uint32_t cc = 0;
-    uint32_t per = period_minus_1;
-    if (initial) {
-        cc = on_ticks_first;
-        per = first_period_minus_1;
-    } else if (on) {
-        cc = on_ticks;
+  // Shape the next cycle. Default = OFF/skipped (CC=0, full period). The
+  // burst's first fired cycle (prev OFF) is soft-start (shorter ON + period,
+  // preserving OFF/ZVS time); other fired cycles are steady ON.
+  bool on = idx < on_cycles;
+  bool initial = on && !prev_was_on;
+  uint32_t cc = 0;
+  uint32_t per = period_minus_1;
+  if (initial) {
+    cc = on_ticks_first;
+    per = first_period_minus_1;
+  } else if (on) {
+    cc = on_ticks;
+  }
+  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc);
+  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(per);
+  prev_was_on = on;
+
+  // Check if this is the final cycle of the burst. If so, advance to the next
+  // burst.
+  if (++idx >= FRAME_CYCLES) {
+    idx = 0;
+    on_cycles = pending_on_cycles;
+    if (on_cycles == 0) {
+      DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
     }
-    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc);
-    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(per);
-    prev_was_on = on;
-
-    // Check if this is the final cycle of the burst. If so, advance to the next
-    // burst.
-    if (++idx >= FRAME_CYCLES) {
-        idx = 0;
-        on_cycles = pending_on_cycles;
-        if (on_cycles == 0) {
-            DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-        }
-    }
-    cycle_idx = idx;
+  }
+  cycle_idx = idx;
 }
 
-extern "C" void
-TCC3_0_Handler(void) {
-    DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
-    if (tuner.on_drive_overflow())
-        return;
-    state.schedule_next_cycle();
+extern "C" void TCC3_0_Handler(void) {
+  DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
+  if (burst.on_drive_overflow())
+    return;
+  state.schedule_next_cycle();
 }
 
-extern "C" void
-AC_Handler(void) {
-    AC->INTFLAG.reg = AC_INTFLAG_COMP0;
-    state.record_overvoltage();
+extern "C" void AC_Handler(void) {
+  AC->INTFLAG.reg = AC_INTFLAG_COMP0;
+  state.record_overvoltage();
 }
 
-extern "C" void
-FEEDBACK_ADC_1_Handler(void) {
-    uint16_t result = FEEDBACK_ADC->RESULT.reg;
-    if (tuner.capture_adc_sample(result))
-        return;
-    current_sense.on_sample(result);
+extern "C" void FEEDBACK_ADC_1_Handler(void) {
+  uint16_t result = FEEDBACK_ADC->RESULT.reg;
+  if (burst.capture_adc_sample(result))
+    return;
+  current_sense.on_sample(result);
 }
 
-extern "C" void
-FEEDBACK_ADC_0_Handler(void) {
-    shutdown("coil driver feedback ADC overrun");
+extern "C" void FEEDBACK_ADC_0_Handler(void) {
+  shutdown("coil driver feedback ADC overrun");
 }
 
 // Enables clock, running at core frequency instead of slower peripheral clkgen.
-static void
-enable_pclock_max(uint32_t pclk_id, int32_t pm_id) {
-    auto val = GCLK_PCHCTRL_GEN(0) | GCLK_PCHCTRL_CHEN;
-    GCLK->PCHCTRL[pclk_id].reg = val;
-    while (GCLK->PCHCTRL[pclk_id].reg != val)
-        ;
-    uint32_t pm_port = pm_id / 32, pm_bit = 1 << (pm_id % 32);
-    (&MCLK->APBAMASK.reg)[pm_port] |= pm_bit;
+static void enable_pclock_max(uint32_t pclk_id, int32_t pm_id) {
+  auto val = GCLK_PCHCTRL_GEN(0) | GCLK_PCHCTRL_CHEN;
+  GCLK->PCHCTRL[pclk_id].reg = val;
+  while (GCLK->PCHCTRL[pclk_id].reg != val)
+    ;
+  uint32_t pm_port = pm_id / 32, pm_bit = 1 << (pm_id % 32);
+  (&MCLK->APBAMASK.reg)[pm_port] |= pm_bit;
 }
 
-static void
-setup_adc1() {
-    // Set up the ADC temperature pin, which ensures `adc_init` gets called. We
-    // let this load the calibration data etc for us.
-    gpio_adc_setup(0xfe);
+static void setup_adc1() {
+  // Set up the ADC temperature pin, which ensures `adc_init` gets called. We
+  // let this load the calibration data etc for us.
+  gpio_adc_setup(0xfe);
 
-    gpio_peripheral(CURRENT_SENSE_PIN, CURRENT_SENSE_PIN_FUNC, 0);
-    gpio_peripheral(FEEDBACK_ADC_PIN, FEEDBACK_ADC_PIN_FUNC, 0);
+  gpio_peripheral(CURRENT_SENSE_PIN, CURRENT_SENSE_PIN_FUNC, 0);
+  gpio_peripheral(FEEDBACK_ADC_PIN, FEEDBACK_ADC_PIN_FUNC, 0);
 
-    enable_pclock(FEEDBACK_ADC_GCLK_ID, FEEDBACK_ADC_PM_ID);
+  enable_pclock(FEEDBACK_ADC_GCLK_ID, FEEDBACK_ADC_PM_ID);
 
-    // Read calibration data so we have it after we reset the ADC
-    auto calib = FEEDBACK_ADC->CALIB.reg;
+  // Read calibration data so we have it after we reset the ADC
+  auto calib = FEEDBACK_ADC->CALIB.reg;
 
-    FEEDBACK_ADC->CTRLA.bit.SWRST = 1;
-    while (FEEDBACK_ADC->SYNCBUSY.bit.SWRST)
-        ;
+  FEEDBACK_ADC->CTRLA.bit.SWRST = 1;
+  while (FEEDBACK_ADC->SYNCBUSY.bit.SWRST)
+    ;
 
-    // Reload calibration
-    FEEDBACK_ADC->CALIB.reg = calib;
+  // Reload calibration
+  FEEDBACK_ADC->CALIB.reg = calib;
 
-    FEEDBACK_ADC->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
-    while (FEEDBACK_ADC->SYNCBUSY.bit.REFCTRL)
-        ;
+  FEEDBACK_ADC->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
+  while (FEEDBACK_ADC->SYNCBUSY.bit.REFCTRL)
+    ;
 
-    FEEDBACK_ADC->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(4);
-    while (FEEDBACK_ADC->SYNCBUSY.bit.SAMPCTRL)
-        ;
+  FEEDBACK_ADC->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(4);
+  while (FEEDBACK_ADC->SYNCBUSY.bit.SAMPCTRL)
+    ;
 
-    // Start out with current sense as our ADC channel
-    FEEDBACK_ADC->INPUTCTRL.reg =
-        ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
-        ADC_INPUTCTRL_MUXNEG(0x18);
-    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-        ;
+  // Start out with current sense as our ADC channel
+  FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
+                                ADC_INPUTCTRL_MUXNEG(0x18);
+  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+    ;
 
-    // ADC runs event triggered. CURRENT_SENSE_TRIGGER_TC paces current sense
-    // measurements via EVSYS. During tuning, DRIVE_TCC takes over.
-    FEEDBACK_ADC->CTRLB.reg = ADC_CTRLB_RESSEL_12BIT;
-    while (FEEDBACK_ADC->SYNCBUSY.bit.CTRLB)
-        ;
-    FEEDBACK_ADC->EVCTRL.reg = ADC_EVCTRL_STARTEI;
+  // ADC runs event triggered. CURRENT_SENSE_TRIGGER_TC paces current sense
+  // measurements via EVSYS. During tuning, DRIVE_TCC takes over.
+  FEEDBACK_ADC->CTRLB.reg = ADC_CTRLB_RESSEL_12BIT;
+  while (FEEDBACK_ADC->SYNCBUSY.bit.CTRLB)
+    ;
+  FEEDBACK_ADC->EVCTRL.reg = ADC_EVCTRL_STARTEI;
 
-    FEEDBACK_ADC->INTENSET.reg = ADC_INTENSET_RESRDY | ADC_INTENSET_OVERRUN;
+  FEEDBACK_ADC->INTENSET.reg = ADC_INTENSET_RESRDY | ADC_INTENSET_OVERRUN;
 
-    NVIC_SetPriority(FEEDBACK_ADC_1_IRQn, 1);
-    NVIC_SetPriority(FEEDBACK_ADC_0_IRQn, 1);
-    NVIC_EnableIRQ(FEEDBACK_ADC_1_IRQn);
-    NVIC_EnableIRQ(FEEDBACK_ADC_0_IRQn);
+  NVIC_SetPriority(FEEDBACK_ADC_1_IRQn, 1);
+  NVIC_SetPriority(FEEDBACK_ADC_0_IRQn, 1);
+  NVIC_EnableIRQ(FEEDBACK_ADC_1_IRQn);
+  NVIC_EnableIRQ(FEEDBACK_ADC_0_IRQn);
 
-    // 48 MHz / 4 = 12 MHz ADC clock, spec calls for < 16MHz.
-    FEEDBACK_ADC->CTRLA.reg =
-        ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV4_Val) | ADC_CTRLA_ENABLE;
-    while (FEEDBACK_ADC->SYNCBUSY.bit.ENABLE)
-        ;
+  // 48 MHz / 4 = 12 MHz ADC clock, spec calls for < 16MHz.
+  FEEDBACK_ADC->CTRLA.reg =
+      ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV4_Val) | ADC_CTRLA_ENABLE;
+  while (FEEDBACK_ADC->SYNCBUSY.bit.ENABLE)
+    ;
 }
 
-static void
-setup_adc_trigger_tc() {
-    enable_pclock_max(CURRENT_SENSE_TRIGGER_TC_GCLK_ID,
-                      CURRENT_SENSE_TRIGGER_TC_PM_ID);
+static void setup_adc_trigger_tc() {
+  enable_pclock_max(CURRENT_SENSE_TRIGGER_TC_GCLK_ID,
+                    CURRENT_SENSE_TRIGGER_TC_PM_ID);
 
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.SWRST = 1;
-    while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.SWRST)
-        ;
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.SWRST = 1;
+  while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.SWRST)
+    ;
 
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.WAVE.reg = TC_WAVE_WAVEGEN_MFRQ;
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.CC[0].reg = ADC_TRIGGER_PERIOD - 1;
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.EVCTRL.reg = TC_EVCTRL_OVFEO;
-    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.reg =
-        TC_CTRLA_MODE_COUNT16 | TC_CTRLA_PRESCALER_DIV1 | TC_CTRLA_ENABLE;
-    while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.ENABLE)
-        ;
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.WAVE.reg = TC_WAVE_WAVEGEN_MFRQ;
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.CC[0].reg = ADC_TRIGGER_PERIOD - 1;
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.EVCTRL.reg = TC_EVCTRL_OVFEO;
+  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.reg =
+      TC_CTRLA_MODE_COUNT16 | TC_CTRLA_PRESCALER_DIV1 | TC_CTRLA_ENABLE;
+  while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.ENABLE)
+    ;
 }
 
-static void
-setup_evsys() {
-    // We need EVSYS for signal routing so bring it up now.
-    MCLK->APBBMASK.bit.EVSYS_ = 1;
+static void setup_evsys() {
+  // We need EVSYS for signal routing so bring it up now.
+  MCLK->APBBMASK.bit.EVSYS_ = 1;
 
-    // Event channel for triggering ADC for tuning and current sensing
-    EVSYS->Channel[DRIVE_TCC_TUNE_EVSYS_CHANNEL].CHANNEL.reg =
-        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TCC3_MC_0) |
-        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+  // Event channel for triggering ADC for tuning and current sensing
+  EVSYS->Channel[DRIVE_TCC_TUNE_EVSYS_CHANNEL].CHANNEL.reg =
+      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TCC3_MC_0) |
+      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
 
-    EVSYS->Channel[ADC_TRIGGER_EVSYS_CHANNEL].CHANNEL.reg =
-        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TC2_OVF) |
-        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
-    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
+  EVSYS->Channel[ADC_TRIGGER_EVSYS_CHANNEL].CHANNEL.reg =
+      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TC2_OVF) |
+      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
 }
 
-static void
-setup_drive_tcc() {
-    enable_pclock_max(DRIVE_TCC_PCLK_ID, DRIVE_TCC_PM_ID);
+static void setup_drive_tcc() {
+  enable_pclock_max(DRIVE_TCC_PCLK_ID, DRIVE_TCC_PM_ID);
 
-    // Set up the drive timer.
-    DRIVE_TCC->CTRLA.bit.SWRST = 1;
-    while (DRIVE_TCC->SYNCBUSY.bit.SWRST)
-        ;
+  // Set up the drive timer.
+  DRIVE_TCC->CTRLA.bit.SWRST = 1;
+  while (DRIVE_TCC->SYNCBUSY.bit.SWRST)
+    ;
 
-    DRIVE_TCC->CTRLA.reg = TCC_CTRLA_PRESCALER_DIV1;
-    DRIVE_TCC->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM;
-    // On a non-recoverable fault, force WO1 (PB17) low so the MOSFET turns off.
-    DRIVE_TCC->DRVCTRL.reg = TCC_DRVCTRL_NRE(1 << DRIVE_TCC_CC);
-    // Overvoltage triggeres a non-recoverable fault on the drive timer via
-    // EVSYS on event 0. During tuning, CC0 match outputs an event to trigger
-    // ADC sampling.
-    DRIVE_TCC->EVCTRL.reg =
-        TCC_EVCTRL_TCEI0 | TCC_EVCTRL_EVACT0_FAULT | TCC_EVCTRL_MCEO0;
+  DRIVE_TCC->CTRLA.reg = TCC_CTRLA_PRESCALER_DIV1;
+  DRIVE_TCC->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM;
+  // On a non-recoverable fault, force WO1 (PB17) low so the MOSFET turns off.
+  DRIVE_TCC->DRVCTRL.reg = TCC_DRVCTRL_NRE(1 << DRIVE_TCC_CC);
+  // Overvoltage triggeres a non-recoverable fault on the drive timer via
+  // EVSYS on event 0. During tuning, CC0 match outputs an event to trigger
+  // ADC sampling.
+  DRIVE_TCC->EVCTRL.reg =
+      TCC_EVCTRL_TCEI0 | TCC_EVCTRL_EVACT0_FAULT | TCC_EVCTRL_MCEO0;
 
-    DRIVE_TCC->CTRLA.bit.ENABLE = 1;
-    while (DRIVE_TCC->SYNCBUSY.bit.ENABLE)
-        ;
-    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-    while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-        ;
+  DRIVE_TCC->CTRLA.bit.ENABLE = 1;
+  while (DRIVE_TCC->SYNCBUSY.bit.ENABLE)
+    ;
+  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+    ;
 
-    DRIVE_TCC->INTENSET.reg = TCC_INTENSET_OVF;
-    NVIC_SetPriority(DRIVE_TCC_IRQn, 1);
-    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+  DRIVE_TCC->INTENSET.reg = TCC_INTENSET_OVF;
+  NVIC_SetPriority(DRIVE_TCC_IRQn, 1);
+  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 
-    gpio_peripheral(DRIVE_PIN, DRIVE_PIN_FUNC, false);
+  gpio_peripheral(DRIVE_PIN, DRIVE_PIN_FUNC, false);
 }
 
-static void
-setup_ac() {
-    gpio_peripheral(FEEDBACK_AC_PIN, FEEDBACK_AC_PIN_FUNC, 0);
+static void setup_ac() {
+  gpio_peripheral(FEEDBACK_AC_PIN, FEEDBACK_AC_PIN_FUNC, 0);
 
-    enable_pclock(AC_GCLK_ID, ID_AC);
+  enable_pclock(AC_GCLK_ID, ID_AC);
 
-    AC->CTRLA.bit.SWRST = 1;
-    while (AC->SYNCBUSY.bit.SWRST)
-        ;
+  AC->CTRLA.bit.SWRST = 1;
+  while (AC->SYNCBUSY.bit.SWRST)
+    ;
 
-    // COMP0: overvoltage detector, interrupt triggers on rising edge which
-    // indicates over voltage.
-    AC->SCALER[0].reg = AC_SCALER_VALUE(OV_SCALER_VALUE);
-    AC->COMPCTRL[0].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
-                          AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
-                          AC_COMPCTRL_HYSTEN | AC_COMPCTRL_HYST_HYST50 |
-                          AC_COMPCTRL_ENABLE;
-    while (AC->SYNCBUSY.bit.COMPCTRL0)
-        ;
+  // COMP0: overvoltage detector, interrupt triggers on rising edge which
+  // indicates over voltage.
+  AC->SCALER[0].reg = AC_SCALER_VALUE(OV_SCALER_VALUE);
+  AC->COMPCTRL[0].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
+                        AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
+                        AC_COMPCTRL_HYSTEN | AC_COMPCTRL_HYST_HYST50 |
+                        AC_COMPCTRL_ENABLE;
+  while (AC->SYNCBUSY.bit.COMPCTRL0)
+    ;
 
-    // COMP1: tuner peak detector. Latches rising edge, not used in normal
-    // driving. No hysteresis as that would bias the detect peak high.
-    AC->SCALER[1].reg = AC_SCALER_VALUE(TUNE_TARGET_SCALER_VALUE);
-    AC->COMPCTRL[1].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
-                          AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
-                          AC_COMPCTRL_ENABLE;
-    while (AC->SYNCBUSY.bit.COMPCTRL1)
-        ;
+  // COMP1: tuner peak detector. Latches rising edge, not used in normal
+  // driving. No hysteresis as that would bias the detect peak high.
+  AC->SCALER[1].reg = AC_SCALER_VALUE(TUNE_TARGET_SCALER_VALUE);
+  AC->COMPCTRL[1].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
+                        AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
+                        AC_COMPCTRL_ENABLE;
+  while (AC->SYNCBUSY.bit.COMPCTRL1)
+    ;
 
-    AC->EVCTRL.reg = AC_EVCTRL_COMPEO0; // COMP0 state sent to event output
-    AC->INTENSET.reg =
-        AC_INTENSET_COMP0; // COMP0 rising edge triggers AC_Handler
+  AC->EVCTRL.reg = AC_EVCTRL_COMPEO0;   // COMP0 state sent to event output
+  AC->INTENSET.reg = AC_INTENSET_COMP0; // COMP0 rising edge triggers AC_Handler
 
-    NVIC_SetPriority(AC_IRQn, 2);
-    NVIC_EnableIRQ(AC_IRQn);
+  NVIC_SetPriority(AC_IRQn, 2);
+  NVIC_EnableIRQ(AC_IRQn);
 
-    AC->CTRLA.reg = AC_CTRLA_ENABLE;
-    while (AC->SYNCBUSY.bit.ENABLE)
-        ;
+  AC->CTRLA.reg = AC_CTRLA_ENABLE;
+  while (AC->SYNCBUSY.bit.ENABLE)
+    ;
 
-    // COMP0 is routed to event on DRIVE_TCC/TCC3 so next cycle can be
-    // prevented.
-    EVSYS->Channel[OV_EVSYS_CHANNEL].CHANNEL.reg =
-        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_AC_COMP_0) |
-        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
-    EVSYS->USER[EVSYS_ID_USER_TCC3_EV_0].reg = OV_EVSYS_CHANNEL + 1;
+  // COMP0 is routed to event on DRIVE_TCC/TCC3 so next cycle can be
+  // prevented.
+  EVSYS->Channel[OV_EVSYS_CHANNEL].CHANNEL.reg =
+      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_AC_COMP_0) |
+      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+  EVSYS->USER[EVSYS_ID_USER_TCC3_EV_0].reg = OV_EVSYS_CHANNEL + 1;
 }
 
-void
-coil_driver::set_timings(float time_on, float time_off, float time_on_first) {
-    auto osc_clk_freq = (float)CONFIG_CLOCK_FREQ;
+void coil_driver::set_timings(float time_on, float time_off,
+                              float time_on_first) {
+  auto osc_clk_freq = (float)CONFIG_CLOCK_FREQ;
 
-    uint32_t on_ticks = (uint32_t)(osc_clk_freq * time_on);
-    uint32_t off_ticks = (uint32_t)(osc_clk_freq * time_off);
-    uint32_t on_ticks_first = (uint32_t)(osc_clk_freq * time_on_first);
-    state.set_drive_ticks(on_ticks, on_ticks_first, off_ticks);
+  uint32_t on_ticks = (uint32_t)(osc_clk_freq * time_on);
+  uint32_t off_ticks = (uint32_t)(osc_clk_freq * time_off);
+  uint32_t on_ticks_first = (uint32_t)(osc_clk_freq * time_on_first);
+  state.set_drive_ticks(on_ticks, on_ticks_first, off_ticks);
 }
 
-coil_driver
-coil_driver_create() {
-    auto driver = coil_driver();
+coil_driver coil_driver_create() {
+  auto driver = coil_driver();
 
-    setup_evsys();
-    setup_drive_tcc();
-    setup_ac();
-    setup_adc1();
-    setup_adc_trigger_tc();
+  setup_evsys();
+  setup_drive_tcc();
+  setup_ac();
+  setup_adc1();
+  setup_adc_trigger_tc();
 
-    return driver;
+  return driver;
 }
 
-static constexpr uint32_t
-volts_to_count(float v) {
-    int32_t c = (int32_t)(v / DRAIN_V_PER_COUNT + 0.5f);
-    if (c < 0)
-        c = 0;
-    if (c > 4095)
-        c = 4095;
-    return (uint32_t)c;
+static constexpr uint32_t volts_to_count(float v) {
+  int32_t c = (int32_t)(v / DRAIN_V_PER_COUNT + 0.5f);
+  if (c < 0)
+    c = 0;
+  if (c > 4095)
+    c = 4095;
+  return (uint32_t)c;
 }
 
-static uint32_t
-ticks_to_ns(uint32_t ticks) {
-    return (uint32_t)((float)ticks * (1.0e9f / (float)CONFIG_CLOCK_FREQ) +
-                      0.5f);
+static uint32_t ticks_to_ns(uint32_t ticks) {
+  return (uint32_t)((float)ticks * (1.0e9f / (float)CONFIG_CLOCK_FREQ) + 0.5f);
 }
 
 // Read and clear the latched COMP1 peak flag.
-static bool
-tune_peak_tripped() {
-    if (!AC->INTFLAG.bit.COMP1)
-        return false;
-    AC->INTFLAG.reg = AC_INTFLAG_COMP1;
-    return true;
+static bool tune_peak_tripped() {
+  if (!AC->INTFLAG.bit.COMP1)
+    return false;
+  AC->INTFLAG.reg = AC_INTFLAG_COMP1;
+  return true;
 }
 
 // Set new drive timings in ticks. If the specified timings are not valid,
 // `timings_valid` is set to false and the currently set ticks are not touched.
-void
-driver_state::set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
-                              uint32_t off_ticks) {
-    if (on_ticks == 0 || off_ticks == 0 || on_ticks_first == 0 ||
-        on_ticks_first > on_ticks) {
-        this->timings_valid = false;
-        return;
-    }
+void driver_state::set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
+                                   uint32_t off_ticks) {
+  if (on_ticks == 0 || off_ticks == 0 || on_ticks_first == 0 ||
+      on_ticks_first > on_ticks) {
+    this->timings_valid = false;
+    return;
+  }
 
-    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
-    this->on_ticks = on_ticks;
-    this->period_minus_1 = on_ticks + off_ticks - 1;
-    this->on_ticks_first = on_ticks_first;
-    this->first_period_minus_1 = on_ticks_first + off_ticks - 1;
-    this->timings_valid = true;
-    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+  this->on_ticks = on_ticks;
+  this->period_minus_1 = on_ticks + off_ticks - 1;
+  this->on_ticks_first = on_ticks_first;
+  this->first_period_minus_1 = on_ticks_first + off_ticks - 1;
+  this->timings_valid = true;
+  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 }
 
 // Fire a single test burst from idle timer. Can fire either 1 or 2 cycles.
-void
-tuner_state::fire_burst(uint32_t n_cycles, uint32_t measure) {
-    cycles_done = 0;
-    stop_after = n_cycles + TUNE_TRAILING_OFF;
-    measure_cycle = measure;
-    burst_done = false;
-    test_active = true;
-    state.pending_on_cycles = n_cycles;
-    burst_in_flight = true;
-    state.arm_timer();
+void test_burst::fire(uint32_t n_cycles, uint32_t measure) {
+  cycles_done = 0;
+  stop_after = n_cycles + TUNE_TRAILING_OFF;
+  measure_cycle = measure;
+  burst_done = false;
+  test_active = true;
+  state.pending_on_cycles = n_cycles;
+  burst_in_flight = true;
+  state.arm_timer();
 }
 
-bool
-tuner_state::on_drive_overflow() {
-    if (!test_active)
-        return false;
+bool test_burst::on_drive_overflow() {
+  if (!test_active)
+    return false;
 
-    // The cycle now beginning. Parameters were already loaded when the burst
-    // started.
-    uint32_t started = cycles_done + 1;
-    cycles_done = started;
+  uint32_t started = cycles_done + 1;
+  cycles_done = started;
 
-    // If we reached cycle to be measured, reset tuning peak flag so it can be
-    // latched if the peak is reached.
-    if (started == measure_cycle) {
-        AC->INTFLAG.reg = AC_INTFLAG_COMP1;
-    }
+  if (started == measure_cycle) {
+    AC->INTFLAG.reg = AC_INTFLAG_COMP1;
+  }
 
-    // Next cycle may final cycle, so put in the extra off time time.
-    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(0);
-    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(state.period_minus_1);
+  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(0);
+  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(state.period_minus_1);
 
-    if (started >= stop_after) {
-        DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-        test_active = false;
-        burst_done = true;
-    }
-    return true;
-}
-
-bool
-tuner_state::capture_adc_sample(uint16_t result) {
-    if (!adc_active)
-        return false;
-    if (adc_capture_armed) {
-        adc_sample = result;
-        adc_capture_armed = false;
-    }
-    return true;
-}
-
-static void
-tune_set_cc0(uint32_t value) {
-    DRIVE_TCC->CC[DRIVE_TCC_TUNE_CC].reg = TCC_CC_CC(value);
-    while (DRIVE_TCC->SYNCBUSY.reg & DRIVE_TCC_TUNE_SYNCBUSY_CC)
-        ;
-}
-
-// Remap ADC1 to read feedback voltage instead of current sensing
-void
-tuner_state::adc_arm() {
-    FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(DRAIN_SENSE_ADC_MUXPOS) |
-                                  ADC_INPUTCTRL_MUXNEG(0x18);
-    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-        ;
-    adc_active = true;
-    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg =
-        DRIVE_TCC_TUNE_EVSYS_CHANNEL + 1;
-}
-
-// Restore ADC1 to read current sensor
-void
-tuner_state::adc_restore() {
-    FEEDBACK_ADC->INPUTCTRL.reg =
-        ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
-        ADC_INPUTCTRL_MUXNEG(0x18);
-    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-        ;
-    adc_active = false;
-    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
-}
-
-// Reconstructed resonance waveform.
-// A tuning round will (over)write every sample before it's read.
-static uint16_t tune_waveform_samples[TUNE_N_SAMPLES];
-
-// Check status of current burst
-burst_status
-tuner_state::burst_poll() {
-    if (burst_in_flight) {
-        if (!burst_done)
-            return burst_status::busy;
-        burst_in_flight = false;
-        next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
-        return burst_status::completed;
-    }
-    if (timer_is_before(timer_read_time(), next_fire_time))
-        return burst_status::busy;
-    return burst_status::ready;
-}
-
-void
-tuner_state::start(bool want_details) {
-    // start_tune() has already verified the coil is idle.
-    *this = tuner_state{};
-    this->want_details = want_details;
-    phase = tune_phase::on_first;
-    status = tune_status::running;
-    on_first_ticks = TUNE_ON_FIRST_SEED;
-    next_fire_time = timer_read_time();
-    ov_count_at_start = state.overvoltage_count();
-    deadline = timer_read_time() + timer_from_us(TUNE_TOTAL_TIMEOUT_US);
-    // The test bursts overwrite the published drive timings, so any previously
-    // valid set is now gone; only a successful tune (or a fresh set_timings)
-    // makes them valid again.
-    state.timings_valid = false;
-}
-
-void
-tuner_state::abort(tune_error e) {
-    if (adc_active)
-        adc_restore();
+  if (started >= stop_after) {
     DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
     test_active = false;
+    burst_done = true;
+  }
+  return true;
+}
+
+bool test_burst::capture_adc_sample(uint16_t result) {
+  if (!adc_active)
+    return false;
+  if (adc_capture_armed) {
+    adc_sample = result;
+    adc_capture_armed = false;
+  }
+  return true;
+}
+
+static void tune_set_cc0(uint32_t value) {
+  DRIVE_TCC->CC[DRIVE_TCC_TUNE_CC].reg = TCC_CC_CC(value);
+  while (DRIVE_TCC->SYNCBUSY.reg & DRIVE_TCC_TUNE_SYNCBUSY_CC)
+    ;
+}
+
+void test_burst::adc_arm() {
+  FEEDBACK_ADC->INPUTCTRL.reg =
+      ADC_INPUTCTRL_MUXPOS(DRAIN_SENSE_ADC_MUXPOS) | ADC_INPUTCTRL_MUXNEG(0x18);
+  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+    ;
+  adc_active = true;
+  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = DRIVE_TCC_TUNE_EVSYS_CHANNEL + 1;
+}
+
+void test_burst::adc_restore() {
+  FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
+                                ADC_INPUTCTRL_MUXNEG(0x18);
+  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+    ;
+  adc_active = false;
+  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
+}
+
+void test_burst::stop_hw() {
+  if (adc_active)
+    adc_restore();
+  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+  test_active = false;
+  burst_in_flight = false;
+}
+
+static uint16_t tune_waveform_samples[TUNE_N_SAMPLES];
+
+burst_status test_burst::poll() {
+  if (burst_in_flight) {
+    if (!burst_done)
+      return burst_status::busy;
     burst_in_flight = false;
-    // A failed tune has no valid result; clear the timings so a poll can't read
-    // a stale/partial value (`error` carries the reason instead).
-    on_first_ticks = 0;
-    off_ticks = 0;
-    error = e;
-    phase = tune_phase::error;
+    next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+    return burst_status::completed;
+  }
+  if (timer_is_before(timer_read_time(), next_fire_time))
+    return burst_status::busy;
+  return burst_status::ready;
 }
 
-void
-tuner_state::finish(tune_status s) {
-    status = s;
-    // A successful tune leaves the found timings in the drive state,
-    // so heating may use them
-    if (s == tune_status::success) {
-        state.timings_valid = true;
-    }
-    sendf("indx_coil_tune_finished status=%c error=%c", (uint32_t)s,
-          (uint32_t)error);
-    phase = tune_phase::idle;
+void tuner_state::start(bool want_details) {
+  // start_tune() has already verified the coil is idle.
+  *this = tuner_state{};
+  this->want_details = want_details;
+  phase = tune_phase::on_first;
+  status = tune_status::running;
+  on_first_ticks = TUNE_ON_FIRST_SEED;
+  burst.next_fire_time = timer_read_time();
+  ov_count_at_start = state.overvoltage_count();
+  deadline = timer_read_time() + timer_from_us(TUNE_TOTAL_TIMEOUT_US);
+  // The test bursts overwrite the published drive timings, so any previously
+  // valid set is now gone; only a successful tune (or a fresh set_timings)
+  // makes them valid again.
+  state.timings_valid = false;
 }
 
-static constexpr uint32_t
-counts_to_mv(uint32_t counts) {
-    return (uint32_t)((float)counts * DRAIN_V_PER_COUNT * 1000.0f + 0.5f);
+void tuner_state::abort(tune_error e) {
+  burst.stop_hw();
+  // A failed tune has no valid result; clear the timings so a poll can't read
+  // a stale/partial value (`error` carries the reason instead).
+  on_first_ticks = 0;
+  off_ticks = 0;
+  error = e;
+  phase = tune_phase::error;
+}
+
+void tuner_state::finish(tune_status s) {
+  status = s;
+  // A successful tune leaves the found timings in the drive state,
+  // so heating may use them
+  if (s == tune_status::success) {
+    state.timings_valid = true;
+  }
+  sendf("indx_coil_tune_finished status=%c error=%c", (uint32_t)s,
+        (uint32_t)error);
+  phase = tune_phase::idle;
+}
+
+static constexpr uint32_t counts_to_mv(uint32_t counts) {
+  return (uint32_t)((float)counts * DRAIN_V_PER_COUNT * 1000.0f + 0.5f);
 }
 
 // Phase 1: from a de-energized tank, fire single-cycle bursts at increasing
 // time_on_first until the resonance peak first crosses the target.
-void
-tuner_state::step_on_first() {
-    switch (burst_poll()) {
-    case burst_status::busy:
-        return;
-    case burst_status::completed:
-        if (tune_peak_tripped()) {
-            // reached the target peak
-            phase = tune_phase::on_first_done;
-            return;
-        }
-        on_first_ticks += TUNE_ON_STEP;
-        if (on_first_ticks > TUNE_ON_MAX) {
-            abort(tune_error::initial_on_ceiling);
-        }
-        return;
-    case burst_status::ready:
-        // Single-cycle burst: cycle is the only fired cycle, so any peak is
-        // unambiguously its own. Steady ON time is irrelevant here.
-        state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
-        tune_peak_tripped(); // clear target peak latch
-        fire_burst(1, 0);
-        return;
+void tuner_state::step_on_first() {
+  switch (burst.poll()) {
+  case burst_status::busy:
+    return;
+  case burst_status::completed:
+    if (tune_peak_tripped()) {
+      // reached the target peak
+      phase = tune_phase::on_first_done;
+      return;
     }
+    on_first_ticks += TUNE_ON_STEP;
+    if (on_first_ticks > TUNE_ON_MAX) {
+      abort(tune_error::initial_on_ceiling);
+    }
+    return;
+  case burst_status::ready:
+    // Single-cycle burst: cycle is the only fired cycle, so any peak is
+    // unambiguously its own. Steady ON time is irrelevant here.
+    state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
+    tune_peak_tripped(); // clear target peak latch
+    burst.fire(1, 0);
+    return;
+  }
 }
 
 // Phase 2: with fixed initial cycle ON time, run consecutive bursts and do
@@ -955,207 +954,470 @@ tuner_state::step_on_first() {
 // actual OFF event as well. This way, when we go to find the actual OFF time we
 // can measure between the zero points instead of relying on the start of the
 // waveform being at exactly the OFF phase start.
-void
-tuner_state::step_off_measure() {
-    switch (burst_poll()) {
-    case burst_status::busy:
-        return;
-    case burst_status::completed:
-        tune_waveform_samples[waveform_sample_idx] = adc_sample;
-        if (++waveform_sample_idx >= waveform_sample_count) {
-            adc_restore();
-            phase = tune_phase::off_analyze;
-        }
-        return;
-    case burst_status::ready:
-        // Excite with the found time_on_first and step the CC0 match further
-        // into cycle 0's OFF/resonance each burst.
-        state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
-        tune_set_cc0(waveform_sample_idx * TUNE_SAMPLE_STEP);
-        adc_capture_armed = true;
-        fire_burst(1, 0);
-        return;
+void tuner_state::step_off_measure() {
+  switch (burst.poll()) {
+  case burst_status::busy:
+    return;
+  case burst_status::completed:
+    tune_waveform_samples[waveform_sample_idx] = burst.adc_sample;
+    if (++waveform_sample_idx >= waveform_sample_count) {
+      burst.adc_restore();
+      phase = tune_phase::off_analyze;
     }
+    return;
+  case burst_status::ready:
+    // Excite with the found time_on_first and step the CC0 match further
+    // into cycle 0's OFF/resonance each burst.
+    state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
+    tune_set_cc0(waveform_sample_idx * TUNE_SAMPLE_STEP);
+    burst.adc_capture_armed = true;
+    burst.fire(1, 0);
+    return;
+  }
 }
 
 // Analyze captured waveform to find ideal off time.
 // The sampled waveform right now contains (most of) the ON phase, and the
 // entire OFF phase. We need to determine the total duration of the OFF phase.
-void
-tuner_state::analyze_off() {
-    auto zero_threshold = volts_to_count(TUNE_ZERO_MARGIN_V);
+void tuner_state::analyze_off() {
+  auto zero_threshold = volts_to_count(TUNE_ZERO_MARGIN_V);
 
-    // Find the start and end of the OFF phase. Note that the signal rise/fall
-    // is so fast that we don't really need to deal with hysteresis when finding
-    // the edges.
-    int16_t phase_off_start = -1;
-    int16_t phase_off_end = -1;
-    for (uint32_t i = 0; i < waveform_sample_count; i++) {
-        auto sample = tune_waveform_samples[i];
-        if (phase_off_start < 0 && sample >= zero_threshold) {
-            // ON->OFF transition
-            phase_off_start = i;
-        } else if (phase_off_start >= 0 && phase_off_end < 0 &&
-                   sample <= zero_threshold) {
-            // OFF->ON transition
-            phase_off_end = i;
-            break;
-        }
+  // Find the start and end of the OFF phase. Note that the signal rise/fall
+  // is so fast that we don't really need to deal with hysteresis when finding
+  // the edges.
+  int16_t phase_off_start = -1;
+  int16_t phase_off_end = -1;
+  for (uint32_t i = 0; i < waveform_sample_count; i++) {
+    auto sample = tune_waveform_samples[i];
+    if (phase_off_start < 0 && sample >= zero_threshold) {
+      // ON->OFF transition
+      phase_off_start = i;
+    } else if (phase_off_start >= 0 && phase_off_end < 0 &&
+               sample <= zero_threshold) {
+      // OFF->ON transition
+      phase_off_end = i;
+      break;
     }
+  }
 
-    // If we didn't find both start and end, we can't find the OFF time.
-    if (phase_off_start == -1 || phase_off_end == -1) {
-        abort(tune_error::off_no_zero);
-        return;
-    }
+  // If we didn't find both start and end, we can't find the OFF time.
+  if (phase_off_start == -1 || phase_off_end == -1) {
+    abort(tune_error::off_no_zero);
+    return;
+  }
 
-    off_ticks = (phase_off_end - phase_off_start + 1) * TUNE_SAMPLE_STEP;
+  off_ticks = (phase_off_end - phase_off_start + 1) * TUNE_SAMPLE_STEP;
 
-    // If details were requested, enter dump phase.
-    next_fire_time =
-        timer_read_time() + (want_details ? 0 : timer_from_us(TUNE_SETTLE_US));
-    phase = want_details ? tune_phase::off_dump : tune_phase::off_done;
-    output("C %u", want_details);
-    waveform_sample_idx = 0;
+  // If details were requested, enter dump phase.
+  burst.next_fire_time =
+      timer_read_time() + (want_details ? 0 : timer_from_us(TUNE_SETTLE_US));
+  phase = want_details ? tune_phase::off_dump : tune_phase::off_done;
+  output("C %u", want_details);
+  waveform_sample_idx = 0;
 }
 
 // Phase 3: find the steady-state ON time, that is the ON time for any phase
 // after the first one. Ramp the steady state ON time from the time found for
 // the initial ON time until the target is crossed. The starting point was set
 // by the `off_done` phase handler.
-void
-tuner_state::step_steady_on() {
-    switch (burst_poll()) {
+void tuner_state::step_steady_on() {
+  switch (burst.poll()) {
+  case burst_status::busy:
+    return;
+  case burst_status::completed:
+    if (tune_peak_tripped()) {
+      // target peak reached
+      phase = tune_phase::steady_done;
+      return;
+    }
+    on_ticks += TUNE_ON_STEP;
+    if (on_ticks > TUNE_ON_MAX) {
+      abort(tune_error::steady_ceiling);
+    }
+    return;
+  case burst_status::ready:
+    state.set_drive_ticks(on_ticks, on_first_ticks, off_ticks);
+    tune_peak_tripped(); // clear target peak latch
+    burst.fire(2, 1);
+    return;
+  }
+}
+
+void tuner_state::step() {
+  // Guards shared for all tuning phases.
+  if (phase != tune_phase::idle && phase != tune_phase::error) {
+    if (state.overvoltage_count() != ov_count_at_start) {
+      abort(tune_error::overvoltage);
+    } else if (!timer_is_before(timer_read_time(), deadline)) {
+      abort(tune_error::timeout);
+    }
+  }
+
+  switch (phase) {
+  case tune_phase::on_first:
+    step_on_first();
+    break;
+
+  case tune_phase::on_first_done:
+    burst.adc_arm(); // Remap ADC to feedback input for off sweep phase
+    waveform_sample_idx = 0;
+    waveform_sample_count = (on_first_ticks + TUNE_OFF_PROV) / TUNE_SAMPLE_STEP;
+    phase = tune_phase::off_measure;
+    break;
+
+  case tune_phase::off_measure:
+    step_off_measure();
+    break;
+
+  case tune_phase::off_analyze:
+    analyze_off();
+    break;
+
+  case tune_phase::off_dump:
+    // Stream the reconstructed waveform one sample at a time, so
+    // it can be overlaid on the scope trace to validate the measurement.
+    // Since this is diagnostic only, dropped samples are acceptable.
+    if (timer_is_before(timer_read_time(), burst.next_fire_time))
+      break;
+    if (waveform_sample_idx < waveform_sample_count) {
+      sendf("indx_coil_tune_wave index=%u ns=%u mv=%u", waveform_sample_idx,
+            ticks_to_ns(waveform_sample_idx * TUNE_SAMPLE_STEP),
+            counts_to_mv(tune_waveform_samples[waveform_sample_idx]));
+      waveform_sample_idx++;
+      burst.next_fire_time =
+          timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+    } else {
+      burst.next_fire_time = timer_read_time();
+      phase = tune_phase::off_done;
+    }
+    break;
+
+  case tune_phase::off_done:
+    // Phase 3: steady state ON time is always >= the initial ON time, so
+    // start from there. Next fire time was set by the previous phase.
+    on_ticks = on_first_ticks;
+    phase = tune_phase::steady_on;
+    break;
+
+  case tune_phase::steady_on:
+    step_steady_on();
+    break;
+
+  case tune_phase::steady_done:
+    finish(tune_status::success);
+    break;
+
+  case tune_phase::error:
+    finish(tune_status::failed);
+    break;
+
+  case tune_phase::idle:
+    break;
+  }
+}
+
+void coil_driver::start_tune(bool want_details) {
+  if (tuner.active() || ringdown.active()) {
+    return;
+  }
+  if (state.pending_on_cycles != 0) {
+    shutdown("INDX coil tune requested while heater active");
+  }
+  tuner.start(want_details);
+}
+
+bool coil_driver::tune_active() { return tuner.active(); }
+
+void coil_driver::tune_step() { tuner.step(); }
+
+void coil_driver::report_tune_status() {
+  sendf("indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
+        (uint32_t)tuner.status, (uint32_t)tuner.error,
+        ticks_to_ns(tuner.on_first_ticks), ticks_to_ns(tuner.off_ticks),
+        ticks_to_ns(tuner.on_ticks));
+}
+
+void coil_driver::report_params() {
+  uint32_t on = state.on_ticks;
+  uint32_t off = state.period_minus_1 + 1 - on;
+  sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
+        ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
+}
+
+// ---------------------------------------------------------------------------
+// Ringdown nozzle-presence probe
+// ---------------------------------------------------------------------------
+
+void ringdown_state::apply_presence(ringdown_status s) {
+  if (s == ringdown_status::valid) {
+    last_presence = presence;
+  } else if (s != ringdown_status::running) {
+    if (presence == nozzle_presence::present)
+      presence = nozzle_presence::unknown;
+    last_presence = presence;
+  }
+}
+
+void ringdown_state::restore_drive() {
+  if (burst.adc_active)
+    burst.adc_restore();
+  state.set_drive_ticks(saved_on_ticks, saved_on_ticks_first, saved_off_ticks);
+  uint32_t cycles = saved_pending_on_cycles;
+  if (heat_gate_blocks_drive())
+    cycles = 0;
+  state.pending_on_cycles = cycles;
+  bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+  if (cycles > 0 && idle) {
+    state.arm_timer();
+  }
+}
+
+void ringdown_state::abort(ringdown_status s) {
+  burst.test_active = false;
+  burst.burst_in_flight = false;
+  presence = nozzle_presence::unknown;
+  apply_presence(s);
+  restore_drive();
+  if (phase == ringdown_phase::dump) {
+    finish(s);
+    return;
+  }
+  dump_count =
+      sample_idx < RINGDOWN_N_SAMPLES ? sample_idx : RINGDOWN_N_SAMPLES;
+  schedule_finish_or_dump(s);
+}
+
+void ringdown_state::schedule_finish_or_dump(ringdown_status s) {
+  pending_status = s;
+  if (want_dump) {
+    dump_idx = 0;
+    burst.next_fire_time = timer_read_time();
+    phase = ringdown_phase::dump;
+    return;
+  }
+  finish(s);
+}
+
+void ringdown_state::finish(ringdown_status s) {
+  status = s;
+  apply_presence(s);
+  if (want_report) {
+    sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
+          timer_read_time(), (uint32_t)status, (uint32_t)presence, peak_mv);
+  }
+  next_schedule_time = timer_read_time();
+  phase = ringdown_phase::idle;
+}
+
+uint32_t ringdown_state::excite_on_ticks() {
+  float scale = ringdown_cfg.excite_scale;
+  if (scale < RINGDOWN_EXCITE_SCALE_MIN)
+    scale = RINGDOWN_EXCITE_SCALE_MIN;
+  if (scale > RINGDOWN_EXCITE_SCALE_MAX)
+    scale = RINGDOWN_EXCITE_SCALE_MAX;
+  uint32_t ticks = (uint32_t)(saved_on_ticks_first * scale + 0.5f);
+  if (ticks < 1)
+    ticks = 1;
+  if (saved_on_ticks_first && ticks > saved_on_ticks_first)
+    ticks = saved_on_ticks_first;
+  return ticks;
+}
+
+void ringdown_state::start(bool report, bool dump) {
+  phase = ringdown_phase::pause_wait;
+  status = ringdown_status::running;
+  presence = nozzle_presence::unknown;
+  want_report = report;
+  want_dump = dump;
+  burst.burst_in_flight = false;
+  burst.test_active = false;
+  burst.burst_done = false;
+  burst.adc_capture_armed = false;
+  burst.adc_sample = 0;
+  burst.next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+  ov_count_at_start = state.overvoltage_count();
+  uint32_t timeout_us = RINGDOWN_TIMEOUT_US;
+  if (dump)
+    timeout_us += RINGDOWN_N_SAMPLES * TUNE_DUMP_INTERVAL_US + 50000;
+  deadline = timer_read_time() + timer_from_us(timeout_us);
+  sample_idx = 0;
+  dump_idx = 0;
+  dump_count = 0;
+  peak_mv = 0;
+  pending_status = ringdown_status::idle;
+  saved_pending_on_cycles = state.pending_on_cycles;
+  saved_on_ticks = state.on_ticks;
+  saved_on_ticks_first = state.on_ticks_first;
+  saved_off_ticks = state.period_minus_1 + 1 - state.on_ticks;
+  state.pending_on_cycles = 0;
+}
+
+void ringdown_state::analyze() {
+  dump_count = RINGDOWN_N_SAMPLES;
+  uint16_t max_counts = 0;
+  for (uint32_t i = 0; i < RINGDOWN_N_SAMPLES; i++) {
+    if (ringdown_samples[i] > max_counts)
+      max_counts = ringdown_samples[i];
+  }
+  peak_mv = counts_to_mv(max_counts);
+  float peak_v = (float)peak_mv / 1000.0f;
+
+  if (peak_v < ringdown_cfg.min_peak_v) {
+    presence = nozzle_presence::unknown;
+    apply_presence(ringdown_status::weak_signal);
+    restore_drive();
+    schedule_finish_or_dump(ringdown_status::weak_signal);
+    return;
+  }
+
+  // Seated loads the coil: lower peak. Empty: higher peak.
+  if (peak_v <= ringdown_cfg.present_peak_v) {
+    presence = nozzle_presence::present;
+  } else if (peak_v >= ringdown_cfg.absent_peak_v) {
+    presence = nozzle_presence::absent;
+  } else {
+    presence = nozzle_presence::unknown;
+  }
+
+  apply_presence(ringdown_status::valid);
+  restore_drive();
+  schedule_finish_or_dump(ringdown_status::valid);
+}
+
+void ringdown_state::step() {
+  if (phase == ringdown_phase::idle)
+    return;
+
+  if (state.overvoltage_count() != ov_count_at_start) {
+    abort(ringdown_status::overvoltage);
+    return;
+  }
+  if (!timer_is_before(timer_read_time(), deadline)) {
+    abort(ringdown_status::timeout);
+    return;
+  }
+
+  uint32_t on_ticks = excite_on_ticks();
+  switch (phase) {
+  case ringdown_phase::pause_wait: {
+    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+    if (!idle || timer_is_before(timer_read_time(), burst.next_fire_time))
+      return;
+    state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+    burst.adc_arm();
+    sample_idx = 0;
+    phase = ringdown_phase::sample;
+    return;
+  }
+  case ringdown_phase::sample: {
+    switch (burst.poll()) {
     case burst_status::busy:
-        return;
+      return;
     case burst_status::completed:
-        if (tune_peak_tripped()) {
-            // target peak reached
-            phase = tune_phase::steady_done;
-            return;
-        }
-        on_ticks += TUNE_ON_STEP;
-        if (on_ticks > TUNE_ON_MAX) {
-            abort(tune_error::steady_ceiling);
-        }
-        return;
+      ringdown_samples[sample_idx] = burst.adc_sample;
+      if (++sample_idx >= RINGDOWN_N_SAMPLES) {
+        burst.adc_restore();
+        phase = ringdown_phase::analyze;
+      }
+      return;
     case burst_status::ready:
-        state.set_drive_ticks(on_ticks, on_first_ticks, off_ticks);
-        tune_peak_tripped(); // clear target peak latch
-        fire_burst(2, 1);
-        return;
+      state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+      tune_set_cc0(sample_idx * RINGDOWN_SAMPLE_STEP);
+      burst.adc_capture_armed = true;
+      burst.fire(1, 0);
+      return;
     }
-}
-
-void
-tuner_state::step() {
-    // Guards shared for all tuning phases.
-    if (phase != tune_phase::idle && phase != tune_phase::error) {
-        if (state.overvoltage_count() != ov_count_at_start) {
-            abort(tune_error::overvoltage);
-        } else if (!timer_is_before(timer_read_time(), deadline)) {
-            abort(tune_error::timeout);
-        }
+    return;
+  }
+  case ringdown_phase::analyze:
+    analyze();
+    return;
+  case ringdown_phase::dump: {
+    if (timer_is_before(timer_read_time(), burst.next_fire_time))
+      return;
+    if (dump_idx < dump_count) {
+      sendf("indx_ringdown_wave index=%u ns=%u counts=%u mv=%u", dump_idx,
+            ticks_to_ns(dump_idx * RINGDOWN_SAMPLE_STEP),
+            (uint32_t)ringdown_samples[dump_idx],
+            counts_to_mv(ringdown_samples[dump_idx]));
+      dump_idx++;
+      burst.next_fire_time =
+          timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+      return;
     }
+    sendf("indx_ringdown_meta status=%c peak_mv=%u", (uint32_t)pending_status,
+          peak_mv);
+    finish(pending_status);
+    return;
+  }
+  case ringdown_phase::idle:
+    break;
+  }
+}
 
-    switch (phase) {
-    case tune_phase::on_first:
-        step_on_first();
-        break;
+void coil_driver::set_ringdown_params(bool enable, bool heat_gate,
+                                      float present_peak_v, float absent_peak_v,
+                                      uint32_t idle_ms, uint32_t heat_ms,
+                                      float excite_scale, float min_peak_v) {
+  if (excite_scale < RINGDOWN_EXCITE_SCALE_MIN)
+    excite_scale = RINGDOWN_EXCITE_SCALE_MIN;
+  if (excite_scale > RINGDOWN_EXCITE_SCALE_MAX)
+    excite_scale = RINGDOWN_EXCITE_SCALE_MAX;
+  ringdown_cfg.enable = enable;
+  ringdown_cfg.heat_gate = heat_gate;
+  ringdown_cfg.idle_ms = idle_ms ? idle_ms : RINGDOWN_IDLE_MS_DEFAULT;
+  ringdown_cfg.heat_ms = heat_ms ? heat_ms : RINGDOWN_HEAT_MS_DEFAULT;
+  ringdown_cfg.excite_scale = excite_scale;
+  if (min_peak_v < 0.0f)
+    min_peak_v = RINGDOWN_MIN_PEAK_V_DEFAULT;
+  ringdown_cfg.min_peak_v =
+      min_peak_v > 0.0f ? min_peak_v : RINGDOWN_MIN_PEAK_V_DEFAULT;
+  if (present_peak_v < absent_peak_v) {
+    ringdown_cfg.present_peak_v = present_peak_v;
+    ringdown_cfg.absent_peak_v = absent_peak_v;
+  }
+}
 
-    case tune_phase::on_first_done:
-        adc_arm(); // Remap ADC to feedback input for off sweep phase
-        waveform_sample_idx = 0;
-        waveform_sample_count =
-            (on_first_ticks + TUNE_OFF_PROV) / TUNE_SAMPLE_STEP;
-        phase = tune_phase::off_measure;
-        break;
-
-    case tune_phase::off_measure:
-        step_off_measure();
-        break;
-
-    case tune_phase::off_analyze:
-        analyze_off();
-        break;
-
-    case tune_phase::off_dump:
-        // Stream the reconstructed waveform one sample at a time, so
-        // it can be overlaid on the scope trace to validate the measurement.
-        // Since this is diagnostic only, dropped samples are acceptable.
-        if (timer_is_before(timer_read_time(), next_fire_time))
-            break;
-        if (waveform_sample_idx < waveform_sample_count) {
-            sendf("indx_coil_tune_wave index=%u ns=%u mv=%u",
-                  waveform_sample_idx,
-                  ticks_to_ns(waveform_sample_idx * TUNE_SAMPLE_STEP),
-                  counts_to_mv(tune_waveform_samples[waveform_sample_idx]));
-            waveform_sample_idx++;
-            next_fire_time =
-                timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
-        } else {
-            next_fire_time = timer_read_time();
-            phase = tune_phase::off_done;
-        }
-        break;
-
-    case tune_phase::off_done:
-        // Phase 3: steady state ON time is always >= the initial ON time, so
-        // start from there. Next fire time was set by the previous phase.
-        on_ticks = on_first_ticks;
-        phase = tune_phase::steady_on;
-        break;
-
-    case tune_phase::steady_on:
-        step_steady_on();
-        break;
-
-    case tune_phase::steady_done:
-        finish(tune_status::success);
-        break;
-
-    case tune_phase::error:
-        finish(tune_status::failed);
-        break;
-
-    case tune_phase::idle:
-        break;
+void coil_driver::start_ringdown(bool report, bool dump) {
+  if (ringdown.active() || tuner.active())
+    return;
+  if (!state.timings_valid) {
+    last_presence = nozzle_presence::unknown;
+    ringdown.status = ringdown_status::aborted;
+    ringdown.presence = nozzle_presence::unknown;
+    ringdown.peak_mv = 0;
+    if (report) {
+      sendf("indx_nozzle_presence clock=%u status=%c presence=%c "
+            "peak_mv=%u",
+            timer_read_time(), (uint32_t)ringdown_status::aborted,
+            (uint32_t)nozzle_presence::unknown, 0u);
     }
+    return;
+  }
+  ringdown.start(report, dump);
 }
 
-void
-coil_driver::start_tune(bool want_details) {
-    if (tuner.active()) {
-        return;
-    }
-    if (state.pending_on_cycles != 0) {
-        shutdown("INDX coil tune requested while heater active");
-    }
-    tuner.start(want_details);
+bool coil_driver::ringdown_active() { return ringdown.active(); }
+
+void coil_driver::ringdown_step(bool heating) {
+  if (ringdown.active()) {
+    ringdown.step();
+    return;
+  }
+  if (!ringdown_cfg.enable || tuner.active() || !state.timings_valid)
+    return;
+  uint32_t period_ms = heating ? ringdown_cfg.heat_ms : ringdown_cfg.idle_ms;
+  uint32_t due = ringdown.next_schedule_time + timer_from_us(period_ms * 1000);
+  if (ringdown.next_schedule_time != 0 &&
+      timer_is_before(timer_read_time(), due))
+    return;
+  start_ringdown(true, false);
 }
 
-bool
-coil_driver::tune_active() {
-    return tuner.active();
-}
+nozzle_presence coil_driver::get_nozzle_presence() { return last_presence; }
 
-void
-coil_driver::tune_step() {
-    tuner.step();
-}
-
-void
-coil_driver::report_tune_status() {
-    sendf("indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
-          (uint32_t)tuner.status, (uint32_t)tuner.error,
-          ticks_to_ns(tuner.on_first_ticks), ticks_to_ns(tuner.off_ticks),
-          ticks_to_ns(tuner.on_ticks));
-}
-
-void
-coil_driver::report_params() {
-    uint32_t on = state.on_ticks;
-    uint32_t off = state.period_minus_1 + 1 - on;
-    sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
-          ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
+void coil_driver::report_ringdown_status() {
+  sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
+        timer_read_time(), (uint32_t)ringdown.status,
+        (uint32_t)ringdown.presence, ringdown.peak_mv);
 }

--- a/src/indx/coil_driver.c++
+++ b/src/indx/coil_driver.c++
@@ -28,7 +28,7 @@ static constexpr uint32_t FRAME_CYCLES = 512;
 
 // Overvoltage and tuning input is via resistive divider
 static constexpr float OV_DIVIDER_R1 = 45000.0f; // Drain to tap
-static constexpr float OV_DIVIDER_R2 = 1500.0f;  // Tap to gnd
+static constexpr float OV_DIVIDER_R2 = 1500.0f; // Tap to gnd
 // The feedback is on both pins PA06(for AC) and PB05(for ADC)
 DECL_CONSTANT_STR("RESERVE_PINS_INDX_FEEDBACK_SENSE", "PA06,PB05");
 
@@ -39,8 +39,8 @@ DECL_CONSTANT_STR("RESERVE_PINS_INDX_FEEDBACK_SENSE", "PA06,PB05");
 #define FEEDBACK_ADC_PIN_FUNC 'B'
 
 #define OV_EVSYS_CHANNEL 1
-static constexpr float OV_VDDANA = 3.3f;           // AC reference voltage
-static constexpr float OV_TRIP_VOLTAGE = 100.0f;   // overvoltage threshold
+static constexpr float OV_VDDANA = 3.3f; // AC reference voltage
+static constexpr float OV_TRIP_VOLTAGE = 100.0f; // overvoltage threshold
 static constexpr float TUNE_TARGET_PEAK_V = 96.0f; // target drive peak voltage
 //
 static constexpr uint32_t OV_SCALER_VALUE =
@@ -95,7 +95,7 @@ static constexpr float DRAIN_V_PER_COUNT =
 
 // ON-time search bounds (clock ticks).
 static constexpr uint32_t TUNE_ON_FIRST_SEED = 180; // safe starting floor
-static constexpr uint32_t TUNE_ON_STEP = 2;         // ramp granularity
+static constexpr uint32_t TUNE_ON_STEP = 2; // ramp granularity
 static constexpr uint32_t TUNE_ON_MAX = 1080;
 
 // Provisional OFF used while ramping ON: long enough to contain a full positive
@@ -129,150 +129,177 @@ static constexpr uint32_t TUNE_DUMP_INTERVAL_US = 3000;
 
 // Runtime state shared between task context and the TCC3/AC/ADC ISRs.
 struct driver_state {
-  // Compare value (ticks) for the steady ON portion.
-  volatile uint32_t on_ticks;
-  // Compare value for the first cycle ON portion in a burst.
-  volatile uint32_t on_ticks_first;
-  // Period-1 of a normal cycle, = on_ticks + off - 1.
-  volatile uint32_t period_minus_1;
-  // Period-1 of the first cycle in a burst, = on_ticks_first + off - 1
-  volatile uint32_t first_period_minus_1;
-  // ON cycles for the burst being scheduled (latched at the boundary).
-  volatile uint32_t on_cycles;
-  // ON cycles requested by set_duty(), latched into on_cycles each burst.
-  volatile uint32_t pending_on_cycles;
-  // Index (0..FRAME_CYCLES-1) of the next cycle the ISR will program.
-  volatile uint32_t cycle_idx;
-  // Whether the preceding cycle is ON. If not, we should use the first cycle
-  // length instead.
-  volatile bool prev_was_on;
-  // Cumulative overvoltage trips, increased by the AC comparator ISR.
-  volatile uint32_t ov_count;
-  // Whether the drive timings above are valid to fire (set explicitly via
-  // set_timings or by a successful tune).
-  bool timings_valid;
+    // Compare value (ticks) for the steady ON portion.
+    volatile uint32_t on_ticks;
+    // Compare value for the first cycle ON portion in a burst.
+    volatile uint32_t on_ticks_first;
+    // Period-1 of a normal cycle, = on_ticks + off - 1.
+    volatile uint32_t period_minus_1;
+    // Period-1 of the first cycle in a burst, = on_ticks_first + off - 1
+    volatile uint32_t first_period_minus_1;
+    // ON cycles for the burst being scheduled (latched at the boundary).
+    volatile uint32_t on_cycles;
+    // ON cycles requested by set_duty(), latched into on_cycles each burst.
+    volatile uint32_t pending_on_cycles;
+    // Index (0..FRAME_CYCLES-1) of the next cycle the ISR will program.
+    volatile uint32_t cycle_idx;
+    // Whether the preceding cycle is ON. If not, we should use the first cycle
+    // length instead.
+    volatile bool prev_was_on;
+    // Cumulative overvoltage trips, increased by the AC comparator ISR.
+    volatile uint32_t ov_count;
+    // Whether the drive timings above are valid to fire (set explicitly via
+    // set_timings or by a successful tune).
+    bool timings_valid;
 
-  // (Re)start a stopped/faulted drive timer for the pending burst.
-  void arm_timer();
-  // Publish drive timings directly in ticks (ISR blocked across the writes).
-  void set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
-                       uint32_t off_ticks);
-  // Cumulative overvoltage trips since boot
-  uint32_t overvoltage_count() {
-    return __atomic_load_n(&ov_count, __ATOMIC_RELAXED);
-  }
+    // (Re)start a stopped/faulted drive timer for the pending burst.
+    void
+    arm_timer();
+    // Publish drive timings directly in ticks (ISR blocked across the writes).
+    void
+    set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
+                    uint32_t off_ticks);
+    // Cumulative overvoltage trips since boot
+    uint32_t
+    overvoltage_count() {
+        return __atomic_load_n(&ov_count, __ATOMIC_RELAXED);
+    }
 
-  // ISR hooks
-  void schedule_next_cycle();
+    // ISR hooks
+    void
+    schedule_next_cycle();
 
-  void record_overvoltage() {
-    // AC COMP0 overvoltage trip. The EVSYS channel already faulted the
-    // timer, so we just record the event here.
-    __atomic_fetch_add(&ov_count, 1, __ATOMIC_RELAXED);
-  }
+    void
+    record_overvoltage() {
+        // AC COMP0 overvoltage trip. The EVSYS channel already faulted the
+        // timer, so we just record the event here.
+        __atomic_fetch_add(&ov_count, 1, __ATOMIC_RELAXED);
+    }
 };
 
 static driver_state state;
 
 struct current_sense_state {
-  uint32_t tally; // raw ADC counts, __atomic
+    uint32_t tally; // raw ADC counts, __atomic
 
-  void on_sample(uint16_t result) {
-    __atomic_fetch_add(&tally, result, __ATOMIC_RELAXED);
-  }
+    void
+    on_sample(uint16_t result) {
+        __atomic_fetch_add(&tally, result, __ATOMIC_RELAXED);
+    }
 
-  uint32_t total() { return __atomic_load_n(&tally, __ATOMIC_RELAXED); }
+    uint32_t
+    total() {
+        return __atomic_load_n(&tally, __ATOMIC_RELAXED);
+    }
 };
 
 static current_sense_state current_sense;
 
 enum class tune_phase : uint8_t {
-  idle,
-  on_first, // Phase 1: ramp first time_on until cycle 0's peak crosses target
-  on_first_done, // start Phase 2
-  off_measure,   // Phase 2: equivalent-time sweep of the positive resonance
+    idle,
+    on_first, // Phase 1: ramp first time_on until cycle 0's peak crosses target
+    on_first_done, // start Phase 2
+    off_measure, // Phase 2: equivalent-time sweep of the positive resonance
                  // half cycle
-  off_analyze,   // find time_off
-  off_dump,      // if requested, transfer the reconstructed waveform
-                 // (rate-limited)
-  off_done,      // start Phase 3
-  steady_on,     // Phase 3: ramp time_on until cycle 1's peak crosses target
-  steady_done,   // report all three timings
-  error,
+    off_analyze, // find time_off
+    off_dump, // if requested, transfer the reconstructed waveform
+              // (rate-limited)
+    off_done, // start Phase 3
+    steady_on, // Phase 3: ramp time_on until cycle 1's peak crosses target
+    steady_done, // report all three timings
+    error,
 };
 
 enum class tune_error : uint8_t {
-  none = 0,
-  overvoltage = 1, // Overvoltage triggered during the tune (target removed?)
-  initial_on_ceiling =
-      2, // ON-time tuning hit maximum time without reaching the target peak
-  off_no_zero =
-      3, // the resonance never returned to zero within the sweep window
-  steady_ceiling = 4, // steady ON hit the ceiling without reaching the target
-  timeout = 5,        // timed out
+    none = 0,
+    overvoltage = 1, // Overvoltage triggered during the tune (target removed?)
+    initial_on_ceiling =
+        2, // ON-time tuning hit maximum time without reaching the target peak
+    off_no_zero =
+        3, // the resonance never returned to zero within the sweep window
+    steady_ceiling = 4, // steady ON hit the ceiling without reaching the target
+    timeout = 5, // timed out
 };
 
 enum class tune_status : uint8_t {
-  idle = 0,    // no tune has run since boot
-  running = 1, // tuning in progress
-  success = 2, // completed. on_first_ticks/off_ticks/on_ticks hold result
-  failed = 3,  // aborted. `error` holds the reason
+    idle = 0, // no tune has run since boot
+    running = 1, // tuning in progress
+    success = 2, // completed. on_first_ticks/off_ticks/on_ticks hold result
+    failed = 3, // aborted. `error` holds the reason
 };
 
 enum class burst_status : uint8_t { busy, completed, ready };
 
 // Bounded test burst used by coil tune and ringdown. Only one owner at a time.
 struct test_burst {
-  bool burst_in_flight{false};
-  uint32_t next_fire_time{0};
+    bool burst_in_flight{false};
+    uint32_t next_fire_time{0};
 
-  volatile bool test_active{false};
-  volatile uint32_t cycles_done{0};
-  volatile uint32_t stop_after{0};
-  volatile uint32_t measure_cycle{0};
-  volatile bool burst_done{false};
-  volatile bool adc_active{false};
-  volatile bool adc_capture_armed{false};
-  volatile uint16_t adc_sample{0};
+    volatile bool test_active{false};
+    volatile uint32_t cycles_done{0};
+    volatile uint32_t stop_after{0};
+    volatile uint32_t measure_cycle{0};
+    volatile bool burst_done{false};
+    volatile bool adc_active{false};
+    volatile bool adc_capture_armed{false};
+    volatile uint16_t adc_sample{0};
 
-  bool on_drive_overflow();
-  bool capture_adc_sample(uint16_t result);
-  burst_status poll();
-  void fire(uint32_t n_cycles, uint32_t measure);
-  void adc_arm();
-  void adc_restore();
-  void stop_hw();
+    bool
+    on_drive_overflow();
+    bool
+    capture_adc_sample(uint16_t result);
+    burst_status
+    poll();
+    void
+    fire(uint32_t n_cycles, uint32_t measure);
+    void
+    adc_arm();
+    void
+    adc_restore();
+    void
+    stop_hw();
 };
 
 static test_burst burst;
 
 struct tuner_state {
-  bool want_details{false};
+    bool want_details{false};
 
-  tune_phase phase{tune_phase::idle};
-  tune_error error{tune_error::none};
-  // Latched across the return to idle so the host can poll the outcome.
-  tune_status status{tune_status::idle};
-  // Snapshot of the overvoltage count at start; any change aborts the tune.
-  uint32_t ov_count_at_start;
-  // Whole-tune watchdog deadline; passing it aborts the tune.
-  uint32_t deadline;
-  uint32_t on_first_ticks;        // Phase 1 candidate, then the kept result
-  uint32_t waveform_sample_count; // Desired number of waveform samples
-  uint32_t waveform_sample_idx;   // OFF-sweep / dump index
-  uint32_t off_ticks;             // result (ticks)
-  uint32_t on_ticks;              // Phase 3 candidate, then the kept result
-  uint32_t found_steady;          // result (ticks)
+    tune_phase phase{tune_phase::idle};
+    tune_error error{tune_error::none};
+    // Latched across the return to idle so the host can poll the outcome.
+    tune_status status{tune_status::idle};
+    // Snapshot of the overvoltage count at start; any change aborts the tune.
+    uint32_t ov_count_at_start;
+    // Whole-tune watchdog deadline; passing it aborts the tune.
+    uint32_t deadline;
+    uint32_t on_first_ticks; // Phase 1 candidate, then the kept result
+    uint32_t waveform_sample_count; // Desired number of waveform samples
+    uint32_t waveform_sample_idx; // OFF-sweep / dump index
+    uint32_t off_ticks; // result (ticks)
+    uint32_t on_ticks; // Phase 3 candidate, then the kept result
+    uint32_t found_steady; // result (ticks)
 
-  bool active() { return phase != tune_phase::idle; }
-  void start(bool want_details);
-  void step();
-  void abort(tune_error e);
-  void finish(tune_status s);
-  void step_on_first();
-  void step_off_measure();
-  void analyze_off();
-  void step_steady_on();
+    bool
+    active() {
+        return phase != tune_phase::idle;
+    }
+    void
+    start(bool want_details);
+    void
+    step();
+    void
+    abort(tune_error e);
+    void
+    finish(tune_status s);
+    void
+    step_on_first();
+    void
+    step_off_measure();
+    void
+    analyze_off();
+    void
+    step_steady_on();
 };
 
 static tuner_state tuner;
@@ -296,53 +323,65 @@ static constexpr uint32_t RINGDOWN_IDLE_MS_DEFAULT = 500;
 static constexpr uint32_t RINGDOWN_HEAT_MS_DEFAULT = 500;
 
 enum class ringdown_phase : uint8_t {
-  idle,
-  pause_wait,
-  sample,
-  analyze,
-  dump,
+    idle,
+    pause_wait,
+    sample,
+    analyze,
+    dump,
 };
 
 struct ringdown_config {
-  bool enable{false};
-  bool heat_gate{false};
-  float present_peak_v{RINGDOWN_PRESENT_PEAK_V_DEFAULT};
-  float absent_peak_v{RINGDOWN_ABSENT_PEAK_V_DEFAULT};
-  float min_peak_v{RINGDOWN_MIN_PEAK_V_DEFAULT};
-  float excite_scale{RINGDOWN_EXCITE_SCALE_DEFAULT};
-  uint32_t idle_ms{RINGDOWN_IDLE_MS_DEFAULT};
-  uint32_t heat_ms{RINGDOWN_HEAT_MS_DEFAULT};
+    bool enable{false};
+    bool heat_gate{false};
+    float present_peak_v{RINGDOWN_PRESENT_PEAK_V_DEFAULT};
+    float absent_peak_v{RINGDOWN_ABSENT_PEAK_V_DEFAULT};
+    float min_peak_v{RINGDOWN_MIN_PEAK_V_DEFAULT};
+    float excite_scale{RINGDOWN_EXCITE_SCALE_DEFAULT};
+    uint32_t idle_ms{RINGDOWN_IDLE_MS_DEFAULT};
+    uint32_t heat_ms{RINGDOWN_HEAT_MS_DEFAULT};
 };
 
 struct ringdown_state {
-  ringdown_phase phase{ringdown_phase::idle};
-  ringdown_status status{ringdown_status::idle};
-  nozzle_presence presence{nozzle_presence::unknown};
-  bool want_report{false};
-  bool want_dump{false};
-  uint32_t ov_count_at_start{0};
-  uint32_t deadline{0};
-  uint32_t sample_idx{0};
-  uint32_t dump_idx{0};
-  uint32_t dump_count{0};
-  uint32_t saved_pending_on_cycles{0};
-  uint32_t saved_on_ticks{0};
-  uint32_t saved_on_ticks_first{0};
-  uint32_t saved_off_ticks{0};
-  uint32_t peak_mv{0};
-  ringdown_status pending_status{ringdown_status::idle};
-  uint32_t next_schedule_time{0};
+    ringdown_phase phase{ringdown_phase::idle};
+    ringdown_status status{ringdown_status::idle};
+    nozzle_presence presence{nozzle_presence::unknown};
+    bool want_report{false};
+    bool want_dump{false};
+    uint32_t ov_count_at_start{0};
+    uint32_t deadline{0};
+    uint32_t sample_idx{0};
+    uint32_t dump_idx{0};
+    uint32_t dump_count{0};
+    uint32_t saved_pending_on_cycles{0};
+    uint32_t saved_on_ticks{0};
+    uint32_t saved_on_ticks_first{0};
+    uint32_t saved_off_ticks{0};
+    uint32_t peak_mv{0};
+    ringdown_status pending_status{ringdown_status::idle};
+    uint32_t next_schedule_time{0};
 
-  bool active() { return phase != ringdown_phase::idle; }
-  void start(bool report, bool dump);
-  void step();
-  void abort(ringdown_status s);
-  void finish(ringdown_status s);
-  void schedule_finish_or_dump(ringdown_status s);
-  void apply_presence(ringdown_status s);
-  void restore_drive();
-  void analyze();
-  uint32_t excite_on_ticks();
+    bool
+    active() {
+        return phase != ringdown_phase::idle;
+    }
+    void
+    start(bool report, bool dump);
+    void
+    step();
+    void
+    abort(ringdown_status s);
+    void
+    finish(ringdown_status s);
+    void
+    schedule_finish_or_dump(ringdown_status s);
+    void
+    apply_presence(ringdown_status s);
+    void
+    restore_drive();
+    void
+    analyze();
+    uint32_t
+    excite_on_ticks();
 };
 
 static ringdown_state ringdown;
@@ -350,9 +389,10 @@ static ringdown_config ringdown_cfg;
 static nozzle_presence last_presence{nozzle_presence::unknown};
 static uint16_t ringdown_samples[RINGDOWN_N_SAMPLES];
 
-static bool heat_gate_blocks_drive() {
-  return ringdown_cfg.enable && ringdown_cfg.heat_gate &&
-         last_presence != nozzle_presence::present;
+static bool
+heat_gate_blocks_drive() {
+    return ringdown_cfg.enable && ringdown_cfg.heat_gate &&
+           last_presence != nozzle_presence::present;
 }
 
 // IRQ declarations and assert correct indices.
@@ -370,582 +410,627 @@ DECL_CTR("DECL_ARMCM_IRQ AC_Handler 122");
 // Start a drive burst from an idle tank state. Sets up first two cycles and
 // starts the timer. Future cycles are set up by the timer ISR later on.
 // Only called if the timer is idle, clears any latched overvoltage fault.
-void driver_state::arm_timer() {
-  uint32_t on_cycles = pending_on_cycles;
-  this->on_cycles = on_cycles;
-  if (on_cycles == 0) {
-    // Nothing to fire: leave the timer stopped, output low.
-    return;
-  }
+void
+driver_state::arm_timer() {
+    uint32_t on_cycles = pending_on_cycles;
+    this->on_cycles = on_cycles;
+    if (on_cycles == 0) {
+        // Nothing to fire: leave the timer stopped, output low.
+        return;
+    }
 
-  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
 
-  // A latched fault (STATUS.FAULT0) leaves the counter halted and WO1 low.
-  // STOP then clear FAULT0. Clearing it while stopped keeps it stopped.
-  if (DRIVE_TCC->STATUS.bit.FAULT0) {
-    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+    // A latched fault (STATUS.FAULT0) leaves the counter halted and WO1 low.
+    // STOP then clear FAULT0. Clearing it while stopped keeps it stopped.
+    if (DRIVE_TCC->STATUS.bit.FAULT0) {
+        DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+        while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+            ;
+        DRIVE_TCC->STATUS.reg = TCC_STATUS_FAULT0;
+    }
+
+    // Flush any PERBUF/CCBUF the ISR staged before the timer stopped (at a
+    // frame boundary or a fault); it was never transferred, so PERBUFV/CCBUFV
+    // stay set. A direct PER/CC write below would then never finish syncing (a
+    // stopped counter has no UPDATE event to consume the buffer) and stall into
+    // a watchdog reset. CMD_UPDATE clears them. No-op at first arm.
+    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_UPDATE;
     while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-      ;
-    DRIVE_TCC->STATUS.reg = TCC_STATUS_FAULT0;
-  }
+        ;
 
-  // Flush any PERBUF/CCBUF the ISR staged before the timer stopped (at a
-  // frame boundary or a fault); it was never transferred, so PERBUFV/CCBUFV
-  // stay set. A direct PER/CC write below would then never finish syncing (a
-  // stopped counter has no UPDATE event to consume the buffer) and stall into
-  // a watchdog reset. CMD_UPDATE clears them. No-op at first arm.
-  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_UPDATE;
-  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-    ;
+    // Cycle 0 (inital ON ON + shortened period) goes in PER/CC. Cycle 1
+    // (steady ON, or 0 if the burst is a single cycle) goes in
+    // PERBUF/CCBUF, copied to PER/CC at the first overflow.
+    bool on1 = on_cycles > 1;
+    uint32_t cc1 = on1 ? on_ticks : 0;
+    DRIVE_TCC->PER.reg = TCC_PER_PER(first_period_minus_1);
+    DRIVE_TCC->CC[DRIVE_TCC_CC].reg = TCC_CC_CC(on_ticks_first);
+    while (DRIVE_TCC->SYNCBUSY.reg & (TCC_SYNCBUSY_PER | DRIVE_TCC_SYNCBUSY_CC))
+        ;
+    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(period_minus_1);
+    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc1);
 
-  // Cycle 0 (inital ON ON + shortened period) goes in PER/CC. Cycle 1
-  // (steady ON, or 0 if the burst is a single cycle) goes in
-  // PERBUF/CCBUF, copied to PER/CC at the first overflow.
-  bool on1 = on_cycles > 1;
-  uint32_t cc1 = on1 ? on_ticks : 0;
-  DRIVE_TCC->PER.reg = TCC_PER_PER(first_period_minus_1);
-  DRIVE_TCC->CC[DRIVE_TCC_CC].reg = TCC_CC_CC(on_ticks_first);
-  while (DRIVE_TCC->SYNCBUSY.reg & (TCC_SYNCBUSY_PER | DRIVE_TCC_SYNCBUSY_CC))
-    ;
-  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(period_minus_1);
-  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc1);
+    cycle_idx = 2;
+    prev_was_on = on1;
 
-  cycle_idx = 2;
-  prev_was_on = on1;
+    // Unset stale overflow flag so the first ISR aligns with cycle 2.
+    DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
 
-  // Unset stale overflow flag so the first ISR aligns with cycle 2.
-  DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
+    // Zero COUNT before retriggering. A retrigger of a STOPPED counter resumes
+    // from current COUNT. After a fault COUNT is frozen mid-cycle, so cycle 0
+    // would otherwise start partway through.
+    DRIVE_TCC->COUNT.reg = TCC_COUNT_COUNT(0);
+    while (DRIVE_TCC->SYNCBUSY.bit.COUNT)
+        ;
 
-  // Zero COUNT before retriggering. A retrigger of a STOPPED counter resumes
-  // from current COUNT. After a fault COUNT is frozen mid-cycle, so cycle 0
-  // would otherwise start partway through.
-  DRIVE_TCC->COUNT.reg = TCC_COUNT_COUNT(0);
-  while (DRIVE_TCC->SYNCBUSY.bit.COUNT)
-    ;
+    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_RETRIGGER;
+    while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+        ;
 
-  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_RETRIGGER;
-  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-    ;
-
-  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 }
 
-void coil_driver::set_duty(float duty) {
-  if (duty != 0.0f && tune_active()) {
-    shutdown("INDX heater target set while coil tuning");
-  }
-  // The coil timings have no default. Driving without first setting them
-  // (explicitly or via a successful tune) is a fault.
-  if (duty != 0.0f && !state.timings_valid) {
-    shutdown("INDX heater started before coil timings were set");
-  }
-  // Soft heat gate: mute drive unless a probe has classified present.
-  if (duty != 0.0f && heat_gate_blocks_drive()) {
-    duty = 0.0f;
-  }
+void
+coil_driver::set_duty(float duty) {
+    if (duty != 0.0f && tune_active()) {
+        shutdown("INDX heater target set while coil tuning");
+    }
+    // The coil timings have no default. Driving without first setting them
+    // (explicitly or via a successful tune) is a fault.
+    if (duty != 0.0f && !state.timings_valid) {
+        shutdown("INDX heater started before coil timings were set");
+    }
+    // Soft heat gate: mute drive unless a probe has classified present.
+    if (duty != 0.0f && heat_gate_blocks_drive()) {
+        duty = 0.0f;
+    }
 
-  uint32_t cycles;
-  if (duty <= 0.0f) {
-    cycles = 0;
-  } else if (duty >= 1.0f) {
-    cycles = FRAME_CYCLES;
-  } else {
-    cycles = (uint32_t)(duty * (float)FRAME_CYCLES);
-  }
-  if (this->duty_limit && cycles > this->duty_limit) {
-    cycles = this->duty_limit;
-  }
-  // Probe owns the tank; latch the requested duty for restore. Do not zero
-  // the request first or restore would drop heat until the next PID tick.
-  if (ringdown_active()) {
-    ringdown.saved_pending_on_cycles = cycles;
-    return;
-  }
-  state.pending_on_cycles = cycles;
+    uint32_t cycles;
+    if (duty <= 0.0f) {
+        cycles = 0;
+    } else if (duty >= 1.0f) {
+        cycles = FRAME_CYCLES;
+    } else {
+        cycles = (uint32_t)(duty * (float)FRAME_CYCLES);
+    }
+    if (this->duty_limit && cycles > this->duty_limit) {
+        cycles = this->duty_limit;
+    }
+    // Probe owns the tank; latch the requested duty for restore. Do not zero
+    // the request first or restore would drop heat until the next PID tick.
+    if (ringdown_active()) {
+        ringdown.saved_pending_on_cycles = cycles;
+        return;
+    }
+    state.pending_on_cycles = cycles;
 
-  // Rearm the timer if it's not currently active.
-  bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
-  if (cycles > 0 && idle) {
-    state.arm_timer();
-  }
+    // Rearm the timer if it's not currently active.
+    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+    if (cycles > 0 && idle) {
+        state.arm_timer();
+    }
 }
 
-void coil_driver::set_cycle_limit(uint32_t limit) { this->duty_limit = limit; }
-
-uint32_t coil_driver::get_ov_count() { return state.overvoltage_count(); }
-
-void coil_driver::shutdown_() {
-  // Disconnect timer from drive pin. The external gate pulldown holds the
-  // MOSFET off.
-  gpio_peripheral(DRIVE_PIN, 0, 0);
-  DRIVE_TCC->CTRLA.bit.ENABLE = 0;
-  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
-
-  // Disable the overvoltage comparator.
-  AC->CTRLA.reg = 0;
-  NVIC_DisableIRQ(AC_IRQn);
-
-  // Stop ADC start events first so no further conversions begin.
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.ENABLE = 0;
-  NVIC_DisableIRQ(FEEDBACK_ADC_1_IRQn);
-  NVIC_DisableIRQ(FEEDBACK_ADC_0_IRQn);
+void
+coil_driver::set_cycle_limit(uint32_t limit) {
+    this->duty_limit = limit;
 }
 
-uint32_t coil_driver::get_total_charge() { return current_sense.total(); }
+uint32_t
+coil_driver::get_ov_count() {
+    return state.overvoltage_count();
+}
+
+void
+coil_driver::shutdown_() {
+    // Disconnect timer from drive pin. The external gate pulldown holds the
+    // MOSFET off.
+    gpio_peripheral(DRIVE_PIN, 0, 0);
+    DRIVE_TCC->CTRLA.bit.ENABLE = 0;
+    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+
+    // Disable the overvoltage comparator.
+    AC->CTRLA.reg = 0;
+    NVIC_DisableIRQ(AC_IRQn);
+
+    // Stop ADC start events first so no further conversions begin.
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.ENABLE = 0;
+    NVIC_DisableIRQ(FEEDBACK_ADC_1_IRQn);
+    NVIC_DisableIRQ(FEEDBACK_ADC_0_IRQn);
+}
+
+uint32_t
+coil_driver::get_total_charge() {
+    return current_sense.total();
+}
 
 // Per-cycle scheduler. Runs at each overflow and stages the next
 // cycle's CCBUF/PERBUF, which are the timings for the cycle that will begin
 // _after_ the one that just started.
-void driver_state::schedule_next_cycle() {
-  uint32_t idx = cycle_idx;
+void
+driver_state::schedule_next_cycle() {
+    uint32_t idx = cycle_idx;
 
-  // Shape the next cycle. Default = OFF/skipped (CC=0, full period). The
-  // burst's first fired cycle (prev OFF) is soft-start (shorter ON + period,
-  // preserving OFF/ZVS time); other fired cycles are steady ON.
-  bool on = idx < on_cycles;
-  bool initial = on && !prev_was_on;
-  uint32_t cc = 0;
-  uint32_t per = period_minus_1;
-  if (initial) {
-    cc = on_ticks_first;
-    per = first_period_minus_1;
-  } else if (on) {
-    cc = on_ticks;
-  }
-  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc);
-  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(per);
-  prev_was_on = on;
-
-  // Check if this is the final cycle of the burst. If so, advance to the next
-  // burst.
-  if (++idx >= FRAME_CYCLES) {
-    idx = 0;
-    on_cycles = pending_on_cycles;
-    if (on_cycles == 0) {
-      DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+    // Shape the next cycle. Default = OFF/skipped (CC=0, full period). The
+    // burst's first fired cycle (prev OFF) is soft-start (shorter ON + period,
+    // preserving OFF/ZVS time); other fired cycles are steady ON.
+    bool on = idx < on_cycles;
+    bool initial = on && !prev_was_on;
+    uint32_t cc = 0;
+    uint32_t per = period_minus_1;
+    if (initial) {
+        cc = on_ticks_first;
+        per = first_period_minus_1;
+    } else if (on) {
+        cc = on_ticks;
     }
-  }
-  cycle_idx = idx;
+    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(cc);
+    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(per);
+    prev_was_on = on;
+
+    // Check if this is the final cycle of the burst. If so, advance to the next
+    // burst.
+    if (++idx >= FRAME_CYCLES) {
+        idx = 0;
+        on_cycles = pending_on_cycles;
+        if (on_cycles == 0) {
+            DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+        }
+    }
+    cycle_idx = idx;
 }
 
-extern "C" void TCC3_0_Handler(void) {
-  DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
-  if (burst.on_drive_overflow())
-    return;
-  state.schedule_next_cycle();
+extern "C" void
+TCC3_0_Handler(void) {
+    DRIVE_TCC->INTFLAG.reg = TCC_INTFLAG_OVF;
+    if (burst.on_drive_overflow())
+        return;
+    state.schedule_next_cycle();
 }
 
-extern "C" void AC_Handler(void) {
-  AC->INTFLAG.reg = AC_INTFLAG_COMP0;
-  state.record_overvoltage();
+extern "C" void
+AC_Handler(void) {
+    AC->INTFLAG.reg = AC_INTFLAG_COMP0;
+    state.record_overvoltage();
 }
 
-extern "C" void FEEDBACK_ADC_1_Handler(void) {
-  uint16_t result = FEEDBACK_ADC->RESULT.reg;
-  if (burst.capture_adc_sample(result))
-    return;
-  current_sense.on_sample(result);
+extern "C" void
+FEEDBACK_ADC_1_Handler(void) {
+    uint16_t result = FEEDBACK_ADC->RESULT.reg;
+    if (burst.capture_adc_sample(result))
+        return;
+    current_sense.on_sample(result);
 }
 
-extern "C" void FEEDBACK_ADC_0_Handler(void) {
-  shutdown("coil driver feedback ADC overrun");
+extern "C" void
+FEEDBACK_ADC_0_Handler(void) {
+    shutdown("coil driver feedback ADC overrun");
 }
 
 // Enables clock, running at core frequency instead of slower peripheral clkgen.
-static void enable_pclock_max(uint32_t pclk_id, int32_t pm_id) {
-  auto val = GCLK_PCHCTRL_GEN(0) | GCLK_PCHCTRL_CHEN;
-  GCLK->PCHCTRL[pclk_id].reg = val;
-  while (GCLK->PCHCTRL[pclk_id].reg != val)
-    ;
-  uint32_t pm_port = pm_id / 32, pm_bit = 1 << (pm_id % 32);
-  (&MCLK->APBAMASK.reg)[pm_port] |= pm_bit;
+static void
+enable_pclock_max(uint32_t pclk_id, int32_t pm_id) {
+    auto val = GCLK_PCHCTRL_GEN(0) | GCLK_PCHCTRL_CHEN;
+    GCLK->PCHCTRL[pclk_id].reg = val;
+    while (GCLK->PCHCTRL[pclk_id].reg != val)
+        ;
+    uint32_t pm_port = pm_id / 32, pm_bit = 1 << (pm_id % 32);
+    (&MCLK->APBAMASK.reg)[pm_port] |= pm_bit;
 }
 
-static void setup_adc1() {
-  // Set up the ADC temperature pin, which ensures `adc_init` gets called. We
-  // let this load the calibration data etc for us.
-  gpio_adc_setup(0xfe);
+static void
+setup_adc1() {
+    // Set up the ADC temperature pin, which ensures `adc_init` gets called. We
+    // let this load the calibration data etc for us.
+    gpio_adc_setup(0xfe);
 
-  gpio_peripheral(CURRENT_SENSE_PIN, CURRENT_SENSE_PIN_FUNC, 0);
-  gpio_peripheral(FEEDBACK_ADC_PIN, FEEDBACK_ADC_PIN_FUNC, 0);
+    gpio_peripheral(CURRENT_SENSE_PIN, CURRENT_SENSE_PIN_FUNC, 0);
+    gpio_peripheral(FEEDBACK_ADC_PIN, FEEDBACK_ADC_PIN_FUNC, 0);
 
-  enable_pclock(FEEDBACK_ADC_GCLK_ID, FEEDBACK_ADC_PM_ID);
+    enable_pclock(FEEDBACK_ADC_GCLK_ID, FEEDBACK_ADC_PM_ID);
 
-  // Read calibration data so we have it after we reset the ADC
-  auto calib = FEEDBACK_ADC->CALIB.reg;
+    // Read calibration data so we have it after we reset the ADC
+    auto calib = FEEDBACK_ADC->CALIB.reg;
 
-  FEEDBACK_ADC->CTRLA.bit.SWRST = 1;
-  while (FEEDBACK_ADC->SYNCBUSY.bit.SWRST)
-    ;
+    FEEDBACK_ADC->CTRLA.bit.SWRST = 1;
+    while (FEEDBACK_ADC->SYNCBUSY.bit.SWRST)
+        ;
 
-  // Reload calibration
-  FEEDBACK_ADC->CALIB.reg = calib;
+    // Reload calibration
+    FEEDBACK_ADC->CALIB.reg = calib;
 
-  FEEDBACK_ADC->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
-  while (FEEDBACK_ADC->SYNCBUSY.bit.REFCTRL)
-    ;
+    FEEDBACK_ADC->REFCTRL.reg = ADC_REFCTRL_REFSEL_INTVCC1;
+    while (FEEDBACK_ADC->SYNCBUSY.bit.REFCTRL)
+        ;
 
-  FEEDBACK_ADC->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(4);
-  while (FEEDBACK_ADC->SYNCBUSY.bit.SAMPCTRL)
-    ;
+    FEEDBACK_ADC->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(4);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.SAMPCTRL)
+        ;
 
-  // Start out with current sense as our ADC channel
-  FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
-                                ADC_INPUTCTRL_MUXNEG(0x18);
-  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-    ;
+    // Start out with current sense as our ADC channel
+    FEEDBACK_ADC->INPUTCTRL.reg =
+        ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
+        ADC_INPUTCTRL_MUXNEG(0x18);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+        ;
 
-  // ADC runs event triggered. CURRENT_SENSE_TRIGGER_TC paces current sense
-  // measurements via EVSYS. During tuning, DRIVE_TCC takes over.
-  FEEDBACK_ADC->CTRLB.reg = ADC_CTRLB_RESSEL_12BIT;
-  while (FEEDBACK_ADC->SYNCBUSY.bit.CTRLB)
-    ;
-  FEEDBACK_ADC->EVCTRL.reg = ADC_EVCTRL_STARTEI;
+    // ADC runs event triggered. CURRENT_SENSE_TRIGGER_TC paces current sense
+    // measurements via EVSYS. During tuning, DRIVE_TCC takes over.
+    FEEDBACK_ADC->CTRLB.reg = ADC_CTRLB_RESSEL_12BIT;
+    while (FEEDBACK_ADC->SYNCBUSY.bit.CTRLB)
+        ;
+    FEEDBACK_ADC->EVCTRL.reg = ADC_EVCTRL_STARTEI;
 
-  FEEDBACK_ADC->INTENSET.reg = ADC_INTENSET_RESRDY | ADC_INTENSET_OVERRUN;
+    FEEDBACK_ADC->INTENSET.reg = ADC_INTENSET_RESRDY | ADC_INTENSET_OVERRUN;
 
-  NVIC_SetPriority(FEEDBACK_ADC_1_IRQn, 1);
-  NVIC_SetPriority(FEEDBACK_ADC_0_IRQn, 1);
-  NVIC_EnableIRQ(FEEDBACK_ADC_1_IRQn);
-  NVIC_EnableIRQ(FEEDBACK_ADC_0_IRQn);
+    NVIC_SetPriority(FEEDBACK_ADC_1_IRQn, 1);
+    NVIC_SetPriority(FEEDBACK_ADC_0_IRQn, 1);
+    NVIC_EnableIRQ(FEEDBACK_ADC_1_IRQn);
+    NVIC_EnableIRQ(FEEDBACK_ADC_0_IRQn);
 
-  // 48 MHz / 4 = 12 MHz ADC clock, spec calls for < 16MHz.
-  FEEDBACK_ADC->CTRLA.reg =
-      ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV4_Val) | ADC_CTRLA_ENABLE;
-  while (FEEDBACK_ADC->SYNCBUSY.bit.ENABLE)
-    ;
+    // 48 MHz / 4 = 12 MHz ADC clock, spec calls for < 16MHz.
+    FEEDBACK_ADC->CTRLA.reg =
+        ADC_CTRLA_PRESCALER(ADC_CTRLA_PRESCALER_DIV4_Val) | ADC_CTRLA_ENABLE;
+    while (FEEDBACK_ADC->SYNCBUSY.bit.ENABLE)
+        ;
 }
 
-static void setup_adc_trigger_tc() {
-  enable_pclock_max(CURRENT_SENSE_TRIGGER_TC_GCLK_ID,
-                    CURRENT_SENSE_TRIGGER_TC_PM_ID);
+static void
+setup_adc_trigger_tc() {
+    enable_pclock_max(CURRENT_SENSE_TRIGGER_TC_GCLK_ID,
+                      CURRENT_SENSE_TRIGGER_TC_PM_ID);
 
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.SWRST = 1;
-  while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.SWRST)
-    ;
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.bit.SWRST = 1;
+    while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.SWRST)
+        ;
 
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.WAVE.reg = TC_WAVE_WAVEGEN_MFRQ;
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.CC[0].reg = ADC_TRIGGER_PERIOD - 1;
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.EVCTRL.reg = TC_EVCTRL_OVFEO;
-  CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.reg =
-      TC_CTRLA_MODE_COUNT16 | TC_CTRLA_PRESCALER_DIV1 | TC_CTRLA_ENABLE;
-  while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.ENABLE)
-    ;
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.WAVE.reg = TC_WAVE_WAVEGEN_MFRQ;
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.CC[0].reg = ADC_TRIGGER_PERIOD - 1;
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.EVCTRL.reg = TC_EVCTRL_OVFEO;
+    CURRENT_SENSE_TRIGGER_TC->COUNT16.CTRLA.reg =
+        TC_CTRLA_MODE_COUNT16 | TC_CTRLA_PRESCALER_DIV1 | TC_CTRLA_ENABLE;
+    while (CURRENT_SENSE_TRIGGER_TC->COUNT16.SYNCBUSY.bit.ENABLE)
+        ;
 }
 
-static void setup_evsys() {
-  // We need EVSYS for signal routing so bring it up now.
-  MCLK->APBBMASK.bit.EVSYS_ = 1;
+static void
+setup_evsys() {
+    // We need EVSYS for signal routing so bring it up now.
+    MCLK->APBBMASK.bit.EVSYS_ = 1;
 
-  // Event channel for triggering ADC for tuning and current sensing
-  EVSYS->Channel[DRIVE_TCC_TUNE_EVSYS_CHANNEL].CHANNEL.reg =
-      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TCC3_MC_0) |
-      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+    // Event channel for triggering ADC for tuning and current sensing
+    EVSYS->Channel[DRIVE_TCC_TUNE_EVSYS_CHANNEL].CHANNEL.reg =
+        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TCC3_MC_0) |
+        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
 
-  EVSYS->Channel[ADC_TRIGGER_EVSYS_CHANNEL].CHANNEL.reg =
-      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TC2_OVF) |
-      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
-  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
+    EVSYS->Channel[ADC_TRIGGER_EVSYS_CHANNEL].CHANNEL.reg =
+        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_TC2_OVF) |
+        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
 }
 
-static void setup_drive_tcc() {
-  enable_pclock_max(DRIVE_TCC_PCLK_ID, DRIVE_TCC_PM_ID);
+static void
+setup_drive_tcc() {
+    enable_pclock_max(DRIVE_TCC_PCLK_ID, DRIVE_TCC_PM_ID);
 
-  // Set up the drive timer.
-  DRIVE_TCC->CTRLA.bit.SWRST = 1;
-  while (DRIVE_TCC->SYNCBUSY.bit.SWRST)
-    ;
+    // Set up the drive timer.
+    DRIVE_TCC->CTRLA.bit.SWRST = 1;
+    while (DRIVE_TCC->SYNCBUSY.bit.SWRST)
+        ;
 
-  DRIVE_TCC->CTRLA.reg = TCC_CTRLA_PRESCALER_DIV1;
-  DRIVE_TCC->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM;
-  // On a non-recoverable fault, force WO1 (PB17) low so the MOSFET turns off.
-  DRIVE_TCC->DRVCTRL.reg = TCC_DRVCTRL_NRE(1 << DRIVE_TCC_CC);
-  // Overvoltage triggeres a non-recoverable fault on the drive timer via
-  // EVSYS on event 0. During tuning, CC0 match outputs an event to trigger
-  // ADC sampling.
-  DRIVE_TCC->EVCTRL.reg =
-      TCC_EVCTRL_TCEI0 | TCC_EVCTRL_EVACT0_FAULT | TCC_EVCTRL_MCEO0;
+    DRIVE_TCC->CTRLA.reg = TCC_CTRLA_PRESCALER_DIV1;
+    DRIVE_TCC->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM;
+    // On a non-recoverable fault, force WO1 (PB17) low so the MOSFET turns off.
+    DRIVE_TCC->DRVCTRL.reg = TCC_DRVCTRL_NRE(1 << DRIVE_TCC_CC);
+    // Overvoltage triggeres a non-recoverable fault on the drive timer via
+    // EVSYS on event 0. During tuning, CC0 match outputs an event to trigger
+    // ADC sampling.
+    DRIVE_TCC->EVCTRL.reg =
+        TCC_EVCTRL_TCEI0 | TCC_EVCTRL_EVACT0_FAULT | TCC_EVCTRL_MCEO0;
 
-  DRIVE_TCC->CTRLA.bit.ENABLE = 1;
-  while (DRIVE_TCC->SYNCBUSY.bit.ENABLE)
-    ;
-  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-  while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
-    ;
+    DRIVE_TCC->CTRLA.bit.ENABLE = 1;
+    while (DRIVE_TCC->SYNCBUSY.bit.ENABLE)
+        ;
+    DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+    while (DRIVE_TCC->SYNCBUSY.bit.CTRLB)
+        ;
 
-  DRIVE_TCC->INTENSET.reg = TCC_INTENSET_OVF;
-  NVIC_SetPriority(DRIVE_TCC_IRQn, 1);
-  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+    DRIVE_TCC->INTENSET.reg = TCC_INTENSET_OVF;
+    NVIC_SetPriority(DRIVE_TCC_IRQn, 1);
+    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 
-  gpio_peripheral(DRIVE_PIN, DRIVE_PIN_FUNC, false);
+    gpio_peripheral(DRIVE_PIN, DRIVE_PIN_FUNC, false);
 }
 
-static void setup_ac() {
-  gpio_peripheral(FEEDBACK_AC_PIN, FEEDBACK_AC_PIN_FUNC, 0);
+static void
+setup_ac() {
+    gpio_peripheral(FEEDBACK_AC_PIN, FEEDBACK_AC_PIN_FUNC, 0);
 
-  enable_pclock(AC_GCLK_ID, ID_AC);
+    enable_pclock(AC_GCLK_ID, ID_AC);
 
-  AC->CTRLA.bit.SWRST = 1;
-  while (AC->SYNCBUSY.bit.SWRST)
-    ;
+    AC->CTRLA.bit.SWRST = 1;
+    while (AC->SYNCBUSY.bit.SWRST)
+        ;
 
-  // COMP0: overvoltage detector, interrupt triggers on rising edge which
-  // indicates over voltage.
-  AC->SCALER[0].reg = AC_SCALER_VALUE(OV_SCALER_VALUE);
-  AC->COMPCTRL[0].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
-                        AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
-                        AC_COMPCTRL_HYSTEN | AC_COMPCTRL_HYST_HYST50 |
-                        AC_COMPCTRL_ENABLE;
-  while (AC->SYNCBUSY.bit.COMPCTRL0)
-    ;
+    // COMP0: overvoltage detector, interrupt triggers on rising edge which
+    // indicates over voltage.
+    AC->SCALER[0].reg = AC_SCALER_VALUE(OV_SCALER_VALUE);
+    AC->COMPCTRL[0].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
+                          AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
+                          AC_COMPCTRL_HYSTEN | AC_COMPCTRL_HYST_HYST50 |
+                          AC_COMPCTRL_ENABLE;
+    while (AC->SYNCBUSY.bit.COMPCTRL0)
+        ;
 
-  // COMP1: tuner peak detector. Latches rising edge, not used in normal
-  // driving. No hysteresis as that would bias the detect peak high.
-  AC->SCALER[1].reg = AC_SCALER_VALUE(TUNE_TARGET_SCALER_VALUE);
-  AC->COMPCTRL[1].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
-                        AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
-                        AC_COMPCTRL_ENABLE;
-  while (AC->SYNCBUSY.bit.COMPCTRL1)
-    ;
+    // COMP1: tuner peak detector. Latches rising edge, not used in normal
+    // driving. No hysteresis as that would bias the detect peak high.
+    AC->SCALER[1].reg = AC_SCALER_VALUE(TUNE_TARGET_SCALER_VALUE);
+    AC->COMPCTRL[1].reg = AC_COMPCTRL_MUXPOS_PIN2 | AC_COMPCTRL_MUXNEG_VSCALE |
+                          AC_COMPCTRL_SPEED_HIGH | AC_COMPCTRL_INTSEL_RISING |
+                          AC_COMPCTRL_ENABLE;
+    while (AC->SYNCBUSY.bit.COMPCTRL1)
+        ;
 
-  AC->EVCTRL.reg = AC_EVCTRL_COMPEO0;   // COMP0 state sent to event output
-  AC->INTENSET.reg = AC_INTENSET_COMP0; // COMP0 rising edge triggers AC_Handler
+    AC->EVCTRL.reg = AC_EVCTRL_COMPEO0; // COMP0 state sent to event output
+    AC->INTENSET.reg =
+        AC_INTENSET_COMP0; // COMP0 rising edge triggers AC_Handler
 
-  NVIC_SetPriority(AC_IRQn, 2);
-  NVIC_EnableIRQ(AC_IRQn);
+    NVIC_SetPriority(AC_IRQn, 2);
+    NVIC_EnableIRQ(AC_IRQn);
 
-  AC->CTRLA.reg = AC_CTRLA_ENABLE;
-  while (AC->SYNCBUSY.bit.ENABLE)
-    ;
+    AC->CTRLA.reg = AC_CTRLA_ENABLE;
+    while (AC->SYNCBUSY.bit.ENABLE)
+        ;
 
-  // COMP0 is routed to event on DRIVE_TCC/TCC3 so next cycle can be
-  // prevented.
-  EVSYS->Channel[OV_EVSYS_CHANNEL].CHANNEL.reg =
-      EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_AC_COMP_0) |
-      EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
-  EVSYS->USER[EVSYS_ID_USER_TCC3_EV_0].reg = OV_EVSYS_CHANNEL + 1;
+    // COMP0 is routed to event on DRIVE_TCC/TCC3 so next cycle can be
+    // prevented.
+    EVSYS->Channel[OV_EVSYS_CHANNEL].CHANNEL.reg =
+        EVSYS_CHANNEL_EVGEN(EVSYS_ID_GEN_AC_COMP_0) |
+        EVSYS_CHANNEL_PATH_ASYNCHRONOUS;
+    EVSYS->USER[EVSYS_ID_USER_TCC3_EV_0].reg = OV_EVSYS_CHANNEL + 1;
 }
 
-void coil_driver::set_timings(float time_on, float time_off,
-                              float time_on_first) {
-  auto osc_clk_freq = (float)CONFIG_CLOCK_FREQ;
+void
+coil_driver::set_timings(float time_on, float time_off, float time_on_first) {
+    auto osc_clk_freq = (float)CONFIG_CLOCK_FREQ;
 
-  uint32_t on_ticks = (uint32_t)(osc_clk_freq * time_on);
-  uint32_t off_ticks = (uint32_t)(osc_clk_freq * time_off);
-  uint32_t on_ticks_first = (uint32_t)(osc_clk_freq * time_on_first);
-  state.set_drive_ticks(on_ticks, on_ticks_first, off_ticks);
+    uint32_t on_ticks = (uint32_t)(osc_clk_freq * time_on);
+    uint32_t off_ticks = (uint32_t)(osc_clk_freq * time_off);
+    uint32_t on_ticks_first = (uint32_t)(osc_clk_freq * time_on_first);
+    state.set_drive_ticks(on_ticks, on_ticks_first, off_ticks);
 }
 
-coil_driver coil_driver_create() {
-  auto driver = coil_driver();
+coil_driver
+coil_driver_create() {
+    auto driver = coil_driver();
 
-  setup_evsys();
-  setup_drive_tcc();
-  setup_ac();
-  setup_adc1();
-  setup_adc_trigger_tc();
+    setup_evsys();
+    setup_drive_tcc();
+    setup_ac();
+    setup_adc1();
+    setup_adc_trigger_tc();
 
-  return driver;
+    return driver;
 }
 
-static constexpr uint32_t volts_to_count(float v) {
-  int32_t c = (int32_t)(v / DRAIN_V_PER_COUNT + 0.5f);
-  if (c < 0)
-    c = 0;
-  if (c > 4095)
-    c = 4095;
-  return (uint32_t)c;
+static constexpr uint32_t
+volts_to_count(float v) {
+    int32_t c = (int32_t)(v / DRAIN_V_PER_COUNT + 0.5f);
+    if (c < 0)
+        c = 0;
+    if (c > 4095)
+        c = 4095;
+    return (uint32_t)c;
 }
 
-static uint32_t ticks_to_ns(uint32_t ticks) {
-  return (uint32_t)((float)ticks * (1.0e9f / (float)CONFIG_CLOCK_FREQ) + 0.5f);
+static uint32_t
+ticks_to_ns(uint32_t ticks) {
+    return (uint32_t)((float)ticks * (1.0e9f / (float)CONFIG_CLOCK_FREQ) +
+                      0.5f);
 }
 
 // Read and clear the latched COMP1 peak flag.
-static bool tune_peak_tripped() {
-  if (!AC->INTFLAG.bit.COMP1)
-    return false;
-  AC->INTFLAG.reg = AC_INTFLAG_COMP1;
-  return true;
+static bool
+tune_peak_tripped() {
+    if (!AC->INTFLAG.bit.COMP1)
+        return false;
+    AC->INTFLAG.reg = AC_INTFLAG_COMP1;
+    return true;
 }
 
 // Set new drive timings in ticks. If the specified timings are not valid,
 // `timings_valid` is set to false and the currently set ticks are not touched.
-void driver_state::set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
-                                   uint32_t off_ticks) {
-  if (on_ticks == 0 || off_ticks == 0 || on_ticks_first == 0 ||
-      on_ticks_first > on_ticks) {
-    this->timings_valid = false;
-    return;
-  }
+void
+driver_state::set_drive_ticks(uint32_t on_ticks, uint32_t on_ticks_first,
+                              uint32_t off_ticks) {
+    if (on_ticks == 0 || off_ticks == 0 || on_ticks_first == 0 ||
+        on_ticks_first > on_ticks) {
+        this->timings_valid = false;
+        return;
+    }
 
-  NVIC_DisableIRQ(DRIVE_TCC_IRQn);
-  this->on_ticks = on_ticks;
-  this->period_minus_1 = on_ticks + off_ticks - 1;
-  this->on_ticks_first = on_ticks_first;
-  this->first_period_minus_1 = on_ticks_first + off_ticks - 1;
-  this->timings_valid = true;
-  NVIC_EnableIRQ(DRIVE_TCC_IRQn);
+    NVIC_DisableIRQ(DRIVE_TCC_IRQn);
+    this->on_ticks = on_ticks;
+    this->period_minus_1 = on_ticks + off_ticks - 1;
+    this->on_ticks_first = on_ticks_first;
+    this->first_period_minus_1 = on_ticks_first + off_ticks - 1;
+    this->timings_valid = true;
+    NVIC_EnableIRQ(DRIVE_TCC_IRQn);
 }
 
 // Fire a single test burst from idle timer. Can fire either 1 or 2 cycles.
-void test_burst::fire(uint32_t n_cycles, uint32_t measure) {
-  cycles_done = 0;
-  stop_after = n_cycles + TUNE_TRAILING_OFF;
-  measure_cycle = measure;
-  burst_done = false;
-  test_active = true;
-  state.pending_on_cycles = n_cycles;
-  burst_in_flight = true;
-  state.arm_timer();
+void
+test_burst::fire(uint32_t n_cycles, uint32_t measure) {
+    cycles_done = 0;
+    stop_after = n_cycles + TUNE_TRAILING_OFF;
+    measure_cycle = measure;
+    burst_done = false;
+    test_active = true;
+    state.pending_on_cycles = n_cycles;
+    burst_in_flight = true;
+    state.arm_timer();
 }
 
-bool test_burst::on_drive_overflow() {
-  if (!test_active)
-    return false;
+bool
+test_burst::on_drive_overflow() {
+    if (!test_active)
+        return false;
 
-  uint32_t started = cycles_done + 1;
-  cycles_done = started;
+    uint32_t started = cycles_done + 1;
+    cycles_done = started;
 
-  if (started == measure_cycle) {
-    AC->INTFLAG.reg = AC_INTFLAG_COMP1;
-  }
+    if (started == measure_cycle) {
+        AC->INTFLAG.reg = AC_INTFLAG_COMP1;
+    }
 
-  DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(0);
-  DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(state.period_minus_1);
+    DRIVE_TCC->CCBUF[DRIVE_TCC_CC].reg = TCC_CCBUF_CCBUF(0);
+    DRIVE_TCC->PERBUF.reg = TCC_PERBUF_PERBUF(state.period_minus_1);
 
-  if (started >= stop_after) {
+    if (started >= stop_after) {
+        DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
+        test_active = false;
+        burst_done = true;
+    }
+    return true;
+}
+
+bool
+test_burst::capture_adc_sample(uint16_t result) {
+    if (!adc_active)
+        return false;
+    if (adc_capture_armed) {
+        adc_sample = result;
+        adc_capture_armed = false;
+    }
+    return true;
+}
+
+static void
+tune_set_cc0(uint32_t value) {
+    DRIVE_TCC->CC[DRIVE_TCC_TUNE_CC].reg = TCC_CC_CC(value);
+    while (DRIVE_TCC->SYNCBUSY.reg & DRIVE_TCC_TUNE_SYNCBUSY_CC)
+        ;
+}
+
+void
+test_burst::adc_arm() {
+    FEEDBACK_ADC->INPUTCTRL.reg =
+            ADC_INPUTCTRL_MUXPOS(DRAIN_SENSE_ADC_MUXPOS) | ADC_INPUTCTRL_MUXNEG(0x18);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+        ;
+    adc_active = true;
+    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg =
+        DRIVE_TCC_TUNE_EVSYS_CHANNEL + 1;
+}
+
+void
+test_burst::adc_restore() {
+    FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
+        ADC_INPUTCTRL_MUXNEG(0x18);
+    while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
+        ;
+    adc_active = false;
+    EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
+}
+
+void
+test_burst::stop_hw() {
+    if (adc_active)
+        adc_restore();
     DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
     test_active = false;
-    burst_done = true;
-  }
-  return true;
-}
-
-bool test_burst::capture_adc_sample(uint16_t result) {
-  if (!adc_active)
-    return false;
-  if (adc_capture_armed) {
-    adc_sample = result;
-    adc_capture_armed = false;
-  }
-  return true;
-}
-
-static void tune_set_cc0(uint32_t value) {
-  DRIVE_TCC->CC[DRIVE_TCC_TUNE_CC].reg = TCC_CC_CC(value);
-  while (DRIVE_TCC->SYNCBUSY.reg & DRIVE_TCC_TUNE_SYNCBUSY_CC)
-    ;
-}
-
-void test_burst::adc_arm() {
-  FEEDBACK_ADC->INPUTCTRL.reg =
-      ADC_INPUTCTRL_MUXPOS(DRAIN_SENSE_ADC_MUXPOS) | ADC_INPUTCTRL_MUXNEG(0x18);
-  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-    ;
-  adc_active = true;
-  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = DRIVE_TCC_TUNE_EVSYS_CHANNEL + 1;
-}
-
-void test_burst::adc_restore() {
-  FEEDBACK_ADC->INPUTCTRL.reg = ADC_INPUTCTRL_MUXPOS(CURRENT_SENSE_ADC_MUXPOS) |
-                                ADC_INPUTCTRL_MUXNEG(0x18);
-  while (FEEDBACK_ADC->SYNCBUSY.bit.INPUTCTRL)
-    ;
-  adc_active = false;
-  EVSYS->USER[EVSYS_ID_USER_ADC1_START].reg = ADC_TRIGGER_EVSYS_CHANNEL + 1;
-}
-
-void test_burst::stop_hw() {
-  if (adc_active)
-    adc_restore();
-  DRIVE_TCC->CTRLBSET.reg = TCC_CTRLBSET_CMD_STOP;
-  test_active = false;
-  burst_in_flight = false;
+    burst_in_flight = false;
 }
 
 static uint16_t tune_waveform_samples[TUNE_N_SAMPLES];
 
-burst_status test_burst::poll() {
-  if (burst_in_flight) {
-    if (!burst_done)
-      return burst_status::busy;
-    burst_in_flight = false;
-    next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
-    return burst_status::completed;
-  }
-  if (timer_is_before(timer_read_time(), next_fire_time))
-    return burst_status::busy;
-  return burst_status::ready;
+burst_status
+test_burst::poll() {
+    if (burst_in_flight) {
+        if (!burst_done)
+            return burst_status::busy;
+        burst_in_flight = false;
+        next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+        return burst_status::completed;
+    }
+    if (timer_is_before(timer_read_time(), next_fire_time))
+        return burst_status::busy;
+    return burst_status::ready;
 }
 
-void tuner_state::start(bool want_details) {
-  // start_tune() has already verified the coil is idle.
-  *this = tuner_state{};
-  this->want_details = want_details;
-  phase = tune_phase::on_first;
-  status = tune_status::running;
-  on_first_ticks = TUNE_ON_FIRST_SEED;
-  burst.next_fire_time = timer_read_time();
-  ov_count_at_start = state.overvoltage_count();
-  deadline = timer_read_time() + timer_from_us(TUNE_TOTAL_TIMEOUT_US);
-  // The test bursts overwrite the published drive timings, so any previously
-  // valid set is now gone; only a successful tune (or a fresh set_timings)
-  // makes them valid again.
-  state.timings_valid = false;
+void
+tuner_state::start(bool want_details) {
+    // start_tune() has already verified the coil is idle.
+    *this = tuner_state{};
+    this->want_details = want_details;
+    phase = tune_phase::on_first;
+    status = tune_status::running;
+    on_first_ticks = TUNE_ON_FIRST_SEED;
+    burst.next_fire_time = timer_read_time();
+    ov_count_at_start = state.overvoltage_count();
+    deadline = timer_read_time() + timer_from_us(TUNE_TOTAL_TIMEOUT_US);
+    // The test bursts overwrite the published drive timings, so any previously
+    // valid set is now gone; only a successful tune (or a fresh set_timings)
+    // makes them valid again.
+    state.timings_valid = false;
 }
 
-void tuner_state::abort(tune_error e) {
-  burst.stop_hw();
-  // A failed tune has no valid result; clear the timings so a poll can't read
-  // a stale/partial value (`error` carries the reason instead).
-  on_first_ticks = 0;
-  off_ticks = 0;
-  error = e;
-  phase = tune_phase::error;
+void
+tuner_state::abort(tune_error e) {
+    burst.stop_hw();
+    // A failed tune has no valid result; clear the timings so a poll can't read
+    // a stale/partial value (`error` carries the reason instead).
+    on_first_ticks = 0;
+    off_ticks = 0;
+    error = e;
+    phase = tune_phase::error;
 }
 
-void tuner_state::finish(tune_status s) {
-  status = s;
-  // A successful tune leaves the found timings in the drive state,
-  // so heating may use them
-  if (s == tune_status::success) {
-    state.timings_valid = true;
-  }
-  sendf("indx_coil_tune_finished status=%c error=%c", (uint32_t)s,
-        (uint32_t)error);
-  phase = tune_phase::idle;
+void
+tuner_state::finish(tune_status s) {
+    status = s;
+    // A successful tune leaves the found timings in the drive state,
+    // so heating may use them
+    if (s == tune_status::success) {
+        state.timings_valid = true;
+    }
+    sendf("indx_coil_tune_finished status=%c error=%c", (uint32_t)s,
+          (uint32_t)error);
+    phase = tune_phase::idle;
 }
 
-static constexpr uint32_t counts_to_mv(uint32_t counts) {
-  return (uint32_t)((float)counts * DRAIN_V_PER_COUNT * 1000.0f + 0.5f);
+static constexpr uint32_t
+counts_to_mv(uint32_t counts) {
+    return (uint32_t)((float)counts * DRAIN_V_PER_COUNT * 1000.0f + 0.5f);
 }
 
 // Phase 1: from a de-energized tank, fire single-cycle bursts at increasing
 // time_on_first until the resonance peak first crosses the target.
-void tuner_state::step_on_first() {
-  switch (burst.poll()) {
-  case burst_status::busy:
-    return;
-  case burst_status::completed:
-    if (tune_peak_tripped()) {
-      // reached the target peak
-      phase = tune_phase::on_first_done;
-      return;
+void
+tuner_state::step_on_first() {
+    switch (burst.poll()) {
+    case burst_status::busy:
+        return;
+    case burst_status::completed:
+        if (tune_peak_tripped()) {
+            // reached the target peak
+            phase = tune_phase::on_first_done;
+            return;
+        }
+        on_first_ticks += TUNE_ON_STEP;
+        if (on_first_ticks > TUNE_ON_MAX) {
+            abort(tune_error::initial_on_ceiling);
+        }
+        return;
+    case burst_status::ready:
+        // Single-cycle burst: cycle is the only fired cycle, so any peak is
+        // unambiguously its own. Steady ON time is irrelevant here.
+        state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
+        tune_peak_tripped(); // clear target peak latch
+        burst.fire(1, 0);
+        return;
     }
-    on_first_ticks += TUNE_ON_STEP;
-    if (on_first_ticks > TUNE_ON_MAX) {
-      abort(tune_error::initial_on_ceiling);
-    }
-    return;
-  case burst_status::ready:
-    // Single-cycle burst: cycle is the only fired cycle, so any peak is
-    // unambiguously its own. Steady ON time is irrelevant here.
-    state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
-    tune_peak_tripped(); // clear target peak latch
-    burst.fire(1, 0);
-    return;
-  }
 }
 
 // Phase 2: with fixed initial cycle ON time, run consecutive bursts and do
@@ -954,470 +1039,503 @@ void tuner_state::step_on_first() {
 // actual OFF event as well. This way, when we go to find the actual OFF time we
 // can measure between the zero points instead of relying on the start of the
 // waveform being at exactly the OFF phase start.
-void tuner_state::step_off_measure() {
-  switch (burst.poll()) {
-  case burst_status::busy:
-    return;
-  case burst_status::completed:
-    tune_waveform_samples[waveform_sample_idx] = burst.adc_sample;
-    if (++waveform_sample_idx >= waveform_sample_count) {
-      burst.adc_restore();
-      phase = tune_phase::off_analyze;
+void
+tuner_state::step_off_measure() {
+    switch (burst.poll()) {
+    case burst_status::busy:
+        return;
+    case burst_status::completed:
+        tune_waveform_samples[waveform_sample_idx] = burst.adc_sample;
+        if (++waveform_sample_idx >= waveform_sample_count) {
+            burst.adc_restore();
+            phase = tune_phase::off_analyze;
+        }
+        return;
+    case burst_status::ready:
+        // Excite with the found time_on_first and step the CC0 match further
+        // into cycle 0's OFF/resonance each burst.
+        state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
+        tune_set_cc0(waveform_sample_idx * TUNE_SAMPLE_STEP);
+        burst.adc_capture_armed = true;
+        burst.fire(1, 0);
+        return;
     }
-    return;
-  case burst_status::ready:
-    // Excite with the found time_on_first and step the CC0 match further
-    // into cycle 0's OFF/resonance each burst.
-    state.set_drive_ticks(on_first_ticks, on_first_ticks, TUNE_OFF_PROV);
-    tune_set_cc0(waveform_sample_idx * TUNE_SAMPLE_STEP);
-    burst.adc_capture_armed = true;
-    burst.fire(1, 0);
-    return;
-  }
 }
 
 // Analyze captured waveform to find ideal off time.
 // The sampled waveform right now contains (most of) the ON phase, and the
 // entire OFF phase. We need to determine the total duration of the OFF phase.
-void tuner_state::analyze_off() {
-  auto zero_threshold = volts_to_count(TUNE_ZERO_MARGIN_V);
+void
+tuner_state::analyze_off() {
+    auto zero_threshold = volts_to_count(TUNE_ZERO_MARGIN_V);
 
-  // Find the start and end of the OFF phase. Note that the signal rise/fall
-  // is so fast that we don't really need to deal with hysteresis when finding
-  // the edges.
-  int16_t phase_off_start = -1;
-  int16_t phase_off_end = -1;
-  for (uint32_t i = 0; i < waveform_sample_count; i++) {
-    auto sample = tune_waveform_samples[i];
-    if (phase_off_start < 0 && sample >= zero_threshold) {
-      // ON->OFF transition
-      phase_off_start = i;
-    } else if (phase_off_start >= 0 && phase_off_end < 0 &&
-               sample <= zero_threshold) {
-      // OFF->ON transition
-      phase_off_end = i;
-      break;
+    // Find the start and end of the OFF phase. Note that the signal rise/fall
+    // is so fast that we don't really need to deal with hysteresis when finding
+    // the edges.
+    int16_t phase_off_start = -1;
+    int16_t phase_off_end = -1;
+    for (uint32_t i = 0; i < waveform_sample_count; i++) {
+        auto sample = tune_waveform_samples[i];
+        if (phase_off_start < 0 && sample >= zero_threshold) {
+            // ON->OFF transition
+            phase_off_start = i;
+        } else if (phase_off_start >= 0 && phase_off_end < 0 &&
+                   sample <= zero_threshold) {
+            // OFF->ON transition
+            phase_off_end = i;
+            break;
+        }
     }
-  }
 
-  // If we didn't find both start and end, we can't find the OFF time.
-  if (phase_off_start == -1 || phase_off_end == -1) {
-    abort(tune_error::off_no_zero);
-    return;
-  }
+    // If we didn't find both start and end, we can't find the OFF time.
+    if (phase_off_start == -1 || phase_off_end == -1) {
+        abort(tune_error::off_no_zero);
+        return;
+    }
 
-  off_ticks = (phase_off_end - phase_off_start + 1) * TUNE_SAMPLE_STEP;
+    off_ticks = (phase_off_end - phase_off_start + 1) * TUNE_SAMPLE_STEP;
 
-  // If details were requested, enter dump phase.
-  burst.next_fire_time =
-      timer_read_time() + (want_details ? 0 : timer_from_us(TUNE_SETTLE_US));
-  phase = want_details ? tune_phase::off_dump : tune_phase::off_done;
-  output("C %u", want_details);
-  waveform_sample_idx = 0;
+    // If details were requested, enter dump phase.
+    burst.next_fire_time =
+        timer_read_time() + (want_details ? 0 : timer_from_us(TUNE_SETTLE_US));
+    phase = want_details ? tune_phase::off_dump : tune_phase::off_done;
+    output("C %u", want_details);
+    waveform_sample_idx = 0;
 }
 
 // Phase 3: find the steady-state ON time, that is the ON time for any phase
 // after the first one. Ramp the steady state ON time from the time found for
 // the initial ON time until the target is crossed. The starting point was set
 // by the `off_done` phase handler.
-void tuner_state::step_steady_on() {
-  switch (burst.poll()) {
-  case burst_status::busy:
-    return;
-  case burst_status::completed:
-    if (tune_peak_tripped()) {
-      // target peak reached
-      phase = tune_phase::steady_done;
-      return;
+void
+tuner_state::step_steady_on() {
+    switch (burst.poll()) {
+    case burst_status::busy:
+        return;
+    case burst_status::completed:
+        if (tune_peak_tripped()) {
+            // target peak reached
+            phase = tune_phase::steady_done;
+            return;
+        }
+        on_ticks += TUNE_ON_STEP;
+        if (on_ticks > TUNE_ON_MAX) {
+            abort(tune_error::steady_ceiling);
+        }
+        return;
+    case burst_status::ready:
+        state.set_drive_ticks(on_ticks, on_first_ticks, off_ticks);
+        tune_peak_tripped(); // clear target peak latch
+        burst.fire(2, 1);
+        return;
     }
-    on_ticks += TUNE_ON_STEP;
-    if (on_ticks > TUNE_ON_MAX) {
-      abort(tune_error::steady_ceiling);
-    }
-    return;
-  case burst_status::ready:
-    state.set_drive_ticks(on_ticks, on_first_ticks, off_ticks);
-    tune_peak_tripped(); // clear target peak latch
-    burst.fire(2, 1);
-    return;
-  }
 }
 
-void tuner_state::step() {
-  // Guards shared for all tuning phases.
-  if (phase != tune_phase::idle && phase != tune_phase::error) {
-    if (state.overvoltage_count() != ov_count_at_start) {
-      abort(tune_error::overvoltage);
-    } else if (!timer_is_before(timer_read_time(), deadline)) {
-      abort(tune_error::timeout);
+void
+tuner_state::step() {
+    // Guards shared for all tuning phases.
+    if (phase != tune_phase::idle && phase != tune_phase::error) {
+        if (state.overvoltage_count() != ov_count_at_start) {
+            abort(tune_error::overvoltage);
+        } else if (!timer_is_before(timer_read_time(), deadline)) {
+            abort(tune_error::timeout);
+        }
     }
-  }
 
-  switch (phase) {
-  case tune_phase::on_first:
-    step_on_first();
-    break;
+    switch (phase) {
+    case tune_phase::on_first:
+        step_on_first();
+        break;
 
-  case tune_phase::on_first_done:
-    burst.adc_arm(); // Remap ADC to feedback input for off sweep phase
-    waveform_sample_idx = 0;
-    waveform_sample_count = (on_first_ticks + TUNE_OFF_PROV) / TUNE_SAMPLE_STEP;
-    phase = tune_phase::off_measure;
-    break;
+    case tune_phase::on_first_done:
+        burst.adc_arm(); // Remap ADC to feedback input for off sweep phase
+        waveform_sample_idx = 0;
+        waveform_sample_count =
+            (on_first_ticks + TUNE_OFF_PROV) / TUNE_SAMPLE_STEP;
+        phase = tune_phase::off_measure;
+        break;
 
-  case tune_phase::off_measure:
-    step_off_measure();
-    break;
+    case tune_phase::off_measure:
+        step_off_measure();
+        break;
 
-  case tune_phase::off_analyze:
-    analyze_off();
-    break;
+    case tune_phase::off_analyze:
+        analyze_off();
+        break;
 
-  case tune_phase::off_dump:
-    // Stream the reconstructed waveform one sample at a time, so
-    // it can be overlaid on the scope trace to validate the measurement.
-    // Since this is diagnostic only, dropped samples are acceptable.
-    if (timer_is_before(timer_read_time(), burst.next_fire_time))
-      break;
-    if (waveform_sample_idx < waveform_sample_count) {
-      sendf("indx_coil_tune_wave index=%u ns=%u mv=%u", waveform_sample_idx,
-            ticks_to_ns(waveform_sample_idx * TUNE_SAMPLE_STEP),
-            counts_to_mv(tune_waveform_samples[waveform_sample_idx]));
-      waveform_sample_idx++;
-      burst.next_fire_time =
-          timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
-    } else {
-      burst.next_fire_time = timer_read_time();
-      phase = tune_phase::off_done;
+    case tune_phase::off_dump:
+        // Stream the reconstructed waveform one sample at a time, so
+        // it can be overlaid on the scope trace to validate the measurement.
+        // Since this is diagnostic only, dropped samples are acceptable.
+        if (timer_is_before(timer_read_time(), burst.next_fire_time))
+            break;
+        if (waveform_sample_idx < waveform_sample_count) {
+            sendf("indx_coil_tune_wave index=%u ns=%u mv=%u",
+                  waveform_sample_idx,
+                  ticks_to_ns(waveform_sample_idx * TUNE_SAMPLE_STEP),
+                  counts_to_mv(tune_waveform_samples[waveform_sample_idx]));
+            waveform_sample_idx++;
+            burst.next_fire_time =
+                timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+        } else {
+            burst.next_fire_time = timer_read_time();
+            phase = tune_phase::off_done;
+        }
+        break;
+
+    case tune_phase::off_done:
+        // Phase 3: steady state ON time is always >= the initial ON time, so
+        // start from there. Next fire time was set by the previous phase.
+        on_ticks = on_first_ticks;
+        phase = tune_phase::steady_on;
+        break;
+
+    case tune_phase::steady_on:
+        step_steady_on();
+        break;
+
+    case tune_phase::steady_done:
+        finish(tune_status::success);
+        break;
+
+    case tune_phase::error:
+        finish(tune_status::failed);
+        break;
+
+    case tune_phase::idle:
+        break;
     }
-    break;
-
-  case tune_phase::off_done:
-    // Phase 3: steady state ON time is always >= the initial ON time, so
-    // start from there. Next fire time was set by the previous phase.
-    on_ticks = on_first_ticks;
-    phase = tune_phase::steady_on;
-    break;
-
-  case tune_phase::steady_on:
-    step_steady_on();
-    break;
-
-  case tune_phase::steady_done:
-    finish(tune_status::success);
-    break;
-
-  case tune_phase::error:
-    finish(tune_status::failed);
-    break;
-
-  case tune_phase::idle:
-    break;
-  }
 }
 
-void coil_driver::start_tune(bool want_details) {
-  if (tuner.active() || ringdown.active()) {
-    return;
-  }
-  if (state.pending_on_cycles != 0) {
-    shutdown("INDX coil tune requested while heater active");
-  }
-  tuner.start(want_details);
+void
+coil_driver::start_tune(bool want_details) {
+    if (tuner.active() || ringdown.active()) {
+        return;
+    }
+    if (state.pending_on_cycles != 0) {
+        shutdown("INDX coil tune requested while heater active");
+    }
+    tuner.start(want_details);
 }
 
-bool coil_driver::tune_active() { return tuner.active(); }
-
-void coil_driver::tune_step() { tuner.step(); }
-
-void coil_driver::report_tune_status() {
-  sendf("indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
-        (uint32_t)tuner.status, (uint32_t)tuner.error,
-        ticks_to_ns(tuner.on_first_ticks), ticks_to_ns(tuner.off_ticks),
-        ticks_to_ns(tuner.on_ticks));
+bool
+coil_driver::tune_active() {
+    return tuner.active();
 }
 
-void coil_driver::report_params() {
-  uint32_t on = state.on_ticks;
-  uint32_t off = state.period_minus_1 + 1 - on;
-  sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
-        ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
+void
+coil_driver::tune_step() {
+    tuner.step();
+}
+
+void
+coil_driver::report_tune_status() {
+    sendf("indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
+          (uint32_t)tuner.status, (uint32_t)tuner.error,
+          ticks_to_ns(tuner.on_first_ticks), ticks_to_ns(tuner.off_ticks),
+          ticks_to_ns(tuner.on_ticks));
+}
+
+void
+coil_driver::report_params() {
+    uint32_t on = state.on_ticks;
+    uint32_t off = state.period_minus_1 + 1 - on;
+    sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
+          ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
 }
 
 // ---------------------------------------------------------------------------
 // Ringdown nozzle-presence probe
 // ---------------------------------------------------------------------------
 
-void ringdown_state::apply_presence(ringdown_status s) {
-  if (s == ringdown_status::valid) {
-    last_presence = presence;
-  } else if (s != ringdown_status::running) {
-    if (presence == nozzle_presence::present)
-      presence = nozzle_presence::unknown;
-    last_presence = presence;
-  }
+void
+ringdown_state::apply_presence(ringdown_status s) {
+    if (s == ringdown_status::valid) {
+        last_presence = presence;
+    } else if (s != ringdown_status::running) {
+        if (presence == nozzle_presence::present)
+            presence = nozzle_presence::unknown;
+        last_presence = presence;
+    }
 }
 
-void ringdown_state::restore_drive() {
-  if (burst.adc_active)
-    burst.adc_restore();
-  state.set_drive_ticks(saved_on_ticks, saved_on_ticks_first, saved_off_ticks);
-  uint32_t cycles = saved_pending_on_cycles;
-  if (heat_gate_blocks_drive())
-    cycles = 0;
-  state.pending_on_cycles = cycles;
-  bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
-  if (cycles > 0 && idle) {
-    state.arm_timer();
-  }
-}
-
-void ringdown_state::abort(ringdown_status s) {
-  burst.test_active = false;
-  burst.burst_in_flight = false;
-  presence = nozzle_presence::unknown;
-  apply_presence(s);
-  restore_drive();
-  if (phase == ringdown_phase::dump) {
-    finish(s);
-    return;
-  }
-  dump_count =
-      sample_idx < RINGDOWN_N_SAMPLES ? sample_idx : RINGDOWN_N_SAMPLES;
-  schedule_finish_or_dump(s);
-}
-
-void ringdown_state::schedule_finish_or_dump(ringdown_status s) {
-  pending_status = s;
-  if (want_dump) {
-    dump_idx = 0;
-    burst.next_fire_time = timer_read_time();
-    phase = ringdown_phase::dump;
-    return;
-  }
-  finish(s);
-}
-
-void ringdown_state::finish(ringdown_status s) {
-  status = s;
-  apply_presence(s);
-  if (want_report) {
-    sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
-          timer_read_time(), (uint32_t)status, (uint32_t)presence, peak_mv);
-  }
-  next_schedule_time = timer_read_time();
-  phase = ringdown_phase::idle;
-}
-
-uint32_t ringdown_state::excite_on_ticks() {
-  float scale = ringdown_cfg.excite_scale;
-  if (scale < RINGDOWN_EXCITE_SCALE_MIN)
-    scale = RINGDOWN_EXCITE_SCALE_MIN;
-  if (scale > RINGDOWN_EXCITE_SCALE_MAX)
-    scale = RINGDOWN_EXCITE_SCALE_MAX;
-  uint32_t ticks = (uint32_t)(saved_on_ticks_first * scale + 0.5f);
-  if (ticks < 1)
-    ticks = 1;
-  if (saved_on_ticks_first && ticks > saved_on_ticks_first)
-    ticks = saved_on_ticks_first;
-  return ticks;
-}
-
-void ringdown_state::start(bool report, bool dump) {
-  phase = ringdown_phase::pause_wait;
-  status = ringdown_status::running;
-  presence = nozzle_presence::unknown;
-  want_report = report;
-  want_dump = dump;
-  burst.burst_in_flight = false;
-  burst.test_active = false;
-  burst.burst_done = false;
-  burst.adc_capture_armed = false;
-  burst.adc_sample = 0;
-  burst.next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
-  ov_count_at_start = state.overvoltage_count();
-  uint32_t timeout_us = RINGDOWN_TIMEOUT_US;
-  if (dump)
-    timeout_us += RINGDOWN_N_SAMPLES * TUNE_DUMP_INTERVAL_US + 50000;
-  deadline = timer_read_time() + timer_from_us(timeout_us);
-  sample_idx = 0;
-  dump_idx = 0;
-  dump_count = 0;
-  peak_mv = 0;
-  pending_status = ringdown_status::idle;
-  saved_pending_on_cycles = state.pending_on_cycles;
-  saved_on_ticks = state.on_ticks;
-  saved_on_ticks_first = state.on_ticks_first;
-  saved_off_ticks = state.period_minus_1 + 1 - state.on_ticks;
-  state.pending_on_cycles = 0;
-}
-
-void ringdown_state::analyze() {
-  dump_count = RINGDOWN_N_SAMPLES;
-  uint16_t max_counts = 0;
-  for (uint32_t i = 0; i < RINGDOWN_N_SAMPLES; i++) {
-    if (ringdown_samples[i] > max_counts)
-      max_counts = ringdown_samples[i];
-  }
-  peak_mv = counts_to_mv(max_counts);
-  float peak_v = (float)peak_mv / 1000.0f;
-
-  if (peak_v < ringdown_cfg.min_peak_v) {
-    presence = nozzle_presence::unknown;
-    apply_presence(ringdown_status::weak_signal);
-    restore_drive();
-    schedule_finish_or_dump(ringdown_status::weak_signal);
-    return;
-  }
-
-  // Seated loads the coil: lower peak. Empty: higher peak.
-  if (peak_v <= ringdown_cfg.present_peak_v) {
-    presence = nozzle_presence::present;
-  } else if (peak_v >= ringdown_cfg.absent_peak_v) {
-    presence = nozzle_presence::absent;
-  } else {
-    presence = nozzle_presence::unknown;
-  }
-
-  apply_presence(ringdown_status::valid);
-  restore_drive();
-  schedule_finish_or_dump(ringdown_status::valid);
-}
-
-void ringdown_state::step() {
-  if (phase == ringdown_phase::idle)
-    return;
-
-  if (state.overvoltage_count() != ov_count_at_start) {
-    abort(ringdown_status::overvoltage);
-    return;
-  }
-  if (!timer_is_before(timer_read_time(), deadline)) {
-    abort(ringdown_status::timeout);
-    return;
-  }
-
-  uint32_t on_ticks = excite_on_ticks();
-  switch (phase) {
-  case ringdown_phase::pause_wait: {
-    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
-    if (!idle || timer_is_before(timer_read_time(), burst.next_fire_time))
-      return;
-    state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
-    burst.adc_arm();
-    sample_idx = 0;
-    phase = ringdown_phase::sample;
-    return;
-  }
-  case ringdown_phase::sample: {
-    switch (burst.poll()) {
-    case burst_status::busy:
-      return;
-    case burst_status::completed:
-      ringdown_samples[sample_idx] = burst.adc_sample;
-      if (++sample_idx >= RINGDOWN_N_SAMPLES) {
+void
+ringdown_state::restore_drive() {
+    if (burst.adc_active)
         burst.adc_restore();
-        phase = ringdown_phase::analyze;
-      }
-      return;
-    case burst_status::ready:
-      state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
-      tune_set_cc0(sample_idx * RINGDOWN_SAMPLE_STEP);
-      burst.adc_capture_armed = true;
-      burst.fire(1, 0);
-      return;
+    state.set_drive_ticks(saved_on_ticks, saved_on_ticks_first, saved_off_ticks);
+    uint32_t cycles = saved_pending_on_cycles;
+    if (heat_gate_blocks_drive())
+        cycles = 0;
+    state.pending_on_cycles = cycles;
+    bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+    if (cycles > 0 && idle) {
+        state.arm_timer();
     }
-    return;
-  }
-  case ringdown_phase::analyze:
-    analyze();
-    return;
-  case ringdown_phase::dump: {
-    if (timer_is_before(timer_read_time(), burst.next_fire_time))
-      return;
-    if (dump_idx < dump_count) {
-      sendf("indx_ringdown_wave index=%u ns=%u counts=%u mv=%u", dump_idx,
-            ticks_to_ns(dump_idx * RINGDOWN_SAMPLE_STEP),
-            (uint32_t)ringdown_samples[dump_idx],
-            counts_to_mv(ringdown_samples[dump_idx]));
-      dump_idx++;
-      burst.next_fire_time =
-          timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
-      return;
+}
+
+void
+ringdown_state::abort(ringdown_status s) {
+    burst.test_active = false;
+    burst.burst_in_flight = false;
+    presence = nozzle_presence::unknown;
+    apply_presence(s);
+    restore_drive();
+    if (phase == ringdown_phase::dump) {
+        finish(s);
+        return;
     }
-    sendf("indx_ringdown_meta status=%c peak_mv=%u", (uint32_t)pending_status,
-          peak_mv);
-    finish(pending_status);
-    return;
-  }
-  case ringdown_phase::idle:
-    break;
-  }
+    dump_count =
+        sample_idx < RINGDOWN_N_SAMPLES ? sample_idx : RINGDOWN_N_SAMPLES;
+    schedule_finish_or_dump(s);
+}
+
+void
+ringdown_state::schedule_finish_or_dump(ringdown_status s) {
+    pending_status = s;
+    if (want_dump) {
+        dump_idx = 0;
+        burst.next_fire_time = timer_read_time();
+        phase = ringdown_phase::dump;
+        return;
+    }
+    finish(s);
+}
+
+void
+ringdown_state::finish(ringdown_status s) {
+    status = s;
+    apply_presence(s);
+    if (want_report) {
+        sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
+              timer_read_time(), (uint32_t)status, (uint32_t)presence, peak_mv);
+    }
+    next_schedule_time = timer_read_time();
+    phase = ringdown_phase::idle;
+}
+
+uint32_t
+ringdown_state::excite_on_ticks() {
+    float scale = ringdown_cfg.excite_scale;
+    if (scale < RINGDOWN_EXCITE_SCALE_MIN)
+        scale = RINGDOWN_EXCITE_SCALE_MIN;
+    if (scale > RINGDOWN_EXCITE_SCALE_MAX)
+        scale = RINGDOWN_EXCITE_SCALE_MAX;
+    uint32_t ticks = (uint32_t)(saved_on_ticks_first * scale + 0.5f);
+    if (ticks < 1)
+        ticks = 1;
+    if (saved_on_ticks_first && ticks > saved_on_ticks_first)
+        ticks = saved_on_ticks_first;
+    return ticks;
+}
+
+void
+ringdown_state::start(bool report, bool dump) {
+    phase = ringdown_phase::pause_wait;
+    status = ringdown_status::running;
+    presence = nozzle_presence::unknown;
+    want_report = report;
+    want_dump = dump;
+    burst.burst_in_flight = false;
+    burst.test_active = false;
+    burst.burst_done = false;
+    burst.adc_capture_armed = false;
+    burst.adc_sample = 0;
+    burst.next_fire_time = timer_read_time() + timer_from_us(TUNE_SETTLE_US);
+    ov_count_at_start = state.overvoltage_count();
+    uint32_t timeout_us = RINGDOWN_TIMEOUT_US;
+    if (dump)
+        timeout_us += RINGDOWN_N_SAMPLES * TUNE_DUMP_INTERVAL_US + 50000;
+    deadline = timer_read_time() + timer_from_us(timeout_us);
+    sample_idx = 0;
+    dump_idx = 0;
+    dump_count = 0;
+    peak_mv = 0;
+    pending_status = ringdown_status::idle;
+    saved_pending_on_cycles = state.pending_on_cycles;
+    saved_on_ticks = state.on_ticks;
+    saved_on_ticks_first = state.on_ticks_first;
+    saved_off_ticks = state.period_minus_1 + 1 - state.on_ticks;
+    state.pending_on_cycles = 0;
+}
+
+void
+ringdown_state::analyze() {
+    dump_count = RINGDOWN_N_SAMPLES;
+    uint16_t max_counts = 0;
+    for (uint32_t i = 0; i < RINGDOWN_N_SAMPLES; i++) {
+        if (ringdown_samples[i] > max_counts)
+            max_counts = ringdown_samples[i];
+    }
+    peak_mv = counts_to_mv(max_counts);
+    float peak_v = (float)peak_mv / 1000.0f;
+
+    if (peak_v < ringdown_cfg.min_peak_v) {
+        presence = nozzle_presence::unknown;
+        apply_presence(ringdown_status::weak_signal);
+        restore_drive();
+        schedule_finish_or_dump(ringdown_status::weak_signal);
+        return;
+    }
+
+    // Seated loads the coil: lower peak. Empty: higher peak.
+    if (peak_v <= ringdown_cfg.present_peak_v) {
+        presence = nozzle_presence::present;
+    } else if (peak_v >= ringdown_cfg.absent_peak_v) {
+        presence = nozzle_presence::absent;
+    } else {
+        presence = nozzle_presence::unknown;
+    }
+
+    apply_presence(ringdown_status::valid);
+    restore_drive();
+    schedule_finish_or_dump(ringdown_status::valid);
+}
+
+void
+ringdown_state::step() {
+    if (phase == ringdown_phase::idle)
+        return;
+
+    if (state.overvoltage_count() != ov_count_at_start) {
+        abort(ringdown_status::overvoltage);
+        return;
+    }
+    if (!timer_is_before(timer_read_time(), deadline)) {
+        abort(ringdown_status::timeout);
+        return;
+    }
+
+    uint32_t on_ticks = excite_on_ticks();
+    switch (phase) {
+    case ringdown_phase::pause_wait: {
+        bool idle = DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+        if (!idle || timer_is_before(timer_read_time(), burst.next_fire_time))
+            return;
+        state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+        burst.adc_arm();
+        sample_idx = 0;
+        phase = ringdown_phase::sample;
+        return;
+    }
+    case ringdown_phase::sample: {
+        switch (burst.poll()) {
+        case burst_status::busy:
+            return;
+        case burst_status::completed:
+            ringdown_samples[sample_idx] = burst.adc_sample;
+            if (++sample_idx >= RINGDOWN_N_SAMPLES) {
+                burst.adc_restore();
+                phase = ringdown_phase::analyze;
+            }
+            return;
+        case burst_status::ready:
+            state.set_drive_ticks(on_ticks, on_ticks, saved_off_ticks);
+            tune_set_cc0(sample_idx * RINGDOWN_SAMPLE_STEP);
+            burst.adc_capture_armed = true;
+            burst.fire(1, 0);
+            return;
+        }
+        return;
+    }
+    case ringdown_phase::analyze:
+        analyze();
+        return;
+    case ringdown_phase::dump: {
+        if (timer_is_before(timer_read_time(), burst.next_fire_time))
+            return;
+        if (dump_idx < dump_count) {
+            sendf("indx_ringdown_wave index=%u ns=%u counts=%u mv=%u", dump_idx,
+                        ticks_to_ns(dump_idx * RINGDOWN_SAMPLE_STEP),
+                        (uint32_t)ringdown_samples[dump_idx],
+                        counts_to_mv(ringdown_samples[dump_idx]));
+            dump_idx++;
+            burst.next_fire_time =
+                    timer_read_time() + timer_from_us(TUNE_DUMP_INTERVAL_US);
+            return;
+        }
+        sendf("indx_ringdown_meta status=%c peak_mv=%u", (uint32_t)pending_status,
+                    peak_mv);
+        finish(pending_status);
+        return;
+    }
+    case ringdown_phase::idle:
+        break;
+    }
 }
 
 void coil_driver::set_ringdown_params(bool enable, bool heat_gate,
-                                      float present_peak_v, float absent_peak_v,
-                                      uint32_t idle_ms, uint32_t heat_ms,
-                                      float excite_scale, float min_peak_v) {
-  if (excite_scale < RINGDOWN_EXCITE_SCALE_MIN)
-    excite_scale = RINGDOWN_EXCITE_SCALE_MIN;
-  if (excite_scale > RINGDOWN_EXCITE_SCALE_MAX)
-    excite_scale = RINGDOWN_EXCITE_SCALE_MAX;
-  ringdown_cfg.enable = enable;
-  ringdown_cfg.heat_gate = heat_gate;
-  ringdown_cfg.idle_ms = idle_ms ? idle_ms : RINGDOWN_IDLE_MS_DEFAULT;
-  ringdown_cfg.heat_ms = heat_ms ? heat_ms : RINGDOWN_HEAT_MS_DEFAULT;
-  ringdown_cfg.excite_scale = excite_scale;
-  if (min_peak_v < 0.0f)
-    min_peak_v = RINGDOWN_MIN_PEAK_V_DEFAULT;
-  ringdown_cfg.min_peak_v =
-      min_peak_v > 0.0f ? min_peak_v : RINGDOWN_MIN_PEAK_V_DEFAULT;
-  if (present_peak_v < absent_peak_v) {
-    ringdown_cfg.present_peak_v = present_peak_v;
-    ringdown_cfg.absent_peak_v = absent_peak_v;
-  }
-}
-
-void coil_driver::start_ringdown(bool report, bool dump) {
-  if (ringdown.active() || tuner.active())
-    return;
-  if (!state.timings_valid) {
-    last_presence = nozzle_presence::unknown;
-    ringdown.status = ringdown_status::aborted;
-    ringdown.presence = nozzle_presence::unknown;
-    ringdown.peak_mv = 0;
-    if (report) {
-      sendf("indx_nozzle_presence clock=%u status=%c presence=%c "
-            "peak_mv=%u",
-            timer_read_time(), (uint32_t)ringdown_status::aborted,
-            (uint32_t)nozzle_presence::unknown, 0u);
+                                                                            float present_peak_v, float absent_peak_v,
+                                                                            uint32_t idle_ms, uint32_t heat_ms,
+                                                                            float excite_scale, float min_peak_v) {
+    if (excite_scale < RINGDOWN_EXCITE_SCALE_MIN)
+        excite_scale = RINGDOWN_EXCITE_SCALE_MIN;
+    if (excite_scale > RINGDOWN_EXCITE_SCALE_MAX)
+        excite_scale = RINGDOWN_EXCITE_SCALE_MAX;
+    ringdown_cfg.enable = enable;
+    ringdown_cfg.heat_gate = heat_gate;
+    ringdown_cfg.idle_ms = idle_ms ? idle_ms : RINGDOWN_IDLE_MS_DEFAULT;
+    ringdown_cfg.heat_ms = heat_ms ? heat_ms : RINGDOWN_HEAT_MS_DEFAULT;
+    ringdown_cfg.excite_scale = excite_scale;
+    if (min_peak_v < 0.0f)
+        min_peak_v = RINGDOWN_MIN_PEAK_V_DEFAULT;
+    ringdown_cfg.min_peak_v =
+            min_peak_v > 0.0f ? min_peak_v : RINGDOWN_MIN_PEAK_V_DEFAULT;
+    if (present_peak_v < absent_peak_v) {
+        ringdown_cfg.present_peak_v = present_peak_v;
+        ringdown_cfg.absent_peak_v = absent_peak_v;
     }
-    return;
-  }
-  ringdown.start(report, dump);
 }
 
-bool coil_driver::ringdown_active() { return ringdown.active(); }
-
-void coil_driver::ringdown_step(bool heating) {
-  if (ringdown.active()) {
-    ringdown.step();
-    return;
-  }
-  if (!ringdown_cfg.enable || tuner.active() || !state.timings_valid)
-    return;
-  uint32_t period_ms = heating ? ringdown_cfg.heat_ms : ringdown_cfg.idle_ms;
-  uint32_t due = ringdown.next_schedule_time + timer_from_us(period_ms * 1000);
-  if (ringdown.next_schedule_time != 0 &&
-      timer_is_before(timer_read_time(), due))
-    return;
-  start_ringdown(true, false);
+void
+coil_driver::start_ringdown(bool report, bool dump) {
+    if (ringdown.active() || tuner.active())
+        return;
+    if (!state.timings_valid) {
+        last_presence = nozzle_presence::unknown;
+        ringdown.status = ringdown_status::aborted;
+        ringdown.presence = nozzle_presence::unknown;
+        ringdown.peak_mv = 0;
+        if (report) {
+            sendf("indx_nozzle_presence clock=%u status=%c presence=%c "
+                        "peak_mv=%u",
+                        timer_read_time(), (uint32_t)ringdown_status::aborted,
+                        (uint32_t)nozzle_presence::unknown, 0u);
+        }
+        return;
+    }
+    ringdown.start(report, dump);
 }
 
-nozzle_presence coil_driver::get_nozzle_presence() { return last_presence; }
+bool
+coil_driver::ringdown_active() {
+    return ringdown.active();
+}
 
-void coil_driver::report_ringdown_status() {
-  sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
-        timer_read_time(), (uint32_t)ringdown.status,
-        (uint32_t)ringdown.presence, ringdown.peak_mv);
+void
+coil_driver::ringdown_step(bool heating) {
+    if (ringdown.active()) {
+        ringdown.step();
+        return;
+    }
+    if (!ringdown_cfg.enable || tuner.active() || !state.timings_valid)
+        return;
+    uint32_t period_ms = heating ? ringdown_cfg.heat_ms : ringdown_cfg.idle_ms;
+    uint32_t due = ringdown.next_schedule_time + timer_from_us(period_ms * 1000);
+    if (ringdown.next_schedule_time != 0 &&
+            timer_is_before(timer_read_time(), due))
+        return;
+    start_ringdown(true, false);
+}
+
+nozzle_presence
+coil_driver::get_nozzle_presence() {
+    return last_presence;
+}
+
+void
+coil_driver::report_ringdown_status() {
+    sendf("indx_nozzle_presence clock=%u status=%c presence=%c peak_mv=%u",
+                timer_read_time(), (uint32_t)ringdown.status,
+                (uint32_t)ringdown.presence, ringdown.peak_mv);
 }

--- a/src/indx/coil_driver.h
+++ b/src/indx/coil_driver.h
@@ -6,6 +6,23 @@ extern "C" {
 #include <stdint.h>
 }
 
+// Latched outcome of a nozzle-presence ringdown probe.
+enum class ringdown_status : uint8_t {
+    idle = 0,
+    running = 1,
+    valid = 2,
+    weak_signal = 3,
+    aborted = 4,
+    overvoltage = 5,
+    timeout = 6,
+};
+
+enum class nozzle_presence : uint8_t {
+    unknown = 0,
+    present = 1,
+    absent = 2,
+};
+
 struct coil_driver {
     // Maximum number of fired cycles per 512-cycle frame (0 = no limit).
     uint32_t duty_limit{0};
@@ -50,6 +67,41 @@ struct coil_driver {
     // Send the drive timings currently in effect to the host.
     void
     report_params();
+
+    // --- Nozzle presence via ringdown ---
+
+    // Configure continuous probe, heat gate, and amplitude thresholds.
+    // present_peak_v / absent_peak_v / min_peak_v are tank volts (Bondtech:
+    // seated loads the coil so peak is lower; require present < absent).
+    // Periods are milliseconds. excite_scale multiplies soft-start ON ticks
+    // (clamped to <= 1.0 so the pulse cannot exceed coil_time_on_first).
+    // Overvoltage mid-probe always aborts.
+    void
+    set_ringdown_params(bool enable, bool heat_gate, float present_peak_v,
+                        float absent_peak_v, uint32_t idle_ms, uint32_t heat_ms,
+                        float excite_scale, float min_peak_v);
+
+    // Start a oneshot ringdown probe. Fails closed if tune is active or coil
+    // timings are not set. report=true sends indx_nozzle_presence when done.
+    // dump=true streams the capture buffer before the status.
+    void
+    start_ringdown(bool report, bool dump);
+
+    bool
+    ringdown_active();
+
+    // Advance the ringdown state machine; also starts background probes when
+    // enabled. heating=true selects the longer recheck period.
+    void
+    ringdown_step(bool heating);
+
+    // Last presence classification (unknown until a valid probe).
+    nozzle_presence
+    get_nozzle_presence();
+
+    // Send latched ringdown outcome to the host.
+    void
+    report_ringdown_status();
 };
 
 coil_driver

--- a/src/indx/heater.c++
+++ b/src/indx/heater.c++
@@ -60,9 +60,19 @@ indx_heater::run() {
     } else {
         this->state.max_power_cycles = 0;
     }
+    // Background ringdown (when enabled) runs between control updates. Heating
+    // selects the slower recheck cadence so probe energy stays small.
+    this->coil_driver_inst.ringdown_step(output > 0.0f);
     this->coil_driver_inst.set_duty(output);
 
-    this->state.power_sum += output;
+    // Report only power actually applied to the coil. During ringdown the PID
+    // request is latched but drive is paused; summing output would inflate the
+    // host thermal model and trip max_model_error on first heatup.
+    float report_power = output;
+    if (this->coil_driver_inst.ringdown_active()) {
+        report_power = 0.0f;
+    }
+    this->state.power_sum += report_power;
     this->state.updates_since_report += 1;
     if (timer_is_before(this->next_temperature_report, now)) {
         this->report_temperature(now);
@@ -367,6 +377,50 @@ command_indx_query_coil_driver_params(uint32_t *args) {
 DECL_COMMAND(command_indx_query_coil_driver_params,
              "indx_query_coil_driver_params");
 
+// Start a oneshot ringdown nozzle-presence probe.
+// args[0]: dump - stream capture buffer before status report.
+extern "C" void
+command_indx_ringdown_probe(uint32_t *args) {
+    if (!indx_heater_instance)
+        return;
+    bool dump = args[0] != 0;
+    indx_heater_instance->coil_driver_inst.start_ringdown(true, dump);
+}
+DECL_COMMAND(command_indx_ringdown_probe, "indx_ringdown_probe dump=%c");
+
+// Poll latched ringdown outcome (replies indx_nozzle_presence).
+extern "C" void
+command_indx_query_ringdown(uint32_t *args) {
+    (void)args;
+    if (!indx_heater_instance)
+        return;
+    indx_heater_instance->coil_driver_inst.report_ringdown_status();
+}
+DECL_COMMAND(command_indx_query_ringdown, "indx_query_ringdown");
+
+// Configure continuous ringdown + optional heat gate + amplitude knobs.
+// present/absent/min peak volts and excite_scale are float bits; periods in ms.
+extern "C" void
+command_indx_set_ringdown_params(uint32_t *args) {
+    if (!indx_heater_instance)
+        return;
+    bool enable = args[0] != 0;
+    bool heat_gate = args[1] != 0;
+    auto present_peak_v = *reinterpret_cast<float *>(&args[2]);
+    auto absent_peak_v = *reinterpret_cast<float *>(&args[3]);
+    uint32_t idle_ms = args[4];
+    uint32_t heat_ms = args[5];
+    auto excite_scale = *reinterpret_cast<float *>(&args[6]);
+    auto min_peak_v = *reinterpret_cast<float *>(&args[7]);
+    indx_heater_instance->coil_driver_inst.set_ringdown_params(
+        enable, heat_gate, present_peak_v, absent_peak_v, idle_ms, heat_ms,
+        excite_scale, min_peak_v);
+}
+DECL_COMMAND(
+    command_indx_set_ringdown_params,
+    "indx_set_ringdown_params enable=%c heat_gate=%c present_peak_v=%u "
+    "absent_peak_v=%u idle_ms=%u heat_ms=%u excite_scale=%u min_peak_v=%u");
+
 extern "C" void
 command_indx_led_force_color(uint32_t *args) {
     if (!indx_heater_instance)
@@ -431,11 +485,16 @@ indx_heater_task(void) {
         return;
     }
 
-    // Pump the auto-tuner every scheduler pass while it runs, so bounded test
-    // bursts fire back to back. Cheap flag check otherwise.
+    // Pump the auto-tuner / ringdown every scheduler pass while active, so
+    // bounded test bursts fire back to back. Cheap flag check otherwise.
     auto &coil = indx_heater_instance->coil_driver_inst;
-    if (coil.tune_active() && !sched_is_shutdown()) {
-        coil.tune_step();
+    if (!sched_is_shutdown()) {
+        if (coil.tune_active()) {
+            coil.tune_step();
+        }
+        if (coil.ringdown_active()) {
+            coil.ringdown_step(false);
+        }
     }
 
     if (!sched_check_wake(&indx_heater_wake)) {

--- a/test/klippy/indx_ringdown_bad_excite.cfg
+++ b/test/klippy/indx_ringdown_bad_excite.cfg
@@ -1,0 +1,33 @@
+# Test config: ringdown excite_scale cannot exceed 1.0
+[mcu]
+serial: /dev/klipper_main
+
+[mcu indxmcu]
+serial: /dev/klipper_indx
+
+[printer]
+kinematics: none
+max_velocity: 300
+max_accel: 3000
+
+[indx]
+mcu: indxmcu
+ringdown_excite_scale: 1.1
+
+[fan]
+pin: indxmcu:part_cooling
+tachometer_pin: indxmcu:part_cooling_tacho
+
+[extruder]
+step_pin: indxmcu:motor_step
+dir_pin: indxmcu:motor_dir
+enable_pin: !indxmcu:motor_enable
+microsteps: 32
+rotation_distance: 5.7
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+heater_pin: indx:heater
+sensor_type: indx
+control: watermark
+min_temp: 0
+max_temp: 300

--- a/test/klippy/indx_ringdown_bad_peak.cfg
+++ b/test/klippy/indx_ringdown_bad_peak.cfg
@@ -1,0 +1,34 @@
+# Test config: ringdown present_peak_v must be < absent_peak_v
+[mcu]
+serial: /dev/klipper_main
+
+[mcu indxmcu]
+serial: /dev/klipper_indx
+
+[printer]
+kinematics: none
+max_velocity: 300
+max_accel: 3000
+
+[indx]
+mcu: indxmcu
+ringdown_present_peak_v: 95
+ringdown_absent_peak_v: 80
+
+[fan]
+pin: indxmcu:part_cooling
+tachometer_pin: indxmcu:part_cooling_tacho
+
+[extruder]
+step_pin: indxmcu:motor_step
+dir_pin: indxmcu:motor_dir
+enable_pin: !indxmcu:motor_enable
+microsteps: 32
+rotation_distance: 5.7
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+heater_pin: indx:heater
+sensor_type: indx
+control: watermark
+min_temp: 0
+max_temp: 300

--- a/test/klippy/indx_ringdown_limits.test
+++ b/test/klippy/indx_ringdown_limits.test
@@ -1,0 +1,5 @@
+# Ringdown config limits: present_peak_v < absent_peak_v, excite_scale <= 1.0
+DICTIONARY atmega2560.dict indxmcu=bondtech_indx.dict
+SHOULD_FAIL
+CONFIG indx_ringdown_bad_peak.cfg
+CONFIG indx_ringdown_bad_excite.cfg


### PR DESCRIPTION
Add nozzle-presence sensing on the INDX toolboard so Kalico can tell
whether a steel nozzle is coupled to the coil.

A soft coil impulse is classified from first-lobe peak tank voltage
(`present` / `absent` / `unknown`). That is independent of load-cell
latch preload: latch force answers whether the latch is preloaded;
ringdown answers whether steel is in the coil. An unlocked tool that
remains in the coil shows present to ringdown but not to the load
cell. Optional `ringdown_heat_gate` refuses to heat unless presence is
`present`.

Oneshot probe is `INDX_RINGDOWN_PROBE` (optional `DUMP=1` waveform
CSV). Continuous probing and thresholds are set with
`INDX_SET_RINGDOWN_PARAMS` or `[indx]` config. Status fields live on
`printer.indx`. Defaults are off. Bondtech characterisation defaults
(87 V / 91 V at `EXCITE_SCALE=0.8`) are documented in `INDX.md`.
While a ringdown pulse pauses the drive, coil power reported to the
host thermal model is zero so `power_sum` is not inflated.

Empty heads at full soft-start often overvolt, so `EXCITE_SCALE`
defaults to 0.8 and is capped at 1.0. Classification uses peak
amplitude (seated peak is lower than empty on Bondtech). DUMP peak
markers are annotated on the host; they are not a user config and do
not affect presence.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green