### PR TITLE
indx: Classify coil presence from OV trips

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1109,8 +1109,7 @@ the module status.
 coil. If the heater already has a target, report the live value from
 temperature reports. If idle, fire one tuned first-cycle burst and
 classify from whether the 100 V overvoltage comparator tripped (a trip
-means the coil is empty). Coil timings must already be set. This is
-not a bed-levelling probe.
+means the coil is empty). Coil timings must already be set.
 
 #### INDX_FORCE_BRACKET_TEMP
 `INDX_FORCE_BRACKET_TEMP [TEMP=<temp>]`: Override the sensor bracket

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1104,6 +1104,14 @@ an INDX toolchanger by energizing the XY motors and homing. Set
 X_FIRST=1 to home X before Y. The result is reported and exported in
 the module status.
 
+#### INDX_COIL_PRESENCE
+`INDX_COIL_PRESENCE`: Sample whether a steel nozzle is in the inductive
+coil. If the heater already has a target, report the live value from
+temperature reports. If idle, fire one tuned first-cycle burst and
+classify from whether the 100 V overvoltage comparator tripped (a trip
+means the coil is empty). Coil timings must already be set. This is
+not a bed-levelling probe.
+
 #### INDX_FORCE_BRACKET_TEMP
 `INDX_FORCE_BRACKET_TEMP [TEMP=<temp>]`: Override the sensor bracket
 temperature reported to the toolboard. Run without TEMP to remove the

--- a/docs/INDX.md
+++ b/docs/INDX.md
@@ -118,5 +118,16 @@ INDX_LOAD_FILAMENT
 Use `INDX_CLEAR_FILAMENT` to reset the filament parameters, and
 `SAVE_CONFIG` to persist any of these values.
 
+## Coil presence
+
+Steel in the coil damps the resonant tank. Tuned drive stays below the
+100 V overvoltage trip; an empty coil overshoots and trips. While the
+heater is running, `printer.indx.inductive_presence` updates from those
+trips on each temperature report.
+
+At idle there is no tank voltage, so run `INDX_COIL_PRESENCE` to fire a
+single burst. The coil must already be tuned. Use
+`inductive_presence_age` to ignore a stale idle reading.
+
 See the [G-Code reference](G-Codes.md#indx) for the full list of INDX
 commands and their parameters.

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -348,6 +348,11 @@ The following information is available in the
 - `last_dock_measurement`: The result of the last INDX_DOCK_MEASURE
   command (None if no measurement has been taken). It is a dictionary
   containing the keys `x`, `y`, `position` and `axis_order`.
+- `inductive_presence`: Whether a steel nozzle is coupled to the coil
+  (`present`, `absent`, or `unknown`). Updated from overvoltage trip
+  counts while the coil is driven, and by INDX_COIL_PRESENCE when idle.
+- `inductive_presence_age`: Seconds since the last presence update, or
+  None if presence is unknown.
 
 ## led
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -310,6 +310,9 @@ class IndxToolboardHeater:
         self.last_report = None
         self.power_scale = 0
         self.heaters = []
+        self.inductive_presence = "unknown"
+        self.inductive_presence_time = None
+        self._ov_count = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
         gcode.register_command("INDX_SET_PID", self.cmd_SET_PID)
@@ -532,6 +535,9 @@ class IndxToolboardHeater:
             self.thermal_model.force_temp(nozzle_temp)
 
         charge = params["charge"]
+        self._update_inductive_presence_from_report(
+            params["overvoltage"], power, charge
+        )
         if self.last_report is not None:
             delta_time = time - self.last_report[0]
             delta_charge = charge - self.last_report[1]
@@ -618,6 +624,40 @@ class IndxToolboardHeater:
                     * (delta_time or 0.0),
                 )
             )
+
+    def get_inductive_presence(self, eventtime):
+        if self.inductive_presence == "unknown":
+            return "unknown", None
+        return (
+            self.inductive_presence,
+            eventtime - self.inductive_presence_time,
+        )
+
+    def _set_inductive_presence(self, value):
+        self.inductive_presence = value
+        self.inductive_presence_time = (
+            self.toolboard.printer.get_reactor().monotonic()
+        )
+
+    def _update_inductive_presence_from_report(self, ov_count, power, charge):
+        # First report, or MCU count reset: store the count and leave
+        # presence unchanged (unknown until the coil has been driven).
+        if self._ov_count is None or ov_count < self._ov_count:
+            self._ov_count = ov_count
+            return
+        tripped = ov_count != self._ov_count
+        self._ov_count = ov_count
+        if tripped:
+            self._set_inductive_presence("absent")
+            return
+        driven = power > 0.0
+        if not driven and self.last_report is not None:
+            delta_charge = charge - self.last_report[1]
+            if delta_charge < 0:
+                delta_charge += 2**32
+            driven = delta_charge > 0
+        if driven:
+            self._set_inductive_presence("present")
 
     def handle_vin_mon(self, _read_time, read_value):
         vin = read_value * 3.3 * (4700 + 60400) / 4700

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import logging
 import math
 import struct
 from collections import namedtuple
+from enum import Enum
 from time import strftime
+from typing import Literal, TypeAlias
 
 from ..thermistor import CustomThermistor
 from . import calibration, compat
@@ -52,14 +56,21 @@ NozzleTemperature = namedtuple(
 )
 
 
+class InductivePresence(str, Enum):
+    UNKNOWN = "unknown"
+    PRESENT = "present"
+    ABSENT = "absent"
+
+
+InductivePresenceValue: TypeAlias = Literal["unknown", "present", "absent"]
+
+
 def float_to_u32(val):
     return int(struct.unpack("!i", struct.pack("!f", val))[0])
 
 
 class IndxThermistorWrapper:
-    def __init__(
-        self, toolboard, sensor, config, def_max_temp, thermistor_config
-    ):
+    def __init__(self, toolboard, sensor, config, def_max_temp, thermistor_config):
         self.toolboard = toolboard
         self.temperature_callbacks = []
 
@@ -111,9 +122,7 @@ class IndxBracketTempSensor:
         self.force_temp = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
