### PR TITLE
indx: Dock measurement improvements

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1099,10 +1099,12 @@ draw over DURATION (default 5) seconds and report the total energy
 and average power.
 
 #### INDX_DOCK_MEASURE
-`INDX_DOCK_MEASURE [X_FIRST=[0|1]]`: Measure the dock X/Y position of
-an INDX toolchanger by energizing the XY motors and homing. Set
-X_FIRST=1 to home X before Y. The result is reported and exported in
-the module status.
+`INDX_DOCK_MEASURE [X_FIRST=[0|1]] [RETREAT=X,Y]`: Measure the dock
+X/Y position of an INDX toolchanger by energizing the XY motors and
+homing. Set X_FIRST=1 to home X before Y. The result is reported and
+exported in the module status. RETREAT can optionally be specified,
+in which case the toolhead will perform this move before doing the
+homing operations.
 
 #### INDX_FORCE_BRACKET_TEMP
 `INDX_FORCE_BRACKET_TEMP [TEMP=<temp>]`: Override the sensor bracket

--- a/klippy/extras/indx/toolboard.py
+++ b/klippy/extras/indx/toolboard.py
@@ -157,7 +157,16 @@ class IndxDockMeasurement:
         x_first = gcmd.get_int("X_FIRST", 0, minval=0, maxval=1)
         axes = [0, 1] if x_first else [1, 0]
         try:
-            measurement = self.measure(axes)
+            retreat = [
+                float(v.strip()) for v in gcmd.get("RETREAT", "0,0").split(",")
+            ]
+        except:
+            raise gcmd.error(
+                "Unable to parse RETREAT parameter. Should be of format '<x>,<y>'."
+            )
+        retreat_speed = gcmd.get_float("RETREAT_SPEED", 10.0, above=0.0)
+        try:
+            measurement = self.measure(axes, retreat, retreat_speed)
         except self.printer.command_error:
             self.printer.lookup_object("stepper_enable").motor_off()
             raise
@@ -187,11 +196,19 @@ class IndxDockMeasurement:
         }
         return kin.calc_position(stepper_positions)
 
-    def measure(self, axes):
+    def measure(self, axes, retreat, retreat_speed):
         toolhead = self.printer.lookup_object("toolhead")
         kin = toolhead.get_kinematics()
         self._enable_motors(toolhead, kin)
+
         kinematic_position_before = self._get_kinematic_position(kin)
+
+        if retreat[0] != 0.0 or retreat[1] != 0.0:
+            curpos = toolhead.get_position()
+            toolhead.set_position([0.0, 0.0, curpos[2], curpos[3]], "xy")
+            toolhead.manual_move(retreat, retreat_speed)
+            toolhead.wait_moves()
+            kin.clear_homing_state("xy")
 
         start_position = [0.0, 0.0]
 

--- a/klippy/extras/indx/toolboard.py
+++ b/klippy/extras/indx/toolboard.py
@@ -193,20 +193,20 @@ class IndxDockMeasurement:
         self._enable_motors(toolhead, kin)
         kinematic_position_before = self._get_kinematic_position(kin)
 
-        homing_state = Homing(self.printer)
-        homing_state.set_axes(axes)
-        kin.home(homing_state)
+        start_position = [0.0, 0.0]
 
-        final_position = toolhead.get_position()
-        kinematic_position_after = self._get_kinematic_position(kin)
-        start_position = [
-            final + before - after
-            for final, after, before in zip(
-                final_position[:2],
-                kinematic_position_after[:2],
-                kinematic_position_before[:2],
+        for axis in axes:
+            homing_state = Homing(self.printer)
+            homing_state.set_axes([axis])
+            kin.home(homing_state)
+            final_position = toolhead.get_position()
+            kinematic_position_after = self._get_kinematic_position(kin)
+            start_position[axis] = (
+                final_position[axis]
+                + kinematic_position_before[axis]
+                - kinematic_position_after[axis]
             )
-        ]
+
         measurement = {
             "position": start_position,
             "x": start_position[0],


### PR DESCRIPTION
Improves dock measurement especially when using sensorless homing on the other direction.

Adds a dock retreat option that can be used to move back from the dock before the homing operation is performed.

Fixes for #946.