### PR TITLE
(fix): Print stats for toolchangers

### DIFF
--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -18,11 +18,13 @@ class PrintStats:
             self.cmd_SET_PRINT_STATS_INFO,
             desc=self.cmd_SET_PRINT_STATS_INFO_help,
         )
-        self.printer.register_event_handler("extruder:activate_extruder",
-                                            self._handle_activate_extruder)
+        self.printer.register_event_handler(
+            "extruder:activate_extruder", self._handle_activate_extruder
+        )
+
     def _handle_activate_extruder(self):
         gc_status = self.gcode_move.get_status()
-        self.last_epos = gc_status['position'].e
+        self.last_epos = gc_status["position"].e
 
     def _update_filament_usage(self, eventtime):
         gc_status = self.gcode_move.get_status(eventtime)

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -18,6 +18,11 @@ class PrintStats:
             self.cmd_SET_PRINT_STATS_INFO,
             desc=self.cmd_SET_PRINT_STATS_INFO_help,
         )
+        self.printer.register_event_handler("extruder:activate_extruder",
+                                            self._handle_activate_extruder)
+    def _handle_activate_extruder(self):
+        gc_status = self.gcode_move.get_status()
+        self.last_epos = gc_status['position'].e
 
     def _update_filament_usage(self, eventtime):
         gc_status = self.gcode_move.get_status(eventtime)


### PR DESCRIPTION
Cherrypicking mainline klipper change from [PR 6946](<https://github.com/Klipper3d/klipper/pull/6946>), fixes print stats for users that user toolchangers.

Before toolchanger stats would show the following between different extruders:
T3:
<img width="632" height="267" alt="image" src="https://github.com/user-attachments/assets/0cc2f7e1-b306-4a3c-b2b9-358f2f235db4" />

T0:
<img width="615" height="262" alt="image" src="https://github.com/user-attachments/assets/272e1f4c-e15b-4f1c-875b-166c3fed5ef7" />

This fix allows all stats to show correctly between different toolheads

This has been tested on my 2.4 toolchanger, for months now.

## Checklist

- [x] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