-        gcode.register_command(
-            "INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP
-        )
+        gcode.register_command("INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP)
 
     def build_config(self):
         self.cmd_set_ambient_temp = self.toolboard.mcu.lookup_command(
@@ -178,9 +187,7 @@ class IndxToolboardHeater:
         self.vin_adc = toolboard.mcu.setup_pin("adc", {"pin": "vin_mon"})
         compat.register_adc_callback(self.vin_adc, self.handle_vin_mon)
         query_adc = toolboard.printer.load_object(config, "query_adc")
-        query_adc.register_adc(
-            f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc
-        )
+        query_adc.register_adc(f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc)
         self.supply_voltage = 24.0
 
         # The autotuned thermal-model parameters have no defaults.
@@ -193,26 +200,18 @@ class IndxToolboardHeater:
             thermal_capacity=config.getfloat(
                 "model_thermal_capacity", default=None, above=0.0
             ),
-            to_ambient_r=config.getfloat(
-                "model_to_ambient_r", default=None, above=0.0
-            ),
+            to_ambient_r=config.getfloat("model_to_ambient_r", default=None, above=0.0),
             filament_radius=config.getfloat(
                 "model_filament_diameter",
                 default=1.75,
             )
             / 2.0,
-            filament_density=config.getfloat(
-                "model_filament_density", default=1.20
-            ),
+            filament_density=config.getfloat("model_filament_density", default=1.20),
             filament_heat_capacity=config.getfloat(
                 "model_filament_heat_capacity", default=1.8
             ),
-            part_cooling_fan_a=config.getfloat(
-                "model_part_cooling_fan_a", default=0.0
-            ),
-            part_cooling_fan_k=config.getfloat(
-                "model_part_cooling_fan_k", default=0.0
-            ),
+            part_cooling_fan_a=config.getfloat("model_part_cooling_fan_a", default=0.0),
+            part_cooling_fan_k=config.getfloat("model_part_cooling_fan_k", default=0.0),
             ambient_blend_board=config.getfloat(
                 "model_ambient_blend_board", default=0.0
             ),
@@ -222,9 +221,7 @@ class IndxToolboardHeater:
             ambient_blend_sensor=config.getfloat(
                 "model_ambient_blend_sensor", default=1.0
             ),
-            error_application=config.getfloat(
-                "model_error_application", default=1.0
-            ),
+            error_application=config.getfloat("model_error_application", default=1.0),
         )
         self.thermal_model = ThermalModel(model_params)
         self.max_model_error = config.getfloat("max_model_error", default=50.0)
@@ -232,18 +229,14 @@ class IndxToolboardHeater:
         self.pid_kp = config.getfloat("pid_kp", default=4.0)
         self.pid_ti = config.getfloat("pid_ti", minval=0.0, default=0.0)
         self.pid_td = config.getfloat("pid_td", minval=0.0, default=0.0)
-        self.pid_b = config.getfloat(
-            "pid_b", minval=0.0, maxval=1.0, default=1.0
-        )
+        self.pid_b = config.getfloat("pid_b", minval=0.0, maxval=1.0, default=1.0)
         self.max_temp_nozzle = config.getfloat("max_temp_nozzle", default=305.0)
         self.max_temp_sensor = config.getfloat("max_temp_sensor", default=130.0)
 
         self.ir_sensor_tuning = None
         ir_sensor_exponent = config.getfloat("ir_sensor_exponent", default=None)
         ir_sensor_obj_gain = config.getfloat("ir_sensor_obj_gain", default=None)
-        ir_sensor_bracket_gain = config.getfloat(
-            "ir_sensor_bracket_gain", default=None
-        )
+        ir_sensor_bracket_gain = config.getfloat("ir_sensor_bracket_gain", default=None)
         tuning = (
             ir_sensor_exponent,
             ir_sensor_obj_gain,
@@ -260,23 +253,15 @@ class IndxToolboardHeater:
         # heating can't be done, but we allow not setting them so the user can run the
         # tuning routine. These are specified in microseconds by the user.
         coil_timings = (
-            config.getfloat(
-                "coil_time_on", default=None, above=0.0, below=10.0
-            ),
-            config.getfloat(
-                "coil_time_off", default=None, above=0.0, below=10.0
-            ),
-            config.getfloat(
-                "coil_time_on_first", default=None, above=0.0, below=10.0
-            ),
+            config.getfloat("coil_time_on", default=None, above=0.0, below=10.0),
+            config.getfloat("coil_time_off", default=None, above=0.0, below=10.0),
+            config.getfloat("coil_time_on_first", default=None, above=0.0, below=10.0),
         )
         self.coil_timings = None
         if all(coil_timings):
             t_on, t_off, t_on_first = coil_timings
             if t_on_first > t_on:
-                raise config.error(
-                    "coil_time_on_first must not exceed coil_time_on"
-                )
+                raise config.error("coil_time_on_first must not exceed coil_time_on")
             # microseconds -> seconds for the MCU
             self.coil_timings = (t_on * 1e-6, t_off * 1e-6, t_on_first * 1e-6)
         elif any(coil_timings):
@@ -292,12 +277,8 @@ class IndxToolboardHeater:
             if fan_obj is None:
                 fan_obj = toolboard.printer.lookup_object(fan_name)
             if fan_obj is None:
-                raise config.error(
-                    f"Unknown cooling_fan '{fan_name}' specified"
-                )
-            if not hasattr(fan_obj, "fan") or not hasattr(
-                fan_obj.fan, "set_speed"
-            ):
+                raise config.error(f"Unknown cooling_fan '{fan_name}' specified")
+            if not hasattr(fan_obj, "fan") or not hasattr(fan_obj.fan, "set_speed"):
                 raise config.error(
                     f"cooling_fan '{fan_name}' is not a valid fan object"
                 )
@@ -314,7 +295,7 @@ class IndxToolboardHeater:
         self.last_report = None
         self.power_scale = 0
         self.heaters = []
-        self.inductive_presence = "unknown"
+        self.inductive_presence = InductivePresence.UNKNOWN
         self.inductive_presence_time = None
         self._ov_count = None
         self.coil_presence_cmd = None
@@ -332,12 +313,8 @@ class IndxToolboardHeater:
         gcode.register_command("INDX_LOAD_FILAMENT", self.cmd_LOAD_FILAMENT)
         gcode.register_command("INDX_CLEAR_FILAMENT", self.cmd_CLEAR_FILAMENT)
         gcode.register_command("INDX_EXTRUDER_MOVE", self.cmd_EXTRUDER_MOVE)
-        gcode.register_command(
-            "INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS
-        )
-        gcode.register_command(
-            "INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE
-        )
+        gcode.register_command("INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS)
+        gcode.register_command("INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE)
         gcode.register_command(
             "INDX_COIL_PRESENCE",
             self.cmd_COIL_PRESENCE,
@@ -396,9 +373,7 @@ class IndxToolboardHeater:
                 "indx_coil_presence_result status=%c tripped=%c",
                 cq=self.cmd_queue,
             )
-        amp_per_count = mcu.get_constant_float(
-            "INDX_CURRENT_SENSE_AMP_PER_COUNT"
-        )
+        amp_per_count = mcu.get_constant_float("INDX_CURRENT_SENSE_AMP_PER_COUNT")
         current_sense_rate = mcu.get_constant_float("INDX_CURRENT_SENSE_RATE")
         self.power_scale = amp_per_count / current_sense_rate
 
@@ -494,11 +469,7 @@ class IndxToolboardHeater:
     def cur_target_temp(self):
         time = self.toolboard.printer.get_reactor().monotonic()
         return next(
-            (
-                h.get_temp(time)[1]
-                for h in self.heaters
-                if h.get_temp(time)[1] != 0.0
-            ),
+            (h.get_temp(time)[1] for h in self.heaters if h.get_temp(time)[1] != 0.0),
             None,
         )
 
@@ -517,9 +488,7 @@ class IndxToolboardHeater:
     def fan_speed(self, time):
         if self.part_cooling_fan is None:
             return 0.0
-        return max(
-            0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"])
-        )
+        return max(0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"]))
 
     def _blend_ambient_temp(self, sensor_temp):
         # Weighted blend of the board/bracket thermistors and the IR sensor's
@@ -557,9 +526,7 @@ class IndxToolboardHeater:
             self.thermal_model.force_temp(nozzle_temp)
 
         charge = params["charge"]
-        self._update_inductive_presence_from_report(
-            params["overvoltage"], power
-        )
+        self._update_inductive_presence_from_report(params["overvoltage"], power)
         if self.last_report is not None:
             delta_time = time - self.last_report[0]
             delta_charge = charge - self.last_report[1]
@@ -594,9 +561,7 @@ class IndxToolboardHeater:
                 # because the user isn't allowed to start heating when no thermal
                 # model is set. We need this check to allow the tuner to work.
                 if self.thermal_model.is_valid():
-                    filament_distance = max(
-                        0.0, extruder_pos - self.last_report[3]
-                    )
+                    filament_distance = max(0.0, extruder_pos - self.last_report[3])
                     fan_speed = self.fan_speed(time)
 
                     ambient_temp = self._blend_ambient_temp(sensor_temp)
@@ -647,19 +612,19 @@ class IndxToolboardHeater:
                 )
             )
 
-    def get_inductive_presence(self, eventtime):
-        if self.inductive_presence == "unknown":
-            return "unknown", None
-        return (
-            self.inductive_presence,
-            eventtime - self.inductive_presence_time,
+    def get_inductive_presence(
+        self, eventtime
+    ) -> tuple[InductivePresenceValue, float | None]:
+        time_since_entry = (
+            eventtime - self.inductive_presence_time
+            if self.inductive_presence_time is not None
+            else None
         )
+        return self.inductive_presence.value, time_since_entry
 
     def _set_inductive_presence(self, value):
-        self.inductive_presence = value
-        self.inductive_presence_time = (
-            self.toolboard.printer.get_reactor().monotonic()
-        )
+        self.inductive_presence = InductivePresence(value)
+        self.inductive_presence_time = self.toolboard.printer.get_reactor().monotonic()
 
     def _update_inductive_presence_from_report(self, ov_count, power):
         # First report, or MCU count reset: store the count and leave
@@ -670,10 +635,10 @@ class IndxToolboardHeater:
         tripped = ov_count != self._ov_count
         self._ov_count = ov_count
         if tripped:
-            self._set_inductive_presence("absent")
+            self._set_inductive_presence(InductivePresence.ABSENT)
             return
         if power > 0.0:
-            self._set_inductive_presence("present")
+            self._set_inductive_presence(InductivePresence.PRESENT)
 
     def handle_vin_mon(self, _read_time, read_value):
         vin = read_value * 3.3 * (4700 + 60400) / 4700
@@ -818,9 +783,7 @@ class IndxToolboardHeater:
         (t_on, t_off, t_on_first) = self.coil_timings
         configfile.set(section, "coil_time_on", "%.3f" % (t_on * 1e6))
         configfile.set(section, "coil_time_off", "%.3f" % (t_off * 1e6))
-        configfile.set(
-            section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6)
-        )
+        configfile.set(section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6))
 
     def _toggle_steppers(self, toolhead, ets, enable):
         # Enable/disable a set of EnableTracking lines with proper toolhead
@@ -846,9 +809,7 @@ class IndxToolboardHeater:
                 return
             if reactor.monotonic() > deadline:
                 raise gcmd.error(timeout_msg)
-            reactor.pause(
-                reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL
-            )
+            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL)
 
     def _wait_cooldown(self, gcmd, min_temp):
         # Block until the nozzle has cooled below min_temp (the heater must
@@ -873,9 +834,7 @@ class IndxToolboardHeater:
                 "INDX: no temperature reports received",
             )
             if last_temp[0] > min_temp:
