### PR TITLE
fix: keep non-critical MCU disconnect from killing the print

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -66,6 +66,7 @@ defs_stepcompress = """
         , uint32_t invert_sdir);
     void stepcompress_free(struct stepcompress *sc);
     int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
+    void stepcompress_clear(struct stepcompress *sc);
     int stepcompress_set_last_position(struct stepcompress *sc
         , uint64_t clock, int64_t last_position);
     int64_t stepcompress_find_past_position(struct stepcompress *sc

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -550,6 +550,26 @@ stepcompress_flush(struct stepcompress *sc, uint64_t move_clock)
     return queue_flush(sc, move_clock);
 }
 
+// Discard pending steps without flushing them to the MCU. Used when a
+// non-critical MCU disconnects mid-print: leftover queue_step messages
+// belong to the old clock domain and will fail with "Invalid sequence"
+// if flushed after reconnect.
+void __visible
+stepcompress_clear(struct stepcompress *sc)
+{
+    message_queue_free(&sc->msg_queue);
+    list_init(&sc->msg_queue);
+    free_history(sc, UINT64_MAX);
+    if (sc->queue)
+        sc->queue_pos = sc->queue_next = sc->queue;
+    sc->next_step_clock = 0;
+    sc->last_step_clock = 0;
+    sc->sdir = -1;
+    sc->last_position = 0;
+    if (sc->mcu_freq)
+        calc_last_step_print_time(sc);
+}
+
 // Reset the internal state of the stepcompress object
 int __visible
 stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock)

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -24,6 +24,7 @@ int stepcompress_append(struct stepcompress *sc, int sdir
                         , double print_time, double step_time);
 int stepcompress_commit(struct stepcompress *sc);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
+void stepcompress_clear(struct stepcompress *sc);
 int stepcompress_set_last_position(struct stepcompress *sc, uint64_t clock
                                    , int64_t last_position);
 int64_t stepcompress_find_past_position(struct stepcompress *sc

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -23,6 +23,10 @@ class MCU_buttons:
         self.invert = self.last_button = 0
         self.ack_cmd = None
         self.ack_count = 0
+        printer.register_event_handler(
+            mcu.get_non_critical_reconnect_event_name(),
+            self._handle_reconnect,
+        )
 
     def setup_buttons(self, pins, callback):
         mask = 0
@@ -63,6 +67,13 @@ class MCU_buttons:
         self.mcu.register_response(
             self.handle_buttons_state, "buttons_state", self.oid
         )
+
+    def _handle_reconnect(self):
+        # Firmware button ack counter restarts at 0 after MCU reset.
+        # A stale host ack_count drops every buttons_state as new_count<=0,
+        # which is why feed/retract/HALL buttons go dead after reconnect.
+        self.ack_count = 0
+        self.last_button = 0
 
     def handle_buttons_state(self, params):
         # Expand the message ack_count from 8-bit

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -228,9 +228,13 @@ class TMCErrorCheck:
                 self._query_temperature()
         except self.printer.command_error as e:
             err = str(e)
-            if mcu is not None and getattr(mcu, "is_non_critical", False) and (
-                "Serial connection closed" in err
-                or "non-critical MCU is disconnected" in err
+            if (
+                mcu is not None
+                and getattr(mcu, "is_non_critical", False)
+                and (
+                    "Serial connection closed" in err
+                    or "non-critical MCU is disconnected" in err
+                )
             ):
                 logging.info(
                     "TMC '%s' comms lost on non-critical MCU '%s': %s",

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -213,6 +213,13 @@ class TMCErrorCheck:
             return
 
     def _do_periodic_check(self, eventtime):
+        # A non-critical MCU (e.g. Mellow LLL buffer) may drop USB mid-print.
+        # is_non_critical already treats that as a disconnect+reconnect, but
+        # this TMC poller still treats "Serial connection closed" as fatal and
+        # shuts the whole printer down. Skip the poll until the MCU is back.
+        mcu = getattr(self.mcu_tmc, "mcu", None)
+        if mcu is not None and getattr(mcu, "non_critical_disconnected", False):
+            return eventtime + 1.0
         try:
             self._query_register(self.drv_status_reg_info)
             if self.gstat_reg_info is not None:
@@ -220,7 +227,19 @@ class TMCErrorCheck:
             if self.adc_temp_reg is not None:
                 self._query_temperature()
         except self.printer.command_error as e:
-            self.printer.invoke_shutdown(str(e))
+            err = str(e)
+            if mcu is not None and getattr(mcu, "is_non_critical", False) and (
+                "Serial connection closed" in err
+                or "non-critical MCU is disconnected" in err
+            ):
+                logging.info(
+                    "TMC '%s' comms lost on non-critical MCU '%s': %s",
+                    self.stepper_name,
+                    mcu.get_name(),
+                    err,
+                )
+                return eventtime + 1.0
+            self.printer.invoke_shutdown(err)
             return self.printer.get_reactor().NEVER
         return eventtime + 1.0
 
@@ -401,6 +420,12 @@ class TMCCommandHelper:
         self.printer.register_event_handler(
             "klippy:connect", self._handle_connect
         )
+        mcu = getattr(mcu_tmc, "mcu", None)
+        if mcu is not None:
+            self.printer.register_event_handler(
+                mcu.get_non_critical_reconnect_event_name(),
+                self._handle_non_critical_reconnect,
+            )
         # Register commands
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command(
@@ -590,6 +615,25 @@ class TMCCommandHelper:
             self.mcu_tmc.set_register(reg_name, val, print_time)
         self.echeck_helper.stop_checks()
 
+    def _ignore_noncritical_tmc_comms(self, exc):
+        mcu = getattr(self.mcu_tmc, "mcu", None)
+        if mcu is None or not getattr(mcu, "is_non_critical", False):
+            return False
+        err = str(exc)
+        if (
+            getattr(mcu, "non_critical_disconnected", False)
+            or "Serial connection closed" in err
+            or "non-critical MCU is disconnected" in err
+        ):
+            logging.info(
+                "Ignoring TMC '%s' comms error on non-critical MCU '%s': %s",
+                self.stepper_name,
+                mcu.get_name(),
+                err,
+            )
+            return True
+        return False
+
     def _handle_stepper_enable(self, print_time, is_enable):
         def enable_disable_cb(eventtime):
             try:
@@ -599,6 +643,8 @@ class TMCCommandHelper:
                     else:
                         self._do_disable(print_time)
             except self.printer.command_error as e:
+                if self._ignore_noncritical_tmc_comms(e):
+                    return
                 self.printer.invoke_shutdown(str(e))
 
         self.printer.get_reactor().register_callback(enable_disable_cb)
@@ -638,6 +684,32 @@ class TMCCommandHelper:
                 self._init_registers()
         except self.printer.command_error as e:
             logging.info("TMC %s failed to init: %s", self.name, str(e))
+
+    def _handle_non_critical_reconnect(self):
+        # MCU reset clears TMC UART state. Re-init registers if the
+        # stepper is supposed to be enabled so FORCE_MOVE / buffer feed
+        # work after reconnect without a FIRMWARE_RESTART.
+        mcu = getattr(self.mcu_tmc, "mcu", None)
+        if mcu is None or mcu.non_critical_disconnected:
+            return
+        try:
+            enable_line = self.stepper_enable.lookup_enable(self.stepper_name)
+            if not enable_line.is_motor_enabled():
+                return
+            logging.info(
+                "Re-init TMC '%s' after non-critical MCU '%s' reconnect",
+                self.stepper_name,
+                mcu.get_name(),
+            )
+            print_time = self.printer.lookup_object(
+                "toolhead"
+            ).get_last_move_time()
+            self._do_enable(print_time)
+        except Exception:
+            logging.exception(
+                "TMC '%s' re-init after non-critical reconnect failed",
+                self.stepper_name,
+            )
 
     # get_status information export
     def get_status(self, eventtime=None):

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -934,7 +934,10 @@ class MCU:
             )
             # Leave _is_shutdown True so reconnect can reset the firmware
             # instead of talking to a halted MCU (Invalid oid type).
-            if self._non_critical_reconnecting or self.non_critical_disconnected:
+            if (
+                self._non_critical_reconnecting
+                or self.non_critical_disconnected
+            ):
                 return
             # _handle_shutdown runs in the serial thread; disconnect must
             # be scheduled on the reactor to avoid joining that thread.
@@ -1042,8 +1045,12 @@ class MCU:
         self.gcode.respond_info(f"mcu: '{self._name}' disconnected!", log=True)
 
     def _clear_stepqueues(self):
-        for sq in self._stepqueues:
-            self._ffi_lib.stepcompress_clear(sq)
+        stepqueues = getattr(self, "_stepqueues", None)
+        ffi_lib = getattr(self, "_ffi_lib", None)
+        if not stepqueues or ffi_lib is None:
+            return
+        for sq in stepqueues:
+            ffi_lib.stepcompress_clear(sq)
 
     def clear_stepqueues(self):
         self._clear_stepqueues()
@@ -1052,7 +1059,9 @@ class MCU:
         # Serial may be back during recon_mcu() while steppersync is
         # still None. Generating steps in that window is what produces
         # "Invalid sequence" on G1.
-        return self._steppersync is not None and not self.non_critical_disconnected
+        return (
+            self._steppersync is not None and not self.non_critical_disconnected
+        )
 
     def non_critical_recon_event(self, eventtime):
         success = self.recon_mcu()
@@ -1342,9 +1351,14 @@ class MCU:
                     # Cheetah boards require RTS to be deasserted
                     # else a reset will trigger the built-in bootloader.
                     rts = resmeth != "cheetah"
-                    connect_timeout = 8.0 if self._non_critical_reconnecting else 90.0
+                    connect_timeout = (
+                        8.0 if self._non_critical_reconnecting else 90.0
+                    )
                     self._serial.connect_uart(
-                        self._serialport, self._baud, rts, timeout=connect_timeout
+                        self._serialport,
+                        self._baud,
+                        rts,
+                        timeout=connect_timeout,
                     )
                 else:
                     self._serial.connect_pipe(self._serialport)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -500,6 +500,11 @@ class MCU_digital_out:
         self._max_duration = 2.0
         self._last_clock = 0
         self._set_cmd = None
+        self._last_set_value = None
+        self._printer.register_event_handler(
+            mcu.get_non_critical_reconnect_event_name(),
+            self._handle_reconnect,
+        )
 
     def get_mcu(self):
         return self._mcu
@@ -543,11 +548,23 @@ class MCU_digital_out:
             "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue
         )
 
+    def _handle_reconnect(self):
+        self._last_clock = 0
+        if self._last_set_value is None or self._set_cmd is None:
+            return
+        if self._mcu.non_critical_disconnected:
+            return
+        toolhead = self._printer.lookup_object("toolhead", None)
+        if toolhead is None:
+            return
+        self.set_digital(toolhead.get_last_move_time(), self._last_set_value)
+
     def set_digital(self, print_time, value):
         if self._mcu.non_critical_disconnected:
             raise self._printer.command_error(
                 f"Cannot set pin on disconnected MCU '{self._mcu.get_name()}'"
             )
+        self._last_set_value = value
         clock = self._mcu.print_time_to_clock(print_time)
         self._set_cmd.send(
             [self._oid, clock, (not not value) ^ self._invert],
@@ -571,9 +588,16 @@ class MCU_pwm:
         self._last_clock = 0
         self._pwm_max = 0.0
         self._set_cmd = None
+        self._mcu.get_printer().register_event_handler(
+            mcu.get_non_critical_reconnect_event_name(),
+            self._handle_pwm_reconnect,
+        )
 
     def get_mcu(self):
         return self._mcu
+
+    def _handle_pwm_reconnect(self):
+        self._last_clock = 0
 
     def setup_max_duration(self, max_duration):
         self._max_duration = max_duration
@@ -851,6 +875,7 @@ class MCU:
         self.reconnect_interval = (
             config.getfloat("reconnect_interval", 2.0) + 0.12
         )  # add small change to not collide with other events
+        self._non_critical_reconnecting = False
         self._cached_init_state = False
         self._oid_count_post_inits = 0
         self._config_cmds_post_inits = []
@@ -900,6 +925,23 @@ class MCU:
         prefix = "MCU '%s' shutdown: " % (self._name,)
         if params["#name"] == "is_shutdown":
             prefix = "Previous MCU '%s' shutdown: " % (self._name,)
+
+        if self.is_non_critical:
+            logging.info(
+                "Non-critical MCU '%s' shutdown: %s - handling as disconnect",
+                self._name,
+                msg,
+            )
+            # Leave _is_shutdown True so reconnect can reset the firmware
+            # instead of talking to a halted MCU (Invalid oid type).
+            if self._non_critical_reconnecting or self.non_critical_disconnected:
+                return
+            # _handle_shutdown runs in the serial thread; disconnect must
+            # be scheduled on the reactor to avoid joining that thread.
+            self._reactor.register_async_callback(
+                lambda e: self.handle_non_critical_disconnect()
+            )
+            return
 
         append_msgs = []
         if (
@@ -986,14 +1028,31 @@ class MCU:
             self.estimated_print_time = dummy_estimated_print_time
 
     def handle_non_critical_disconnect(self):
+        if self.non_critical_disconnected:
+            return
         self.non_critical_disconnected = True
+        self._get_status_info["non_critical_disconnected"] = True
         self._clocksync.disconnect()
         self._disconnect()
+        self._clear_stepqueues()
         self._reactor.update_timer(
             self.non_critical_recon_timer, self._reactor.NOW
         )
         self._printer.send_event(self._non_critical_disconnect_event_name)
         self.gcode.respond_info(f"mcu: '{self._name}' disconnected!", log=True)
+
+    def _clear_stepqueues(self):
+        for sq in self._stepqueues:
+            self._ffi_lib.stepcompress_clear(sq)
+
+    def clear_stepqueues(self):
+        self._clear_stepqueues()
+
+    def can_generate_steps(self):
+        # Serial may be back during recon_mcu() while steppersync is
+        # still None. Generating steps in that window is what produces
+        # "Invalid sequence" on G1.
+        return self._steppersync is not None and not self.non_critical_disconnected
 
     def non_critical_recon_event(self, eventtime):
         success = self.recon_mcu()
@@ -1100,6 +1159,7 @@ class MCU:
         return "\n".join(log_info)
 
     def recon_mcu(self):
+        self._non_critical_reconnecting = True
         try:
             if not self._mcu_identify():
                 return False
@@ -1108,6 +1168,7 @@ class MCU:
             self._is_shutdown = False
             self.reset_to_initial_state()
             self.non_critical_disconnected = False
+            self._get_status_info["non_critical_disconnected"] = False
             self._connect()
         except Exception:
             logging.exception(
@@ -1115,6 +1176,8 @@ class MCU:
             )
             self._abort_recon_attempt()
             return False
+        finally:
+            self._non_critical_reconnecting = False
         self._printer.send_event(self._non_critical_reconnect_event_name)
         return True
 
@@ -1126,21 +1189,30 @@ class MCU:
             "get_config",
             "config is_config=%c crc=%u is_shutdown=%c move_count=%hu",
         )
-        if not get_config_cmd.send()["is_shutdown"]:
+        try:
+            is_shutdown = get_config_cmd.send()["is_shutdown"]
+        except Exception:
+            is_shutdown = self._is_shutdown
+        if not is_shutdown:
             return False
         logging.info(
             "MCU '%s' is in a shutdown state - attempting reset", self._name
         )
-        if self._reset_cmd is not None:
-            self._reset_cmd.send()
-        elif self._config_reset_cmd is not None:
-            self._config_reset_cmd.send()
-        else:
-            # No reset mechanism - clear the shutdown state and let the
-            # next reconnect attempt reuse the retained config
-            clear_shutdown_cmd = self.try_lookup_command("clear_shutdown")
-            if clear_shutdown_cmd is not None:
-                clear_shutdown_cmd.send()
+        try:
+            if self._reset_cmd is not None:
+                self._reset_cmd.send()
+            elif self._config_reset_cmd is not None:
+                self._config_reset_cmd.send()
+            else:
+                # No reset mechanism - clear the shutdown state and let the
+                # next reconnect attempt reuse the retained config
+                clear_shutdown_cmd = self.try_lookup_command("clear_shutdown")
+                if clear_shutdown_cmd is not None:
+                    clear_shutdown_cmd.send()
+        except Exception:
+            logging.exception(
+                "MCU '%s' reset after shutdown failed", self._name
+            )
         self._reactor.pause(self._reactor.monotonic() + 0.015)
         self._abort_recon_attempt()
         return True
@@ -1151,6 +1223,7 @@ class MCU:
         self._disconnect()
         self.non_critical_disconnected = True
         self._get_status_info["non_critical_disconnected"] = True
+        self._clear_stepqueues()
 
     def reset_to_initial_state(self):
         if self._cached_init_state:
@@ -1206,6 +1279,24 @@ class MCU:
             ffi_lib.steppersync_free,
         )
         ffi_lib.steppersync_set_time(self._steppersync, 0.0, self._mcu_freq)
+        if self.is_non_critical:
+            # Reconnect happens at a large print_time against a freshly
+            # booted MCU clock. Apply the secondary clock mapping and
+            # drop leftover stepcompress state so new steps are not
+            # compressed as interval=0 ("Invalid sequence").
+            eventtime = self._reactor.monotonic()
+            print_time = self.estimated_print_time(eventtime)
+            try:
+                offset, freq = self._clocksync.calibrate_clock(
+                    print_time, eventtime
+                )
+                ffi_lib.steppersync_set_time(self._steppersync, offset, freq)
+            except Exception:
+                logging.exception(
+                    "MCU '%s' failed to sync step clocks after reconnect",
+                    self._name,
+                )
+            self._clear_stepqueues()
         # Log config information
         move_msg = "Configured MCU '%s' (%d moves)" % (self._name, move_count)
         logging.info(move_msg)
@@ -1251,7 +1342,10 @@ class MCU:
                     # Cheetah boards require RTS to be deasserted
                     # else a reset will trigger the built-in bootloader.
                     rts = resmeth != "cheetah"
-                    self._serial.connect_uart(self._serialport, self._baud, rts)
+                    connect_timeout = 8.0 if self._non_critical_reconnecting else 90.0
+                    self._serial.connect_uart(
+                        self._serialport, self._baud, rts, timeout=connect_timeout
+                    )
                 else:
                     self._serial.connect_pipe(self._serialport)
                 self._clocksync.connect(self._serial)
@@ -1444,6 +1538,8 @@ class MCU:
             or (self._is_shutdown and not force)
         ):
             return
+        if self.non_critical_disconnected and not force:
+            return
         self._emergency_stop_cmd.send()
 
     def _restart_arduino(self):
@@ -1527,6 +1623,14 @@ class MCU:
             self._steppersync, clock, clear_history_clock
         )
         if ret:
+            if self.is_non_critical:
+                logging.error(
+                    "Dropping pending steps on non-critical MCU '%s' "
+                    "(stepcompress error after disconnect/reconnect)",
+                    self._name,
+                )
+                self._clear_stepqueues()
+                return
             raise error(
                 "Internal error in MCU '%s' stepcompress" % (self._name,)
             )

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -273,7 +273,7 @@ class SerialReader:
             if ret:
                 break
 
-    def connect_uart(self, serialport, baud, rts=True):
+    def connect_uart(self, serialport, baud, rts=True, timeout=90.0):
         # Initial connection
         logging.info("%sStarting serial connect", self.warn_prefix)
         start_time = self.reactor.monotonic()
@@ -282,7 +282,7 @@ class SerialReader:
                 self.serialqueue is not None
             ):  # if we're already connected, don't recon
                 break
-            if self.reactor.monotonic() > start_time + 90.0:
+            if self.reactor.monotonic() > start_time + timeout:
                 self._error("Unable to connect")
             try:
                 serial_dev = serial.Serial(
@@ -301,6 +301,10 @@ class SerialReader:
             ret = self._start_session(serial_dev)
             if ret:
                 break
+            try:
+                serial_dev.close()
+            except Exception:
+                pass
 
     def check_connect(self, serialport, baud, rts=True):
         serial_dev = serial.Serial(baudrate=baud, timeout=0, exclusive=False)
@@ -368,7 +372,11 @@ class SerialReader:
                 self.handlers[name, oid] = callback
 
     def _check_noncritical_disconnected(self):
-        if self.mcu is not None and self.mcu.non_critical_disconnected:
+        if self.mcu is None:
+            return
+        if getattr(self.mcu, "_non_critical_reconnecting", False):
+            return
+        if self.mcu.non_critical_disconnected:
             self._error("non-critical MCU is disconnected")
 
     # Command sending

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import collections
+import logging
 import math
 
 from . import chelper
@@ -67,6 +68,11 @@ class MCU_stepper:
         self._mcu.get_printer().register_event_handler(
             "klippy:connect", self._query_mcu_position
         )
+        if self._mcu.is_non_critical:
+            self._mcu.get_printer().register_event_handler(
+                self._mcu.get_non_critical_reconnect_event_name(),
+                self._handle_non_critical_reconnect,
+            )
         self._tmc_current_helper = None
 
     def get_tmc_current_helper(self):
@@ -270,6 +276,29 @@ class MCU_stepper:
             raise error("Internal error in stepcompress")
         self._query_mcu_position()
 
+    def _handle_non_critical_reconnect(self):
+        # MCU reset_step_clock is 0 after config. Host stepcompress must
+        # match or generate_steps compresses to interval=0 and the buffer
+        # motor never moves.
+        ffi_main, ffi_lib = chelper.get_ffi()
+        ffi_lib.stepcompress_clear(self._stepqueue)
+        if self._reset_cmd_tag is None:
+            return
+        ret = ffi_lib.stepcompress_reset(self._stepqueue, 0)
+        if ret:
+            logging.warning(
+                "stepcompress_reset failed for '%s' after non-critical reconnect",
+                self._name,
+            )
+            return
+        data = (self._reset_cmd_tag, self._oid, 0)
+        ret = ffi_lib.stepcompress_queue_msg(self._stepqueue, data, len(data))
+        if ret:
+            logging.warning(
+                "reset_step_clock failed for '%s' after non-critical reconnect",
+                self._name,
+            )
+
     def _query_mcu_position(self):
         if self._mcu.is_fileoutput() or self._mcu.non_critical_disconnected:
             return
@@ -304,6 +333,20 @@ class MCU_stepper:
         self._active_callbacks.append(cb)
 
     def generate_steps(self, flush_time):
+        # A non-critical MCU may be gone, or mid-reconnect (serial is
+        # back but steppersync is not allocated yet). Do not queue
+        # steps, but DO advance last_flush_time so reconnect does not
+        # try to backfill the outage.
+        if self._mcu.is_non_critical and not self._mcu.can_generate_steps():
+            old_tq = self.set_trapq(None)
+            try:
+                if self._stepper_kinematics is not None:
+                    self._itersolve_generate_steps(
+                        self._stepper_kinematics, flush_time
+                    )
+            finally:
+                self.set_trapq(old_tq)
+            return
         # Check for activity if necessary
         if self._active_callbacks:
             sk = self._stepper_kinematics
@@ -317,6 +360,14 @@ class MCU_stepper:
         sk = self._stepper_kinematics
         ret = self._itersolve_generate_steps(sk, flush_time)
         if ret:
+            if self._mcu.is_non_critical:
+                logging.warning(
+                    "Dropping generated steps for '%s' on non-critical MCU '%s'",
+                    self._name,
+                    self._mcu.get_name(),
+                )
+                self._mcu.clear_stepqueues()
+                return
             raise error("Internal error in stepcompress")
 
     def is_active_axis(self, axis):

--- a/test/test_mcu_recon.py
+++ b/test/test_mcu_recon.py
@@ -60,6 +60,7 @@ def _make_mcu(is_shutdown_response=0):
     mcu.non_critical_disconnected = True
     mcu._get_status_info = {}
     mcu._steppersync = None
+    mcu._stepqueues = []
     mcu._cached_init_state = False
     mcu._reserved_move_slots = 0
     mcu._reset_cmd = None


### PR DESCRIPTION
## Bug Description

`is_non_critical: True` on an auxiliary MCU (filament buffer, extra MCU, etc.) is supposed to mean a USB drop does **not** emergency-stop the printer. The host already logs `mcu: 'NAME' disconnected!` and retries reconnect. Several other host paths still treated that same drop as fatal, or left the board connected but unable to move/sense after reconnect.

This was found on a Rat Rig V-Core 4.1 IDEX 500 running Kalico with two Mellow LLL Plus buffer boards (`[mcu LLL_PLUS]` / `[mcu LLL_PLUS1]`, both `is_non_critical: True`, each with a `[tmc2208 extruder_stepper mellow*]` and HALL/feed/retract `[gcode_button]`s). The same holes apply to any non-critical MCU that owns steppers, TMC UART, or buttons.

**Authorship / testing**

- **Code:** written by **Grok (xAI)** via Hermes Agent. I (ufoDziner) did not author these host patches.
- **Physical testing:** **ufoDziner**. Mid-print USB unplug/replug of the LLL buffer while the toolhead was actually extruding, with the buffer motor enabled. Idle unplug is **not** a valid test of the TMC poller (the 1 Hz DRV_STATUS check is stopped when that stepper is disabled).

## Root Cause

Several independent host paths ignored `is_non_critical`:

1. **TMC poller.** `[tmc2208]` `_do_periodic_check` (1 Hz DRV_STATUS) called `invoke_shutdown("mcu '...': Serial connection closed")` even after `handle_non_critical_disconnect` had already accepted the drop. That was the original print killer.
2. **Firmware shutdown frames.** After reconnect, leftover host commands could hit stale oids (`Invalid oid type`) or clocks (`Timer too close`). The STM32 shutdown frame still went through `_handle_shutdown` → `invoke_async_shutdown`, taking the whole printer down. Kalico already had `_recon_handle_shutdown` for a board that was *already* in shutdown at reconnect time; it did not catch a shutdown that arrived *during* a live session.
3. **Stepcompress clock domain.** `generate_steps` kept queueing for a missing `steppersync`, then after reconnect leftover queues compressed to `interval=0` (`Invalid sequence`). Console showed `reconnected!` while the buffer motor never moved. Failed reconnects also leaked serial fds (`Too many open files`).
4. **Host objects that MCU reset wipes.** Button `ack_count` stayed in the old session (`new_count <= 0`, feed/retract/HALL dead). Enable pin and TMC UART registers were not re-asserted, so FORCE_MOVE / auto-feed could no-op.

## Fix

Host-only. No MCU protocol change.

- `tmc.py`: skip DRV_STATUS while `non_critical_disconnected`; ignore serial-closed / disconnected errors on an `is_non_critical` MCU in the poller and in enable/disable. Re-init TMC registers on the reconnect event if that stepper is supposed to be enabled. Real TMC faults on a live MCU still shut down.
- `mcu.py`: non-critical firmware shutdown → disconnect + retry (scheduled on the reactor, not from the serial thread). Reconnect sets `_non_critical_reconnecting` so identify is allowed. Reset a board that is still in `is_shutdown`. `stepcompress_clear` on disconnect/failed retry. After `_connect`, apply secondary clock mapping and clear leftover step queues. Swallow leftover stepcompress errors on non-critical flush instead of `Internal error`. Close serial fds on failed UART session. Re-assert digital-out enable pin on reconnect.
- `stepper.py`: do not generate steps until `steppersync` exists; advance flush time so reconnect does not backfill the outage. On reconnect, `reset_step_clock` so new steps are not `interval=0`.
- `serialhdl.py`: allow commands while reconnecting; close the serial device if `_start_session` fails (fd leak).
- `buttons.py`: reset `ack_count` / `last_button` on reconnect so HALL/feed/retract fire again.
- `chelper/stepcompress.*`: `stepcompress_clear()` discards pending steps without flushing them into a reset MCU.

## How to Verify

1. Auxiliary MCU with `is_non_critical: True`, a TMC UART stepper, and at least one `gcode_button` on that MCU.
2. Start a print so that stepper is **enabled** (buffer actually feeding). Idle unplug is insufficient.
3. Unplug that MCU's USB for a few seconds, plug it back in, leave it.
4. Expect:
   - `mcu: '<name>' disconnected!` then `mcu: '<name>' reconnected!`
   - print continues (no `Transition to shutdown`)
   - buffer motor moves again (HALL bursts or feed button)
   - feed/retract buttons print their M118 lines
5. Optional: a second `Timer too close` disconnect/reconnect a few seconds later is leftover clock hygiene; it must **not** kill the print.

## Test Plan

- [ ] Added regression test for this bug
- [x] Existing tests still pass (not run in CI from this host; `test/test_mcu_recon.py` already covers the reconnect wrapper)
- [x] Manual verification of the fix — mid-print LLL USB unplug on V-Core 4.1 IDEX 500; print continued and buffer resumed feeding

## Risk Assessment

Medium — scoped to `is_non_critical` MCUs. Primary MCU behavior is unchanged. Real TMC faults on a connected non-critical MCU still shut down. Worst case if something is missed: an auxiliary board stays idle until FIRMWARE_RESTART, rather than killing a print.

Known leftover, **not** in this PR: after a successful reconnect the firmware can still emit `Timer too close` once, which this patch recovers as a second disconnect/reconnect. Pause-on-buffer-disconnect is a separate product change.
