### PR TITLE
Import klippy/extras on demand instead of at startup

### DIFF
--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -112,24 +112,48 @@ class SubsystemComponentCollection:
         subsystem[component_name] = component
 
 
+COMPONENT_HOOK = "register_components"
+
+
 class PrinterModule:
     name: str
     module_info: pkgutil.ModuleInfo
     module: Optional[ModuleType] = None
     exception: Optional[Exception] = None
+    loaded: bool = False
+    _may_register: Optional[bool] = None
 
     def __init__(self, name: str, module_info: pkgutil.ModuleInfo):
         self.name = name
         self.module_info = module_info
 
     def load(self):
+        if self.loaded:
+            return
+        self.loaded = True
         try:
             self.module = importlib.import_module(self.module_info.name)
         except Exception as ex:
             logging.exception(f"Failed to load module '{self.name}'.")
             self.exception = ex
 
+    def may_register_components(self) -> bool:
+        # Checked by reading the source, so that a module nothing references
+        # is never imported. Anything we cannot read the source of, such as an
+        # extension module or a sourceless .pyc, is assumed to register.
+        if self._may_register is None:
+            try:
+                spec = self.module_info.module_finder.find_spec(
+                    self.module_info.name
+                )
+                source = spec.loader.get_source(self.module_info.name)
+            except Exception:
+                source = None
+            self._may_register = source is None or COMPONENT_HOOK in source
+        return self._may_register
+
     def get_init_function(self, section: str):
+        self.load()
         # if loading failed, raise that exception now
         if self.exception is not None:
             raise self.exception
@@ -139,16 +163,20 @@ class PrinterModule:
         return self.get_method(init_func_name)
 
     def register_components(self, collector: SubsystemComponentCollection):
+        if not self.may_register_components():
+            return
+        self.load()
         # skip failed modules: this is a tradeoff vs failing all loading for
         # unused modules
         if self.exception is not None:
             return
-        register_func = self.get_method("register_components")
+        register_func = self.get_method(COMPONENT_HOOK)
         if register_func is None:
             return
         register_func(collector)
 
     def get_method(self, function_name):
+        self.load()
         if self.module is None:
             return None
         return getattr(self.module, function_name, None)
@@ -197,9 +225,6 @@ class Printer:
                     f"Module '{pm.name}' found in both extras and plugins!"
                 )
             self.printer_modules[pm.name] = pm
-
-        for pm in self.printer_modules.values():
-            pm.load()
 
     def _register_subsystem_components(self):
         for printer_module in self.printer_modules.values():


### PR DESCRIPTION
Closes #954.

`_load_modules` imported every module in `klippy/extras` and `klippy/plugins` before any config section was read, so that `register_components` could be called on the ones defining it. This decides which modules define the hook by reading their source instead of executing it, and imports only those up front. Everything else is left to `load_object`, which already resolves modules on demand.

One correction to the issue: I said one module defines the hook. It is two, `load_cell_probe` and the `load_cell` package. My original grep only looked at `extras/*.py` and missed the package form. The scan in this PR finds both.

### Approach

#769 set out to have "truly dynamic registration without having registries in code, special directories, or files with lists of components", so this deliberately does not introduce a manifest or an opt-in list. Discovery stays automatic: add `register_components` to a module and it is picked up, exactly as now.

Modules that cannot be read as source, extension modules and sourceless `.pyc`, are assumed to define the hook and are still imported. That keeps #786's behavior for those intact, at the cost of not saving anything on them.

### Measurements

On a Pi 4 running Python 3.9 against a real `printer.cfg`, comparing what is resident after startup:

| | extras resident | RSS |
|---|---|---|
| before | 164 | +9.9 MB |
| after | 49 | +3.8 MB |

Scanning 140 modules takes about 60 ms and imports none of them. For scale, the klippy process on that host is 50 MB RSS.

### Verification

- Full suite in the CI image at the CI Python version, `docker run -v $PWD:/klipper dangerklippers/klipper-build:latest --python 3.9 py.test -n auto`: 124 passed, 1 xfailed.
- `ruff format --check` and `ruff check` clean at the pinned 0.15.22.
- Detection checked against `grep -rl "^def register_components"` on the extras tree: same two modules, and nothing under `klippy.extras.` is present in `sys.modules` afterwards. Nothing in the tree currently mentions the name without defining it, so the substring check has no false positives today.

### Tradeoffs

An import error in a module no config references now surfaces when that module is first used rather than at startup. `import_test()`, which CI runs through `test/test_imports.py`, still imports every module, so a module that cannot be imported at all is still caught there.

`PrinterModule.load()` is now idempotent and `get_method` triggers it, so the lazy path cannot leave `self.module` unset for a module that is actually used. `get_init_function` loads before checking `self.exception`, which preserves the existing behavior of re-raising the original import error rather than reporting a missing module.

---

Disclosure: I used Claude to help investigate and measure this. I have reviewed the change and run the tests myself.