-                gcmd.respond_info(
-                    "INDX: cooling below %.0f C before tuning" % min_temp
-                )
+                gcmd.respond_info("INDX: cooling below %.0f C before tuning" % min_temp)
                 self._model_cal_wait_temp(
                     reactor,
                     gcmd,
@@ -990,9 +949,7 @@ class IndxToolboardHeater:
             # Baseline (heater off) draw to subtract from measured power.
             phase[0] = "baseline"
             gcmd.respond_info("INDX: measuring baseline power")
-            reactor.pause(
-                reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME
-            )
+            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME)
             baseline_power = calibration.mean_phase_power(samples, "baseline")
             if baseline_power is None:
                 raise gcmd.error("INDX: no baseline power samples received")
@@ -1000,8 +957,7 @@ class IndxToolboardHeater:
             # Heatup to MAX_TEMP.
             phase[0] = "heat"
             gcmd.respond_info(
-                "INDX: heating to %.0f C (baseline %.2f W)"
-                % (max_temp, baseline_power)
+                "INDX: heating to %.0f C (baseline %.2f W)" % (max_temp, baseline_power)
             )
             self.heater_raw_set_temp(max_temp)
             self._model_cal_wait_temp(
@@ -1023,9 +979,7 @@ class IndxToolboardHeater:
             self.heater.set_temp(0.0)
             if cooldown_time > 0.0:
                 phase[0] = "cooldown"
-                gcmd.respond_info(
-                    "INDX: measuring cooldown for %.0f s" % cooldown_time
-                )
+                gcmd.respond_info("INDX: measuring cooldown for %.0f s" % cooldown_time)
                 reactor.pause(reactor.monotonic() + cooldown_time)
 
             self.temperature_callbacks.remove(sampler)
@@ -1052,9 +1006,7 @@ class IndxToolboardHeater:
             self._toggle_steppers(toolhead, reenable, True)
 
         if result.get("error"):
-            raise gcmd.error(
-                "INDX thermal model fit failed: %s" % result["error"]
-            )
+            raise gcmd.error("INDX thermal model fit failed: %s" % result["error"])
         self._apply_model_calibration(gcmd, result)
 
     def _apply_model_calibration(self, gcmd, result):
@@ -1110,16 +1062,13 @@ class IndxToolboardHeater:
                 % (p_lo, t_min, p_hi, t_max, -drop_pct)
             )
         lines.append(
-            "thermal_capacity: "
-            + fmt(capacity, result["thermal_capacity_ci"], "J/K")
+            "thermal_capacity: " + fmt(capacity, result["thermal_capacity_ci"], "J/K")
         )
         lines.append(
-            "to_ambient_r: "
-            + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
+            "to_ambient_r: " + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
         )
         lines.append(
-            "fit RMS error: %.2f C over %d samples"
-            % (result["rms"], result["n_fit"])
+            "fit RMS error: %.2f C over %d samples" % (result["rms"], result["n_fit"])
         )
         gcmd.respond_info("INDX thermal model calibrated:\n" + "\n".join(lines))
 
@@ -1129,9 +1078,7 @@ class IndxToolboardHeater:
         if self.part_cooling_fan is None:
             raise gcmd.error("INDX part cooling fan is not configured")
 
