### PR TITLE
add a no_reconnect flag for non critical mcu that can be problematic to

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -837,6 +837,7 @@ class MCU:
         self.is_non_critical = config.getboolean("is_non_critical", False)
         if self.is_non_critical and self.get_name() == "mcu":
             raise error("Primary MCU cannot be marked as non-critical!")
+        self.no_reconnect = config.getboolean("no_reconnect", False)
         if self.is_non_critical:
             self.non_critical_recon_timer = self._reactor.register_timer(
                 self.non_critical_recon_event
@@ -996,6 +997,9 @@ class MCU:
         self.gcode.respond_info(f"mcu: '{self._name}' disconnected!", log=True)
 
     def non_critical_recon_event(self, eventtime):
+        # do not support reconnect for some MCUs which are problematic
+        if self.no_reconnect:
+            return self._reactor.NEVER
         success = self.recon_mcu()
         if success:
             self.gcode.respond_info(


### PR DESCRIPTION
I am wondering before I invest additional effort in docs and tests and things, is would something like this be accepted, I have this in my local fork for cartographer, beacon and eddy because I have found a reconnect can sometimes crash kalico during homing, and its better to allow a print to complete, but force the user to restart klipper afterwards than crash klipper by allowing an automatic reconnect.



