### PR TITLE
build: embed build configuration in identify dictionary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ ctrs-y = \
 $(OUT)compile_time_request.o: $(ctrs-y) ./scripts/buildcommands.py
 	@echo "  Building $@"
 	$(Q)cat $(ctrs-y) | tr -s '\0' '\n' > $(OUT)compile_time_request.txt
-	$(Q)$(PYTHON) ./scripts/buildcommands.py -d $(OUT)klipper.dict -t "$(CC);$(AS);$(LD);$(OBJCOPY);$(OBJDUMP);$(STRIP)" $(OUT)compile_time_request.txt $(OUT)compile_time_request.c
+	$(Q)$(PYTHON) lib/kconfiglib/savedefconfig.py --kconfig src/Kconfig --out $(OUT)defconfig
+	$(Q)$(PYTHON) ./scripts/buildcommands.py -d $(OUT)klipper.dict -k $(OUT)defconfig -t "$(CC);$(AS);$(LD);$(OBJCOPY);$(OBJDUMP);$(STRIP)" $(OUT)compile_time_request.txt $(OUT)compile_time_request.c
 	$(Q)$(CC) $(CFLAGS) -c $(OUT)compile_time_request.c -o $@
 
 ################ Auto generation of "board/" include file link

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -406,6 +406,11 @@ The following information is available in
 - `mcu_constants.<constant_name>`: Compile time constants reported by
   the micro-controller. The available constants may differ between
   micro-controller architectures and with each code revision.
+- `mcu_kconfig`: The minimal build configuration (`savedefconfig`
+  output) the micro-controller firmware was compiled from, as reported by
+  the micro-controller. `None` if the firmware predates this feature, is a
+  nonconforming build, or is a fork that doesn't implement it — absence
+  does not identify which of those applies.
 - `last_stats.<statistics_name>`: Statistics information on the
   micro-controller connection.
 - `non_critical_disconnected`: True/False if the mcu is disconnected.

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1294,6 +1294,7 @@ class MCU:
         self._get_status_info["mcu_version"] = version
         self._get_status_info["mcu_build_versions"] = build_versions
         self._get_status_info["mcu_constants"] = msgparser.get_constants()
+        self._get_status_info["mcu_kconfig"] = msgparser.get_kconfig()
         if app in ("Klipper", "Danger-Klipper"):
             pconfig = self._printer.lookup_object("configfile")
             pconfig.runtime_warning(

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -293,6 +293,7 @@ class MessageParser:
         self.msgid_by_format = {}
         self.msgid_parser = PT_int32()
         self.config = {}
+        self.kconfig = None
         self.version = self.build_versions = ""
         self.raw_identify_data = ""
         self._init_messages(DefaultMessages)
@@ -485,6 +486,7 @@ class MessageParser:
                 all_messages, commands.values(), output.values()
             )
             self.config.update(data.get("config", {}))
+            self.kconfig = data.get("kconfig")
             self.app = data.get("app", "")
             self.version = data.get("version", "")
             self.build_versions = data.get("build_versions", "")
@@ -511,6 +513,9 @@ class MessageParser:
 
     def get_constants(self):
         return dict(self.config)
+
+    def get_kconfig(self):
+        return self.kconfig
 
     class sentinel:
         pass

--- a/lib/kconfiglib/savedefconfig.py
+++ b/lib/kconfiglib/savedefconfig.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019, Ulf Magnusson
+# SPDX-License-Identifier: ISC
+
+"""
+Saves a minimal configuration file that only lists symbols that differ in value
+from their defaults. Loading such a configuration file is equivalent to loading
+the "full" configuration file.
+
+Minimal configuration files are handy to start from when editing configuration
+files by hand.
+
+The default input configuration file is '.config'. A different input filename
+can be passed in the KCONFIG_CONFIG environment variable.
+
+Note: Minimal configurations can also be generated from within the menuconfig
+interface.
+"""
+import argparse
+
+import kconfiglib
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__)
+
+    parser.add_argument(
+        "--kconfig",
+        default="Kconfig",
+        help="Top-level Kconfig file (default: Kconfig)")
+
+    parser.add_argument(
+        "--out",
+        metavar="MINIMAL_CONFIGURATION",
+        default="defconfig",
+        help="Output filename for minimal configuration (default: defconfig)")
+
+    args = parser.parse_args()
+
+    kconf = kconfiglib.Kconfig(args.kconfig, suppress_traceback=True)
+    print(kconf.load_config())
+    print(kconf.write_min_config(args.out))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -665,6 +665,23 @@ class HandleVersions:
 Handlers.append(HandleVersions())
 
 