-        breaks = gcmd.get_int(
-            "BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3
-        )
+        breaks = gcmd.get_int("BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3)
         hold_time = gcmd.get_float(
             "HOLD_TIME", calibration.FAN_CAL_HOLD_TIME_DEFAULT, above=0.0
         )
@@ -1185,9 +1132,7 @@ class IndxToolboardHeater:
             self.temperature_callbacks.append(sampler)
             installed = True
             self.heater_raw_set_temp(target)
-            gcmd.respond_info(
-                "INDX: waiting for %.0f C for fan calibration" % target
-            )
+            gcmd.respond_info("INDX: waiting for %.0f C for fan calibration" % target)
             self._model_cal_wait_temp(
                 reactor,
                 gcmd,
@@ -1283,9 +1228,7 @@ class IndxToolboardHeater:
             self.temperature_callbacks.remove(cb)
 
         if totals[0] == 0:
-            raise gcmd.error(
-                "No power meansurements received over entire duration"
-            )
+            raise gcmd.error("No power meansurements received over entire duration")
 
         power = totals[1] / totals[0]
         gcmd.respond_info(
@@ -1316,27 +1259,19 @@ class IndxToolboardHeater:
             )
 
         speed = gcmd.get_float("SPEED", FILAMENT_LOAD_SPEED, above=0.0)
-        max_length = gcmd.get_float(
-            "MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0
-        )
-        prime_time = gcmd.get_float(
-            "PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0
-        )
+        max_length = gcmd.get_float("MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0)
+        prime_time = gcmd.get_float("PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0)
         prime_length = gcmd.get_float("PRIME_LENGTH", None, above=0.0)
         if prime_length is None:
             prime_length = speed * prime_time
-        threshold = gcmd.get_float(
-            "THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0
-        )
+        threshold = gcmd.get_float("THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0)
         segment_time = gcmd.get_float(
             "SEGMENT_TIME", FILAMENT_LOAD_SEGMENT_TIME, above=0.0
         )
         apply_result = gcmd.get_int("APPLY", 1, minval=0, maxval=1)
 
         params = self.thermal_model.params
-        filament_area = (
-            params.filament_radius * params.filament_radius * math.pi
-        )
+        filament_area = params.filament_radius * params.filament_radius * math.pi
         last_temp = last_pos = start_pos = loaded_at_pos = None
         load_energy = loaded_energy = loaded_denominator = 0.0
         loaded = False
@@ -1358,9 +1293,7 @@ class IndxToolboardHeater:
                 return
             dt = reading.delta_time
             ambient = self._blend_ambient_temp(reading.sensor_temperature)
-            loss_ambient = (
-                reading.nozzle_temperature - ambient
-            ) / params.to_ambient_r
+            loss_ambient = (reading.nozzle_temperature - ambient) / params.to_ambient_r
             loss_part_cooling = 0.0
             fan_speed = self.fan_speed(reading.time)
             if fan_speed > 0.0:
@@ -1372,9 +1305,7 @@ class IndxToolboardHeater:
                         0.0,
                         (reading.nozzle_temperature - ambient) / pcf_ambient_r,
                     )
-            stored = params.thermal_capacity * (
-                reading.nozzle_temperature - last_temp
-            )
+            stored = params.thermal_capacity * (reading.nozzle_temperature - last_temp)
             loss = (loss_ambient + loss_part_cooling) * dt
             residual = reading.delta_pwm_energy - loss - stored
             load_energy = max(0.0, load_energy + residual)
@@ -1382,9 +1313,7 @@ class IndxToolboardHeater:
             temp_delta = max(0.0, reading.nozzle_temperature - ambient)
             if loaded:
                 loaded_energy += max(0.0, residual)
-                loaded_denominator += (
-                    pos_delta * filament_area / 1000.0 * temp_delta
-                )
+                loaded_denominator += pos_delta * filament_area / 1000.0 * temp_delta
             elif load_energy >= threshold:
                 loaded = True
                 loaded_at_pos = pos
@@ -1447,9 +1376,11 @@ class IndxToolboardHeater:
                 loaded_at_pos - start_pos,
                 last_pos - loaded_at_pos,
                 heat_capacity,
-                "Run SAVE_CONFIG to save the new filament parameters."
-                if apply_result
-                else "Use APPLY=1 to apply the measured filament parameters.",
+                (
+                    "Run SAVE_CONFIG to save the new filament parameters."
+                    if apply_result
+                    else "Use APPLY=1 to apply the measured filament parameters."
+                ),
             )
         )
 
@@ -1462,9 +1393,7 @@ class IndxToolboardHeater:
         section = self.toolboard.name
         configfile.set(section, "model_filament_density", "0.0000")
         configfile.set(section, "model_filament_heat_capacity", "0.0000")
-        gcmd.respond_info(
-            "INDX filament model cleared. Run SAVE_CONFIG to save."
-        )
+        gcmd.respond_info("INDX filament model cleared. Run SAVE_CONFIG to save.")
 
     def cmd_EXTRUDER_MOVE(self, gcmd):
         distance = gcmd.get_float("DISTANCE")
@@ -1480,13 +1409,9 @@ class IndxToolboardHeater:
         stepper = extruder.extruder_stepper.stepper
         current_helper = compat.get_tmc_current_helper(stepper)
         if current_helper is None:
-            raise gcmd.error(
-                "Active extruder does not have a TMC current helper"
-            )
+            raise gcmd.error("Active extruder does not have a TMC current helper")
 
-        run_current, hold_current, req_hold_current, *_ = (
-            current_helper.get_current()
-        )
+        run_current, hold_current, req_hold_current, *_ = current_helper.get_current()
         current = min(current, run_current)
         restore_hold_current = (
             req_hold_current if req_hold_current is not None else hold_current
@@ -1507,16 +1432,12 @@ class IndxToolboardHeater:
             toolhead.wait_moves()
         finally:
             print_time = toolhead.get_last_move_time()
-            current_helper.set_current(
-                run_current, restore_hold_current, print_time
-            )
+            current_helper.set_current(run_current, restore_hold_current, print_time)
 
     def cmd_SET_MODEL_PARAMS(self, gcmd):
         cur = self.thermal_model.params
 
-        max_power = gcmd.get_float(
-            "MAX_POWER", default=cur.max_power, minval=0.0
-        )
+        max_power = gcmd.get_float("MAX_POWER", default=cur.max_power, minval=0.0)
         max_power_temp_coeff = gcmd.get_float(
             "MAX_POWER_TEMP_COEFF", default=cur.max_power_temp_coeff
         )
@@ -1591,9 +1512,7 @@ class IndxToolboardHeater:
         else:
             gcmd.respond_info("Thermal model has not yet run")
 
-    cmd_COIL_PRESENCE_help = (
-        "Sample whether a steel nozzle is coupled to the INDX coil"
-    )
+    cmd_COIL_PRESENCE_help = "Sample whether a steel nozzle is coupled to the INDX coil"
 
     def cmd_COIL_PRESENCE(self, gcmd):
         reactor = self.toolboard.printer.get_reactor()
@@ -1604,13 +1523,8 @@ class IndxToolboardHeater:
             )
             return
         if self.coil_timings is None:
-            raise gcmd.error(
-                "INDX coil timings are not set. Run INDX_CALIBRATE first."
-            )
-        if (
-            self.coil_presence_cmd is None
-            or self.query_coil_presence_cmd is None
-        ):
+            raise gcmd.error("INDX coil timings are not set. Run INDX_CALIBRATE first.")
+        if self.coil_presence_cmd is None or self.query_coil_presence_cmd is None:
             raise gcmd.error(
                 "INDX toolboard firmware does not support coil presence. "
                 "Flash the toolboard."
@@ -1631,16 +1545,16 @@ class IndxToolboardHeater:
                 "(coil busy, tune active, or timings not set)"
             )
         if result["tripped"]:
-            self._set_inductive_presence("absent")
+            self._set_inductive_presence(InductivePresence.ABSENT)
         else:
-            self._set_inductive_presence("present")
+            self._set_inductive_presence(InductivePresence.PRESENT)
         presence, age = self.get_inductive_presence(reactor.monotonic())
         gcmd.respond_info(
             self._format_coil_presence(presence, age, heater_active=False)
         )
 
     def _format_coil_presence(self, presence, age, heater_active):
-        if presence == "unknown" or age is None:
+        if presence == InductivePresence.UNKNOWN or age is None:
             msg = "INDX coil presence: unknown"
         else:
             msg = "INDX coil presence: %s (age %.3fs)" % (presence, age)
@@ -1664,9 +1578,7 @@ class IndxToolboardHeater:
         )
         res = cmd.send([])
         print(res)
-        gcmd.respond_info(
-            "".join(hex(c)[2:].ljust(2, "0") for c in res["data"])
-        )
+        gcmd.respond_info("".join(hex(c)[2:].ljust(2, "0") for c in res["data"]))
 
     def cmd_DEBUG_STREAM_RAW_IR_SENSOR(self, gcmd):
         if self.raw_ir_log_file is not None:
@@ -1689,9 +1601,11 @@ class IndxToolboardHeater:
         path = "/tmp/indx_raw_ir_%s.csv" % strftime("%Y%m%d_%H%M%S")
         self.raw_ir_log_file = open(path, "w")
         names = [
-            n[len("temperature_sensor ") :]
-            if n.startswith("temperature_sensor ")
-            else n
+            (
+                n[len("temperature_sensor ") :]
+                if n.startswith("temperature_sensor ")
+                else n
+            )
             for n in self.raw_ir_log_sensors
         ]
         header = ["time", "raw_object", "raw_ambient"] + names
@@ -1713,9 +1627,7 @@ class IndxToolboardHeater:
             try:
                 cols.append(
                     "%.2f"
-                    % printer.lookup_object(name).get_status(eventtime)[
-                        "temperature"
-                    ]
+                    % printer.lookup_object(name).get_status(eventtime)["temperature"]
                 )
             except Exception as e:
                 cols.append("")
@@ -1839,18 +1751,14 @@ class ThermalModel:
                     0.0, (self.temperature - ambient_temp) / pcf_ambient_r
                 )
 
-        loss_ambient = (
-            self.temperature - ambient_temp
-        ) / self.params.to_ambient_r
+        loss_ambient = (self.temperature - ambient_temp) / self.params.to_ambient_r
         loss_filament = (
             filament_distance
             * filament_heat_capacity_mm
             * (self.temperature - filament_temp)
             / dt
         )
-        total_power = (
-            avg_input_power - loss_ambient - loss_filament - loss_part_cooling
-        )
+        total_power = avg_input_power - loss_ambient - loss_filament - loss_part_cooling
         delta_temp_rate = total_power / self.params.thermal_capacity
         new_temp = self.temperature + delta_temp_rate * dt
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -558,7 +558,7 @@ class IndxToolboardHeater:
 
         charge = params["charge"]
         self._update_inductive_presence_from_report(
-            params["overvoltage"], power, charge
+            params["overvoltage"], power
         )
         if self.last_report is not None:
             delta_time = time - self.last_report[0]
@@ -661,7 +661,7 @@ class IndxToolboardHeater:
             self.toolboard.printer.get_reactor().monotonic()
         )
 
-    def _update_inductive_presence_from_report(self, ov_count, power, charge):
+    def _update_inductive_presence_from_report(self, ov_count, power):
         # First report, or MCU count reset: store the count and leave
         # presence unchanged (unknown until the coil has been driven).
         if self._ov_count is None or ov_count < self._ov_count:
@@ -672,13 +672,7 @@ class IndxToolboardHeater:
         if tripped:
             self._set_inductive_presence("absent")
             return
-        driven = power > 0.0
-        if not driven and self.last_report is not None:
-            delta_charge = charge - self.last_report[1]
-            if delta_charge < 0:
-                delta_charge += 2**32
-            driven = delta_charge > 0
-        if driven:
+        if power > 0.0:
             self._set_inductive_presence("present")
 
     def handle_vin_mon(self, _read_time, read_value):

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -6,7 +6,6 @@ import struct
 from collections import namedtuple
 from enum import Enum
 from time import strftime
-from typing import Literal, TypeAlias
 
 from ..thermistor import CustomThermistor
 from . import calibration, compat
@@ -62,15 +61,14 @@ class InductivePresence(str, Enum):
     ABSENT = "absent"
 
 
-InductivePresenceValue: TypeAlias = Literal["unknown", "present", "absent"]
-
-
 def float_to_u32(val):
     return int(struct.unpack("!i", struct.pack("!f", val))[0])
 
 
 class IndxThermistorWrapper:
-    def __init__(self, toolboard, sensor, config, def_max_temp, thermistor_config):
+    def __init__(
+        self, toolboard, sensor, config, def_max_temp, thermistor_config
+    ):
         self.toolboard = toolboard
         self.temperature_callbacks = []
 
@@ -122,7 +120,9 @@ class IndxBracketTempSensor:
         self.force_temp = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
-        gcode.register_command("INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP)
+        gcode.register_command(
+            "INDX_FORCE_BRACKET_TEMP", self.cmd_FORCE_BRACKET_TEMP
+        )
 
     def build_config(self):
         self.cmd_set_ambient_temp = self.toolboard.mcu.lookup_command(
@@ -187,7 +187,9 @@ class IndxToolboardHeater:
         self.vin_adc = toolboard.mcu.setup_pin("adc", {"pin": "vin_mon"})
         compat.register_adc_callback(self.vin_adc, self.handle_vin_mon)
         query_adc = toolboard.printer.load_object(config, "query_adc")
-        query_adc.register_adc(f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc)
+        query_adc.register_adc(
+            f"{toolboard.mcu.get_name()}_vin_mon", self.vin_adc
+        )
         self.supply_voltage = 24.0
 
         # The autotuned thermal-model parameters have no defaults.
@@ -200,18 +202,26 @@ class IndxToolboardHeater:
             thermal_capacity=config.getfloat(
                 "model_thermal_capacity", default=None, above=0.0
             ),
-            to_ambient_r=config.getfloat("model_to_ambient_r", default=None, above=0.0),
+            to_ambient_r=config.getfloat(
+                "model_to_ambient_r", default=None, above=0.0
+            ),
             filament_radius=config.getfloat(
                 "model_filament_diameter",
                 default=1.75,
             )
             / 2.0,
-            filament_density=config.getfloat("model_filament_density", default=1.20),
+            filament_density=config.getfloat(
+                "model_filament_density", default=1.20
+            ),
             filament_heat_capacity=config.getfloat(
                 "model_filament_heat_capacity", default=1.8
             ),
-            part_cooling_fan_a=config.getfloat("model_part_cooling_fan_a", default=0.0),
-            part_cooling_fan_k=config.getfloat("model_part_cooling_fan_k", default=0.0),
+            part_cooling_fan_a=config.getfloat(
+                "model_part_cooling_fan_a", default=0.0
+            ),
+            part_cooling_fan_k=config.getfloat(
+                "model_part_cooling_fan_k", default=0.0
+            ),
             ambient_blend_board=config.getfloat(
                 "model_ambient_blend_board", default=0.0
             ),
@@ -221,7 +231,9 @@ class IndxToolboardHeater:
             ambient_blend_sensor=config.getfloat(
                 "model_ambient_blend_sensor", default=1.0
             ),
-            error_application=config.getfloat("model_error_application", default=1.0),
+            error_application=config.getfloat(
+                "model_error_application", default=1.0
+            ),
         )
         self.thermal_model = ThermalModel(model_params)
         self.max_model_error = config.getfloat("max_model_error", default=50.0)
@@ -229,14 +241,18 @@ class IndxToolboardHeater:
         self.pid_kp = config.getfloat("pid_kp", default=4.0)
         self.pid_ti = config.getfloat("pid_ti", minval=0.0, default=0.0)
         self.pid_td = config.getfloat("pid_td", minval=0.0, default=0.0)
-        self.pid_b = config.getfloat("pid_b", minval=0.0, maxval=1.0, default=1.0)
+        self.pid_b = config.getfloat(
+            "pid_b", minval=0.0, maxval=1.0, default=1.0
+        )
         self.max_temp_nozzle = config.getfloat("max_temp_nozzle", default=305.0)
         self.max_temp_sensor = config.getfloat("max_temp_sensor", default=130.0)
 
         self.ir_sensor_tuning = None
         ir_sensor_exponent = config.getfloat("ir_sensor_exponent", default=None)
         ir_sensor_obj_gain = config.getfloat("ir_sensor_obj_gain", default=None)
-        ir_sensor_bracket_gain = config.getfloat("ir_sensor_bracket_gain", default=None)
+        ir_sensor_bracket_gain = config.getfloat(
+            "ir_sensor_bracket_gain", default=None
+        )
         tuning = (
             ir_sensor_exponent,
             ir_sensor_obj_gain,
@@ -253,15 +269,23 @@ class IndxToolboardHeater:
         # heating can't be done, but we allow not setting them so the user can run the
         # tuning routine. These are specified in microseconds by the user.
         coil_timings = (
-            config.getfloat("coil_time_on", default=None, above=0.0, below=10.0),
-            config.getfloat("coil_time_off", default=None, above=0.0, below=10.0),
-            config.getfloat("coil_time_on_first", default=None, above=0.0, below=10.0),
+            config.getfloat(
+                "coil_time_on", default=None, above=0.0, below=10.0
+            ),
+            config.getfloat(
+                "coil_time_off", default=None, above=0.0, below=10.0
+            ),
+            config.getfloat(
+                "coil_time_on_first", default=None, above=0.0, below=10.0
+            ),
         )
         self.coil_timings = None
         if all(coil_timings):
             t_on, t_off, t_on_first = coil_timings
             if t_on_first > t_on:
-                raise config.error("coil_time_on_first must not exceed coil_time_on")
+                raise config.error(
+                    "coil_time_on_first must not exceed coil_time_on"
+                )
             # microseconds -> seconds for the MCU
             self.coil_timings = (t_on * 1e-6, t_off * 1e-6, t_on_first * 1e-6)
         elif any(coil_timings):
@@ -277,8 +301,12 @@ class IndxToolboardHeater:
             if fan_obj is None:
                 fan_obj = toolboard.printer.lookup_object(fan_name)
             if fan_obj is None:
-                raise config.error(f"Unknown cooling_fan '{fan_name}' specified")
-            if not hasattr(fan_obj, "fan") or not hasattr(fan_obj.fan, "set_speed"):
+                raise config.error(
+                    f"Unknown cooling_fan '{fan_name}' specified"
+                )
+            if not hasattr(fan_obj, "fan") or not hasattr(
+                fan_obj.fan, "set_speed"
+            ):
                 raise config.error(
                     f"cooling_fan '{fan_name}' is not a valid fan object"
                 )
@@ -313,8 +341,12 @@ class IndxToolboardHeater:
         gcode.register_command("INDX_LOAD_FILAMENT", self.cmd_LOAD_FILAMENT)
         gcode.register_command("INDX_CLEAR_FILAMENT", self.cmd_CLEAR_FILAMENT)
         gcode.register_command("INDX_EXTRUDER_MOVE", self.cmd_EXTRUDER_MOVE)
-        gcode.register_command("INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS)
-        gcode.register_command("INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE)
+        gcode.register_command(
+            "INDX_SET_MODEL_PARAMS", self.cmd_SET_MODEL_PARAMS
+        )
+        gcode.register_command(
+            "INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE
+        )
         gcode.register_command(
             "INDX_COIL_PRESENCE",
             self.cmd_COIL_PRESENCE,
@@ -373,7 +405,9 @@ class IndxToolboardHeater:
                 "indx_coil_presence_result status=%c tripped=%c",
                 cq=self.cmd_queue,
             )
-        amp_per_count = mcu.get_constant_float("INDX_CURRENT_SENSE_AMP_PER_COUNT")
+        amp_per_count = mcu.get_constant_float(
+            "INDX_CURRENT_SENSE_AMP_PER_COUNT"
+        )
         current_sense_rate = mcu.get_constant_float("INDX_CURRENT_SENSE_RATE")
         self.power_scale = amp_per_count / current_sense_rate
 
@@ -469,7 +503,11 @@ class IndxToolboardHeater:
     def cur_target_temp(self):
         time = self.toolboard.printer.get_reactor().monotonic()
         return next(
-            (h.get_temp(time)[1] for h in self.heaters if h.get_temp(time)[1] != 0.0),
+            (
+                h.get_temp(time)[1]
+                for h in self.heaters
+                if h.get_temp(time)[1] != 0.0
+            ),
             None,
         )
 
@@ -488,7 +526,9 @@ class IndxToolboardHeater:
     def fan_speed(self, time):
         if self.part_cooling_fan is None:
             return 0.0
-        return max(0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"]))
+        return max(
+            0.0, min(1.0, self.part_cooling_fan.get_status(time)["speed"])
+        )
 
     def _blend_ambient_temp(self, sensor_temp):
         # Weighted blend of the board/bracket thermistors and the IR sensor's
@@ -526,7 +566,9 @@ class IndxToolboardHeater:
             self.thermal_model.force_temp(nozzle_temp)
 
         charge = params["charge"]
-        self._update_inductive_presence_from_report(params["overvoltage"], power)
+        self._update_inductive_presence_from_report(
+            params["overvoltage"], power
+        )
         if self.last_report is not None:
             delta_time = time - self.last_report[0]
             delta_charge = charge - self.last_report[1]
@@ -561,7 +603,9 @@ class IndxToolboardHeater:
                 # because the user isn't allowed to start heating when no thermal
                 # model is set. We need this check to allow the tuner to work.
                 if self.thermal_model.is_valid():
-                    filament_distance = max(0.0, extruder_pos - self.last_report[3])
+                    filament_distance = max(
+                        0.0, extruder_pos - self.last_report[3]
+                    )
                     fan_speed = self.fan_speed(time)
 
                     ambient_temp = self._blend_ambient_temp(sensor_temp)
@@ -612,9 +656,7 @@ class IndxToolboardHeater:
                 )
             )
 
-    def get_inductive_presence(
-        self, eventtime
-    ) -> tuple[InductivePresenceValue, float | None]:
+    def get_inductive_presence(self, eventtime) -> tuple[str, float | None]:
         time_since_entry = (
             eventtime - self.inductive_presence_time
             if self.inductive_presence_time is not None
@@ -624,7 +666,9 @@ class IndxToolboardHeater:
 
     def _set_inductive_presence(self, value):
         self.inductive_presence = InductivePresence(value)
-        self.inductive_presence_time = self.toolboard.printer.get_reactor().monotonic()
+        self.inductive_presence_time = (
+            self.toolboard.printer.get_reactor().monotonic()
+        )
 
     def _update_inductive_presence_from_report(self, ov_count, power):
         # First report, or MCU count reset: store the count and leave
@@ -783,7 +827,9 @@ class IndxToolboardHeater:
         (t_on, t_off, t_on_first) = self.coil_timings
         configfile.set(section, "coil_time_on", "%.3f" % (t_on * 1e6))
         configfile.set(section, "coil_time_off", "%.3f" % (t_off * 1e6))
-        configfile.set(section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6))
+        configfile.set(
+            section, "coil_time_on_first", "%.3f" % (t_on_first * 1e6)
+        )
 
     def _toggle_steppers(self, toolhead, ets, enable):
         # Enable/disable a set of EnableTracking lines with proper toolhead
@@ -809,7 +855,9 @@ class IndxToolboardHeater:
                 return
             if reactor.monotonic() > deadline:
                 raise gcmd.error(timeout_msg)
-            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL)
+            reactor.pause(
+                reactor.monotonic() + calibration.MODEL_CAL_POLL_INTERVAL
+            )
 
     def _wait_cooldown(self, gcmd, min_temp):
         # Block until the nozzle has cooled below min_temp (the heater must
@@ -834,7 +882,9 @@ class IndxToolboardHeater:
                 "INDX: no temperature reports received",
             )
             if last_temp[0] > min_temp:
-                gcmd.respond_info("INDX: cooling below %.0f C before tuning" % min_temp)
+                gcmd.respond_info(
+                    "INDX: cooling below %.0f C before tuning" % min_temp
+                )
                 self._model_cal_wait_temp(
                     reactor,
                     gcmd,
@@ -949,7 +999,9 @@ class IndxToolboardHeater:
             # Baseline (heater off) draw to subtract from measured power.
             phase[0] = "baseline"
             gcmd.respond_info("INDX: measuring baseline power")
-            reactor.pause(reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME)
+            reactor.pause(
+                reactor.monotonic() + calibration.MODEL_CAL_BASELINE_TIME
+            )
             baseline_power = calibration.mean_phase_power(samples, "baseline")
             if baseline_power is None:
                 raise gcmd.error("INDX: no baseline power samples received")
@@ -957,7 +1009,8 @@ class IndxToolboardHeater:
             # Heatup to MAX_TEMP.
             phase[0] = "heat"
             gcmd.respond_info(
-                "INDX: heating to %.0f C (baseline %.2f W)" % (max_temp, baseline_power)
+                "INDX: heating to %.0f C (baseline %.2f W)"
+                % (max_temp, baseline_power)
             )
             self.heater_raw_set_temp(max_temp)
             self._model_cal_wait_temp(
@@ -979,7 +1032,9 @@ class IndxToolboardHeater:
             self.heater.set_temp(0.0)
             if cooldown_time > 0.0:
                 phase[0] = "cooldown"
-                gcmd.respond_info("INDX: measuring cooldown for %.0f s" % cooldown_time)
+                gcmd.respond_info(
+                    "INDX: measuring cooldown for %.0f s" % cooldown_time
+                )
                 reactor.pause(reactor.monotonic() + cooldown_time)
 
             self.temperature_callbacks.remove(sampler)
@@ -1006,7 +1061,9 @@ class IndxToolboardHeater:
             self._toggle_steppers(toolhead, reenable, True)
 
         if result.get("error"):
-            raise gcmd.error("INDX thermal model fit failed: %s" % result["error"])
+            raise gcmd.error(
+                "INDX thermal model fit failed: %s" % result["error"]
+            )
         self._apply_model_calibration(gcmd, result)
 
     def _apply_model_calibration(self, gcmd, result):
@@ -1062,13 +1119,16 @@ class IndxToolboardHeater:
                 % (p_lo, t_min, p_hi, t_max, -drop_pct)
             )
         lines.append(
-            "thermal_capacity: " + fmt(capacity, result["thermal_capacity_ci"], "J/K")
+            "thermal_capacity: "
+            + fmt(capacity, result["thermal_capacity_ci"], "J/K")
         )
         lines.append(
-            "to_ambient_r: " + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
+            "to_ambient_r: "
+            + fmt(to_ambient_r, result["to_ambient_r_ci"], "K/W")
         )
         lines.append(
-            "fit RMS error: %.2f C over %d samples" % (result["rms"], result["n_fit"])
+            "fit RMS error: %.2f C over %d samples"
+            % (result["rms"], result["n_fit"])
         )
         gcmd.respond_info("INDX thermal model calibrated:\n" + "\n".join(lines))
 
@@ -1078,7 +1138,9 @@ class IndxToolboardHeater:
         if self.part_cooling_fan is None:
             raise gcmd.error("INDX part cooling fan is not configured")
 
-        breaks = gcmd.get_int("BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3)
+        breaks = gcmd.get_int(
+            "BREAKS", calibration.FAN_CAL_BREAKS_DEFAULT, minval=3
+        )
         hold_time = gcmd.get_float(
             "HOLD_TIME", calibration.FAN_CAL_HOLD_TIME_DEFAULT, above=0.0
         )
@@ -1132,7 +1194,9 @@ class IndxToolboardHeater:
             self.temperature_callbacks.append(sampler)
             installed = True
             self.heater_raw_set_temp(target)
-            gcmd.respond_info("INDX: waiting for %.0f C for fan calibration" % target)
+            gcmd.respond_info(
+                "INDX: waiting for %.0f C for fan calibration" % target
+            )
             self._model_cal_wait_temp(
                 reactor,
                 gcmd,
@@ -1228,7 +1292,9 @@ class IndxToolboardHeater:
             self.temperature_callbacks.remove(cb)
 
         if totals[0] == 0:
-            raise gcmd.error("No power meansurements received over entire duration")
+            raise gcmd.error(
+                "No power meansurements received over entire duration"
+            )
 
         power = totals[1] / totals[0]
         gcmd.respond_info(
@@ -1259,19 +1325,27 @@ class IndxToolboardHeater:
             )
 
         speed = gcmd.get_float("SPEED", FILAMENT_LOAD_SPEED, above=0.0)
-        max_length = gcmd.get_float("MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0)
-        prime_time = gcmd.get_float("PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0)
+        max_length = gcmd.get_float(
+            "MAX_LENGTH", FILAMENT_LOAD_MAX_LENGTH, above=0.0
+        )
+        prime_time = gcmd.get_float(
+            "PRIME_TIME", FILAMENT_LOAD_PRIME_TIME, above=0.0
+        )
         prime_length = gcmd.get_float("PRIME_LENGTH", None, above=0.0)
         if prime_length is None:
             prime_length = speed * prime_time
-        threshold = gcmd.get_float("THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0)
+        threshold = gcmd.get_float(
+            "THRESHOLD", FILAMENT_LOAD_THRESHOLD, above=0.0
+        )
         segment_time = gcmd.get_float(
             "SEGMENT_TIME", FILAMENT_LOAD_SEGMENT_TIME, above=0.0
         )
         apply_result = gcmd.get_int("APPLY", 1, minval=0, maxval=1)
 
         params = self.thermal_model.params
-        filament_area = params.filament_radius * params.filament_radius * math.pi
+        filament_area = (
+            params.filament_radius * params.filament_radius * math.pi
+        )
         last_temp = last_pos = start_pos = loaded_at_pos = None
         load_energy = loaded_energy = loaded_denominator = 0.0
         loaded = False
@@ -1293,7 +1367,9 @@ class IndxToolboardHeater:
                 return
             dt = reading.delta_time
             ambient = self._blend_ambient_temp(reading.sensor_temperature)
-            loss_ambient = (reading.nozzle_temperature - ambient) / params.to_ambient_r
+            loss_ambient = (
+                reading.nozzle_temperature - ambient
+            ) / params.to_ambient_r
             loss_part_cooling = 0.0
             fan_speed = self.fan_speed(reading.time)
             if fan_speed > 0.0:
@@ -1305,7 +1381,9 @@ class IndxToolboardHeater:
                         0.0,
                         (reading.nozzle_temperature - ambient) / pcf_ambient_r,
                     )
-            stored = params.thermal_capacity * (reading.nozzle_temperature - last_temp)
+            stored = params.thermal_capacity * (
+                reading.nozzle_temperature - last_temp
+            )
             loss = (loss_ambient + loss_part_cooling) * dt
             residual = reading.delta_pwm_energy - loss - stored
             load_energy = max(0.0, load_energy + residual)
@@ -1313,7 +1391,9 @@ class IndxToolboardHeater:
             temp_delta = max(0.0, reading.nozzle_temperature - ambient)
             if loaded:
                 loaded_energy += max(0.0, residual)
-                loaded_denominator += pos_delta * filament_area / 1000.0 * temp_delta
+                loaded_denominator += (
+                    pos_delta * filament_area / 1000.0 * temp_delta
+                )
             elif load_energy >= threshold:
                 loaded = True
                 loaded_at_pos = pos
@@ -1393,7 +1473,9 @@ class IndxToolboardHeater:
         section = self.toolboard.name
         configfile.set(section, "model_filament_density", "0.0000")
         configfile.set(section, "model_filament_heat_capacity", "0.0000")
-        gcmd.respond_info("INDX filament model cleared. Run SAVE_CONFIG to save.")
+        gcmd.respond_info(
+            "INDX filament model cleared. Run SAVE_CONFIG to save."
+        )
 
     def cmd_EXTRUDER_MOVE(self, gcmd):
         distance = gcmd.get_float("DISTANCE")
@@ -1409,9 +1491,13 @@ class IndxToolboardHeater:
         stepper = extruder.extruder_stepper.stepper
         current_helper = compat.get_tmc_current_helper(stepper)
         if current_helper is None:
-            raise gcmd.error("Active extruder does not have a TMC current helper")
+            raise gcmd.error(
+                "Active extruder does not have a TMC current helper"
+            )
 
-        run_current, hold_current, req_hold_current, *_ = current_helper.get_current()
+        run_current, hold_current, req_hold_current, *_ = (
+            current_helper.get_current()
+        )
         current = min(current, run_current)
         restore_hold_current = (
             req_hold_current if req_hold_current is not None else hold_current
@@ -1432,12 +1518,16 @@ class IndxToolboardHeater:
             toolhead.wait_moves()
         finally:
             print_time = toolhead.get_last_move_time()
-            current_helper.set_current(run_current, restore_hold_current, print_time)
+            current_helper.set_current(
+                run_current, restore_hold_current, print_time
+            )
 
     def cmd_SET_MODEL_PARAMS(self, gcmd):
         cur = self.thermal_model.params
 
-        max_power = gcmd.get_float("MAX_POWER", default=cur.max_power, minval=0.0)
+        max_power = gcmd.get_float(
+            "MAX_POWER", default=cur.max_power, minval=0.0
+        )
         max_power_temp_coeff = gcmd.get_float(
             "MAX_POWER_TEMP_COEFF", default=cur.max_power_temp_coeff
         )
@@ -1512,7 +1602,9 @@ class IndxToolboardHeater:
         else:
             gcmd.respond_info("Thermal model has not yet run")
 
-    cmd_COIL_PRESENCE_help = "Sample whether a steel nozzle is coupled to the INDX coil"
+    cmd_COIL_PRESENCE_help = (
+        "Sample whether a steel nozzle is coupled to the INDX coil"
+    )
 
     def cmd_COIL_PRESENCE(self, gcmd):
         reactor = self.toolboard.printer.get_reactor()
@@ -1523,8 +1615,13 @@ class IndxToolboardHeater:
             )
             return
         if self.coil_timings is None:
-            raise gcmd.error("INDX coil timings are not set. Run INDX_CALIBRATE first.")
-        if self.coil_presence_cmd is None or self.query_coil_presence_cmd is None:
+            raise gcmd.error(
+                "INDX coil timings are not set. Run INDX_CALIBRATE first."
+            )
+        if (
+            self.coil_presence_cmd is None
+            or self.query_coil_presence_cmd is None
+        ):
             raise gcmd.error(
                 "INDX toolboard firmware does not support coil presence. "
                 "Flash the toolboard."
@@ -1578,7 +1675,9 @@ class IndxToolboardHeater:
         )
         res = cmd.send([])
         print(res)
-        gcmd.respond_info("".join(hex(c)[2:].ljust(2, "0") for c in res["data"]))
+        gcmd.respond_info(
+            "".join(hex(c)[2:].ljust(2, "0") for c in res["data"])
+        )
 
     def cmd_DEBUG_STREAM_RAW_IR_SENSOR(self, gcmd):
         if self.raw_ir_log_file is not None:
@@ -1627,7 +1726,9 @@ class IndxToolboardHeater:
             try:
                 cols.append(
                     "%.2f"
-                    % printer.lookup_object(name).get_status(eventtime)["temperature"]
+                    % printer.lookup_object(name).get_status(eventtime)[
+                        "temperature"
+                    ]
                 )
             except Exception as e:
                 cols.append("")
@@ -1751,14 +1852,18 @@ class ThermalModel:
                     0.0, (self.temperature - ambient_temp) / pcf_ambient_r
                 )
 
-        loss_ambient = (self.temperature - ambient_temp) / self.params.to_ambient_r
+        loss_ambient = (
+            self.temperature - ambient_temp
+        ) / self.params.to_ambient_r
         loss_filament = (
             filament_distance
             * filament_heat_capacity_mm
             * (self.temperature - filament_temp)
             / dt
         )
-        total_power = avg_input_power - loss_ambient - loss_filament - loss_part_cooling
+        total_power = (
+            avg_input_power - loss_ambient - loss_filament - loss_part_cooling
+        )
         delta_temp_rate = total_power / self.params.thermal_capacity
         new_temp = self.temperature + delta_temp_rate * dt
 

--- a/klippy/extras/indx/heater.py
+++ b/klippy/extras/indx/heater.py
@@ -27,6 +27,10 @@ COIL_TUNE_STATUS_RUNNING = 1
 COIL_TUNE_TIMEOUT = 15.0  # seconds. The MCU self-aborts a stuck tune at 10 s
 COIL_TUNE_POLL_INTERVAL = 0.2  # seconds between latched-status polls
 COIL_TUNE_WAVE_PATH = "/tmp/indx_coil_waveform.csv"
+COIL_PRESENCE_STATUS_RUNNING = 1
+COIL_PRESENCE_STATUS_DONE = 2
+COIL_PRESENCE_TIMEOUT = 1.0
+COIL_PRESENCE_POLL_INTERVAL = 0.02
 FILAMENT_LOAD_THRESHOLD = 10.0
 FILAMENT_LOAD_PRIME_TIME = 5.0
 FILAMENT_LOAD_MAX_LENGTH = 120.0
@@ -313,6 +317,8 @@ class IndxToolboardHeater:
         self.inductive_presence = "unknown"
         self.inductive_presence_time = None
         self._ov_count = None
+        self.coil_presence_cmd = None
+        self.query_coil_presence_cmd = None
 
         gcode = self.toolboard.printer.lookup_object("gcode")
         gcode.register_command("INDX_SET_PID", self.cmd_SET_PID)
@@ -331,6 +337,11 @@ class IndxToolboardHeater:
         )
         gcode.register_command(
             "INDX_DUMP_MODEL_UPDATE", self.cmd_DUMP_MODEL_UPDATE
+        )
+        gcode.register_command(
+            "INDX_COIL_PRESENCE",
+            self.cmd_COIL_PRESENCE,
+            desc=self.cmd_COIL_PRESENCE_help,
         )
 
         gcode.register_command("INDX_LOG", self.cmd_LOG)
@@ -374,6 +385,17 @@ class IndxToolboardHeater:
             "indx_coil_tune_result status=%c error=%c on_first=%u off=%u on=%u",
             cq=self.cmd_queue,
         )
+        self.coil_presence_cmd = None
+        self.query_coil_presence_cmd = None
+        if mcu.try_lookup_command("indx_coil_presence") is not None:
+            self.coil_presence_cmd = mcu.lookup_command(
+                "indx_coil_presence", cq=self.cmd_queue
+            )
+            self.query_coil_presence_cmd = mcu.lookup_query_command(
+                "indx_query_coil_presence",
+                "indx_coil_presence_result status=%c tripped=%c",
+                cq=self.cmd_queue,
+            )
         amp_per_count = mcu.get_constant_float(
             "INDX_CURRENT_SENSE_AMP_PER_COUNT"
         )
@@ -1574,6 +1596,63 @@ class IndxToolboardHeater:
             gcmd.respond_info(f"Last model update:\n{params}")
         else:
             gcmd.respond_info("Thermal model has not yet run")
+
+    cmd_COIL_PRESENCE_help = (
+        "Sample whether a steel nozzle is coupled to the INDX coil"
+    )
+
+    def cmd_COIL_PRESENCE(self, gcmd):
+        reactor = self.toolboard.printer.get_reactor()
+        if self.cur_target_temp() is not None:
+            presence, age = self.get_inductive_presence(reactor.monotonic())
+            gcmd.respond_info(
+                self._format_coil_presence(presence, age, heater_active=True)
+            )
+            return
+        if self.coil_timings is None:
+            raise gcmd.error(
+                "INDX coil timings are not set. Run INDX_CALIBRATE first."
+            )
+        if (
+            self.coil_presence_cmd is None
+            or self.query_coil_presence_cmd is None
+        ):
+            raise gcmd.error(
+                "INDX toolboard firmware does not support coil presence. "
+                "Flash the toolboard."
+            )
+        self.coil_presence_cmd.send([])
+        deadline = reactor.monotonic() + COIL_PRESENCE_TIMEOUT
+        while True:
+            result = self.query_coil_presence_cmd.send([])
+            status = result["status"]
+            if status != COIL_PRESENCE_STATUS_RUNNING:
+                break
+            if reactor.monotonic() > deadline:
+                raise gcmd.error("INDX coil presence check timed out")
+            reactor.pause(reactor.monotonic() + COIL_PRESENCE_POLL_INTERVAL)
+        if status != COIL_PRESENCE_STATUS_DONE:
+            raise gcmd.error(
+                "INDX coil presence check failed "
+                "(coil busy, tune active, or timings not set)"
+            )
+        if result["tripped"]:
+            self._set_inductive_presence("absent")
+        else:
+            self._set_inductive_presence("present")
+        presence, age = self.get_inductive_presence(reactor.monotonic())
+        gcmd.respond_info(
+            self._format_coil_presence(presence, age, heater_active=False)
+        )
+
+    def _format_coil_presence(self, presence, age, heater_active):
+        if presence == "unknown" or age is None:
+            msg = "INDX coil presence: unknown"
+        else:
+            msg = "INDX coil presence: %s (age %.3fs)" % (presence, age)
+        if heater_active:
+            msg += " (heater active, no pulse)"
+        return msg
 
     def cmd_LOG(self, gcmd):
         if self.log_file is not None:

--- a/klippy/extras/indx/toolboard.py
+++ b/klippy/extras/indx/toolboard.py
@@ -96,8 +96,11 @@ class IndxToolboard:
         gcode.register_command("INDX_LED_SET_CURRENT", self.cmd_LED_SET_CURRENT)
 
     def get_status(self, eventtime):
+        presence, age = self.heater.get_inductive_presence(eventtime)
         return {
-            "last_dock_measurement": self.dock_measurement.last_dock_measurement
+            "last_dock_measurement": self.dock_measurement.last_dock_measurement,
+            "inductive_presence": presence,
+            "inductive_presence_age": age,
         }
 
     def cmd_LED_FORCE_COLOR(self, gcmd):

--- a/src/indx/coil_driver.c++
+++ b/src/indx/coil_driver.c++
@@ -315,6 +315,26 @@ struct tuner_state {
 
 static tuner_state tuner;
 
+enum class presence_status : uint8_t {
+    idle = 0,
+    running = 1,
+    done = 2,
+    failed = 3,
+};
+
+struct presence_oneshot {
+    presence_status status{presence_status::idle};
+    uint32_t ov_snapshot{0};
+    uint8_t tripped{0};
+};
+
+static presence_oneshot presence;
+
+static bool
+drive_timer_idle() {
+    return DRIVE_TCC->STATUS.bit.STOP || DRIVE_TCC->STATUS.bit.FAULT0;
+}
+
 // IRQ declarations and assert correct indices.
 
 static_assert(FEEDBACK_ADC_1_IRQn == 121);
@@ -1158,4 +1178,34 @@ coil_driver::report_params() {
     uint32_t off = state.period_minus_1 + 1 - on;
     sendf("indx_coil_driver_params time_on=%u time_off=%u time_on_first=%u",
           ticks_to_ns(on), ticks_to_ns(off), ticks_to_ns(state.on_ticks_first));
+}
+
+void
+coil_driver::start_coil_presence() {
+    if (presence.status == presence_status::running) {
+        return;
+    }
+    presence.tripped = 0;
+    if (tuner.active() || !state.timings_valid ||
+        state.pending_on_cycles != 0 || !drive_timer_idle()) {
+        presence.status = presence_status::failed;
+        return;
+    }
+    presence.ov_snapshot = state.overvoltage_count();
+    state.pending_on_cycles = 1;
+    state.arm_timer();
+    // Clear so the 512-cycle frame does not repeat after it STOPs.
+    state.pending_on_cycles = 0;
+    presence.status = presence_status::running;
+}
+
+void
+coil_driver::report_coil_presence() {
+    if (presence.status == presence_status::running && drive_timer_idle()) {
+        presence.tripped =
+            state.overvoltage_count() != presence.ov_snapshot ? 1 : 0;
+        presence.status = presence_status::done;
+    }
+    sendf("indx_coil_presence_result status=%c tripped=%c",
+          (uint32_t)presence.status, (uint32_t)presence.tripped);
 }

--- a/src/indx/coil_driver.h
+++ b/src/indx/coil_driver.h
@@ -50,6 +50,14 @@ struct coil_driver {
     // Send the drive timings currently in effect to the host.
     void
     report_params();
+
+    // Fire one tuned first-cycle burst and latch whether COMP0 tripped.
+    void
+    start_coil_presence();
+
+    // Send the latched coil-presence outcome to the host.
+    void
+    report_coil_presence();
 };
 
 coil_driver

--- a/src/indx/heater.c++
+++ b/src/indx/heater.c++
@@ -367,6 +367,28 @@ command_indx_query_coil_driver_params(uint32_t *args) {
 DECL_COMMAND(command_indx_query_coil_driver_params,
              "indx_query_coil_driver_params");
 
+// Fire one tuned first-cycle burst so the host can classify coil-target
+// presence from COMP0 while the heater is idle.
+extern "C" void
+command_indx_coil_presence(uint32_t *args) {
+    (void)args;
+    if (!indx_heater_instance)
+        return;
+
+    indx_heater_instance->coil_driver_inst.start_coil_presence();
+}
+DECL_COMMAND(command_indx_coil_presence, "indx_coil_presence");
+
+extern "C" void
+command_indx_query_coil_presence(uint32_t *args) {
+    (void)args;
+    if (!indx_heater_instance)
+        return;
+
+    indx_heater_instance->coil_driver_inst.report_coil_presence();
+}
+DECL_COMMAND(command_indx_query_coil_presence, "indx_query_coil_presence");
+
 extern "C" void
 command_indx_led_force_color(uint32_t *args) {
     if (!indx_heater_instance)

--- a/test/klippy/indx.test
+++ b/test/klippy/indx.test
@@ -7,6 +7,9 @@ INDX_LED_FORCE_COLOR RED=10 GREEN=20 BLUE=30
 INDX_LED_FORCE_COLOR CLEAR=1
 INDX_LED_SET_CURRENT RED=10 GREEN=10 BLUE=10
 INDX_FORCE_BRACKET_TEMP TEMP=25
+ASSERT TEST='{"INDX_COIL_PRESENCE" in printer.gcode.commands}'
 
 # Verify the toolboard status is exported
 ASSERT TEST='{printer.indx.last_dock_measurement is none}'
+ASSERT TEST='{printer.indx.inductive_presence == "unknown"}'
+ASSERT TEST='{printer.indx.inductive_presence_age is none}'


### PR DESCRIPTION
# indx: Classify coil presence from OV trips

Steel in the coil damps the resonant tank, so tuned drive stays under
the 100 V overvoltage trip and an empty coil overshoots. Temperature
reports already carry a cumulative trip count; the host ignored it.

`printer.indx.inductive_presence` is now classified from those count
deltas while the coil is driven. Idle reports have no tank voltage, so
`INDX_COIL_PRESENCE` fires one tuned first-cycle burst and reads
whether COMP0 tripped. That uses the existing overvoltage path rather
than a second ADC ringdown stack.

Same aim as #949 but reusing existing OV detection.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