+class HandleKConfig:
+    def __init__(self):
+        self.ctr_dispatch = {}
+        self.defconfig = ""
+
+    def update_data_dictionary(self, data):
+        data["kconfig"] = self.defconfig
+
+    def generate_code(self, options):
+        with open(options.kconfig) as f:
+            self.defconfig = f.read()
+        return ""
+
+
+Handlers.append(HandleKConfig())
+
+
 ######################################################################
 # Identify data dictionary generation
 ######################################################################
@@ -731,6 +748,11 @@ def main():
         "-d",
         dest="write_dictionary",
         help="file to write mcu protocol dictionary",
+    )
+    opts.add_option(
+        "-k",
+        dest="kconfig",
+        help="file containing the minimal (savedefconfig) build configuration",
     )
     opts.add_option(
         "-t",

--- a/test/test_buildcommands_kconfig.py
+++ b/test/test_buildcommands_kconfig.py
@@ -1,0 +1,56 @@
+import types
+
+from scripts import buildcommands
+
+
+def test_handle_kconfig_generate_code_reads_file(tmp_path):
+    defconfig = tmp_path / "defconfig"
+    defconfig.write_text("CONFIG_MACH_STM32=y\nCONFIG_MACH_STM32F042=y\n")
+    handler = buildcommands.HandleKConfig()
+    options = types.SimpleNamespace(kconfig=str(defconfig))
+
+    code = handler.generate_code(options)
+
+    assert code == ""
+    assert handler.defconfig == "CONFIG_MACH_STM32=y\nCONFIG_MACH_STM32F042=y\n"
+
+
+def test_handle_kconfig_update_data_dictionary():
+    handler = buildcommands.HandleKConfig()
+    handler.defconfig = "CONFIG_MACH_STM32=y\n"
+    data = {}
+
+    handler.update_data_dictionary(data)
+
+    assert data == {"kconfig": "CONFIG_MACH_STM32=y\n"}
+
+
+def test_handle_kconfig_accepts_empty_defconfig(tmp_path):
+    # A board matching Kconfig defaults exactly produces an empty
+    # defconfig; that's valid, not a build failure.
+    defconfig = tmp_path / "defconfig"
+    defconfig.write_text("")
+    handler = buildcommands.HandleKConfig()
+    options = types.SimpleNamespace(kconfig=str(defconfig))
+
+    code = handler.generate_code(options)
+
+    assert code == ""
+    data = {}
+    handler.update_data_dictionary(data)
+    assert data == {"kconfig": ""}
+
+
+def test_handle_kconfig_registered_before_handle_identify():
+    kconfig_indices = [
+        i
+        for i, h in enumerate(buildcommands.Handlers)
+        if isinstance(h, buildcommands.HandleKConfig)
+    ]
+    identify_indices = [
+        i
+        for i, h in enumerate(buildcommands.Handlers)
+        if isinstance(h, buildcommands.HandleIdentify)
+    ]
+    assert kconfig_indices and identify_indices
+    assert kconfig_indices[0] < identify_indices[0]

--- a/test/test_kconfig_defconfig_roundtrip.py
+++ b/test/test_kconfig_defconfig_roundtrip.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import types
 
 import pytest
 
@@ -59,3 +60,28 @@ def test_defconfig_roundtrip_reproduces_expanded_config(config_path, tmp_path):
     replayed_path = tmp_path / "replayed.config"
     kconf2.write_config(str(replayed_path), save_old=False)
     assert replayed_path.read_text() == expanded_before
+
+
+def test_handlekconfig_accepts_a_real_all_defaults_board_config(tmp_path):
+    # atmega2560.config matches the Kconfig tree's defaults exactly, so
+    # write_min_config() produces a zero-byte defconfig for it.
+    # HandleKConfig must accept that, not treat it as a failure.
+    from scripts import buildcommands
+
+    kconf = kconfiglib.Kconfig(KCONFIG, suppress_traceback=True)
+    kconf.load_config(
+        str(ROOT / "test" / "configs" / "atmega2560.config"), replace=True
+    )
+    defconfig_path = tmp_path / "defconfig"
+    kconf.write_min_config(str(defconfig_path))
+
+    # Verify the empty case actually occurs rather than assuming it.
+    assert defconfig_path.read_text() == ""
+
+    handler = buildcommands.HandleKConfig()
+    options = types.SimpleNamespace(kconfig=str(defconfig_path))
+    handler.generate_code(options)  # must not raise
+
+    data = {}
+    handler.update_data_dictionary(data)
+    assert data == {"kconfig": defconfig_path.read_text()}

--- a/test/test_kconfig_defconfig_roundtrip.py
+++ b/test/test_kconfig_defconfig_roundtrip.py
@@ -1,0 +1,61 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "lib" / "kconfiglib"))
+
+import kconfiglib  # noqa: E402
+
+KCONFIG = str(ROOT / "src" / "Kconfig")
+CONFIGS = sorted((ROOT / "test" / "configs").glob("*.config")) + sorted(
+    (ROOT / "board_configs").glob("*.config")
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _repo_root_cwd():
+    # src/Kconfig sources the generated, gitignored src/extras/Kconfig,
+    # and kconfiglib resolves "source" paths relative to cwd, not the
+    # Kconfig file's location. Regenerate src/extras/ and run from the
+    # repo root so this doesn't depend on `make` having already run.
+    previous = os.getcwd()
+    os.chdir(ROOT)
+    subprocess.run(
+        ["bash", str(ROOT / "scripts" / "find-firmware-extras.sh")],
+        cwd=ROOT,
+        check=True,
+    )
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+@pytest.mark.parametrize("config_path", CONFIGS, ids=lambda p: p.stem)
+def test_defconfig_roundtrip_reproduces_expanded_config(config_path, tmp_path):
+    # Loading a minimized defconfig into a fresh Kconfig instance must
+    # expand back to the config that produced it. Compare canonical
+    # write_config() output, not raw defconfig text.
+    kconf = kconfiglib.Kconfig(KCONFIG, suppress_traceback=True)
+    kconf.load_config(str(config_path), replace=True)
+
+    expanded_path = tmp_path / "expanded.config"
+    kconf.write_config(str(expanded_path), save_old=False)
+    expanded_before = expanded_path.read_text()
+
+    defconfig_path = tmp_path / "defconfig"
+    kconf.write_min_config(str(defconfig_path))
+
+    kconf2 = kconfiglib.Kconfig(KCONFIG, suppress_traceback=True)
+    kconf2.load_config(str(defconfig_path), replace=True)
+    # kconfiglib silently drops assignments to symbols the tree doesn't
+    # define — assert there are none for a same-tree round trip.
+    assert kconf2.missing_syms == []
+
+    replayed_path = tmp_path / "replayed.config"
+    kconf2.write_config(str(replayed_path), save_old=False)
+    assert replayed_path.read_text() == expanded_before

--- a/test/test_msgproto_kconfig.py
+++ b/test/test_msgproto_kconfig.py
@@ -1,0 +1,36 @@
+import json
+import zlib
+
+from klippy import msgproto
+
+
+def _identify_payload(**overrides):
+    data = {
+        "enumerations": {},
+        "commands": {},
+        "responses": {},
+        "output": {},
+        "app": "Kalico",
+        "version": "v0.13.0-241-g5fdf0dd3e",
+    }
+    data.update(overrides)
+    return zlib.compress(json.dumps(data).encode())
+
+
+def test_get_kconfig_before_identify_returns_none():
+    mp = msgproto.MessageParser()
+    assert mp.get_kconfig() is None
+
+
+def test_process_identify_without_kconfig_key_stays_none():
+    # Firmware predating this feature has no "kconfig" key at all.
+    mp = msgproto.MessageParser()
+    mp.process_identify(_identify_payload())
+    assert mp.get_kconfig() is None
+
+
+def test_process_identify_with_kconfig_key():
+    payload = _identify_payload(kconfig="CONFIG_MACH_STM32=y\n")
+    mp = msgproto.MessageParser()
+    mp.process_identify(payload)
+    assert mp.get_kconfig() == "CONFIG_MACH_STM32=y\n"


### PR DESCRIPTION
## Summary

Embed the minimal Kconfig in the identify dictionary and expose it through `mcu_kconfig` status.
This can be used by flash & update tools to rebuild firmware without needing to have a local copy of the build config.

The identify data is compressed with bzip2. The decoder still accepts zlib data from older firmware.

## Size comparison

| Configuration | Before | After (zlib) | After (bzip2) |
| --- | ---: | ---: | ---: |
| Voron V0 display | 19,960 | 20,192 | 20,132 |
| ERCF easy-brd | 41,439 | 41,495 | 41,303 |
| BTT Manta M8P v2.0 | 46,867 | 46,955 | 46,723 |
| BTT Octopus F446 | 44,491 | 44,563 | 44,355 |
| BTT SKR Pico | 43,924 | 43,988 | 43,732 |
| BTT EBB36 Gen2 | 44,508 | 44,596 | 44,372 |
| RAMPS 1.4 | 50,458 | 50,468 | 50,278 |

Bzip2 produced smaller identify data in every tested configuration except
`lgt8f328p`, where it was 5 bytes larger.

## Testing

- 50 focused pytest tests pass.
- Ruff passes.
- Defconfig round-trip tests cover the supported board configurations.

## Checklist

- [x] pr title makes sense
- [x] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
